### PR TITLE
Use phrase text when saving instead of typed text

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1820,21 +1820,11 @@ class App extends Component {
       if (!accurateStroke) { newState.totalNumberOfMistypedWords = this.state.totalNumberOfMistypedWords + 1; }
 
       if (!strokeHintShown && accurateStroke) {
-
-        // for suffixes and prefixes, record material with ignored chars instead of actualText
-        let lesson = this.state.lesson;
-        if (lesson && lesson.settings && lesson.settings.ignoredChars && lesson.settings.ignoredChars.length > 0 ) {
-          actualText = this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase;
-          if (this.state.userSettings.spacePlacement === 'spaceBeforeOutput') {
-            actualText = ' ' + this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase;
-          } else if (this.state.userSettings.spacePlacement === 'spaceAfterOutput') {
-            actualText = this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase + ' ';
-          }
-        }
-
-        const meetingsCount = newState.metWords[actualText] || 0;
+        // Use the original text when recording to preserve case and spacing
+        let phraseText = this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase;
+        const meetingsCount = newState.metWords[phraseText] || 0;
         Object.assign(newState, increaseMetWords.call(this, meetingsCount));
-        newState.metWords[actualText] = meetingsCount + 1;
+        newState.metWords[phraseText] = meetingsCount + 1;
       }
 
       if (this.state.userSettings.speakMaterial) {


### PR DESCRIPTION
I hope this is the right approach, but I'm only 7% of the way through so I might be missing something later on!

Currently in revision mode, if you're given a word such as `salt`, even though my settings are case insensitive and ignore spacing - it records what I've put in, resulting in a lot of variations being saved in local storage. This could result in `(space)salt` and `(space)Salt` based on what text it follows for capitalisation. This commit changes it to the prompted phrase.

Downside is that all saved entries which include spacing will be skipped/ignored.