### PR TITLE
Add 1 character for the space between words when calculating WPM.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1857,7 +1857,7 @@ class App extends Component {
       this.state.lesson.newPresentedMaterial.visitNext();
 
       newState.repetitionsRemaining = repetitionsRemaining(this.state.userSettings, this.state.lesson.presentedMaterial, this.state.currentPhraseID + 1);
-      newState.totalNumberOfMatchedChars = this.state.totalNumberOfMatchedChars + numberOfMatchedChars;
+      newState.totalNumberOfMatchedChars = this.state.totalNumberOfMatchedChars + numberOfMatchedChars + 1;
       newState.previousCompletedPhraseAsTyped = actualText;
       newState.actualText = '';
       newState.showStrokesInLesson = false;

--- a/src/App.js
+++ b/src/App.js
@@ -1782,7 +1782,7 @@ class App extends Component {
     var newState = {
       currentPhraseAttempts: currentPhraseAttempts,
       numberOfMatchedChars: numberOfMatchedChars,
-      totalNumberOfMatchedWords: (this.state.totalNumberOfMatchedChars + numberOfMatchedChars) / this.charsPerWord,
+      totalNumberOfMatchedWords: (this.state.totalNumberOfMatchedChars + numberOfMatchedChars + 1) / this.charsPerWord,
       totalNumberOfNewWordsMet: this.state.totalNumberOfNewWordsMet,
       totalNumberOfLowExposuresSeen: this.state.totalNumberOfLowExposuresSeen,
       totalNumberOfRetainedWords: this.state.totalNumberOfRetainedWords,


### PR DESCRIPTION
The traditional "letters divided by 5" approach for calculating WPM includes spaces in the letter count. Currently the count on Typey-Type does not include spaces, making WPM counts appear artificially low.

This PR is just a small fix that simply adds 1 to the "number of matched chars" for each word to account for the extra space.