### PR TITLE
WIP: Fix progress counts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -839,10 +839,13 @@ class App extends Component {
       numberOfWordsSeen = lessonsProgress[lessonpath].numberOfWordsSeen;
     }
 
+    let material = this.state.lesson?.sourceMaterial ? this.state.lesson.sourceMaterial.map(copy => ({...copy})) : [{phrase: "the", stroke: "-T"}];
+    if (this.state.userSettings.simpleTypography) {
+      material = replaceSmartTypographyInPresentedMaterial.call(this, material);
+    }
+
     let metWords = this.state.metWords;
-    let sourceMaterial;
-    sourceMaterial = (this.state.lesson && this.state.lesson.sourceMaterial) ? this.state.lesson.sourceMaterial : [{phrase: "the", stroke: "-T"}];
-    let len = sourceMaterial.length;
+    let len = material.length;
     let seenAccumulator = 0;
     let memorisedAccumulator = 0;
 
@@ -859,7 +862,7 @@ class App extends Component {
     let alreadyChecked = [];
     let wordsLeftToDiscover = [];
     for (let i = 0; i < len; ++i) {
-      let sourceMaterialPhrase = sourceMaterial[i].phrase;
+      let sourceMaterialPhrase = material[i].phrase;
       sourceMaterialPhrase = sourceMaterialPhrase.trim();
 
       // have you seen this word?

--- a/src/App.js
+++ b/src/App.js
@@ -1596,12 +1596,12 @@ class App extends Component {
         lesson: newLesson,
         currentPhraseID: 0
       }, () => {
-    if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom") && !this.state.lesson.path.endsWith("/lessons/custom/setup")) {
-      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path);
-      let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
-      writePersonalPreferences('lessonsProgress', lessonsProgress);
-      writePersonalPreferences('recentLessons', recentLessons);
-    }
+        if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom") && !this.state.lesson.path.endsWith("/lessons/custom/setup")) {
+          let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path);
+          let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
+          writePersonalPreferences('lessonsProgress', lessonsProgress);
+          writePersonalPreferences('recentLessons', recentLessons);
+        }
       });
 
     });

--- a/src/App.js
+++ b/src/App.js
@@ -2322,6 +2322,7 @@ class App extends Component {
                           updateUserGoals={this.updateUserGoals.bind(this)}
                           updateUserGoalsUnveiled={this.updateUserGoalsUnveiled.bind(this)}
                           userGoals={this.state.userGoals}
+                          userSettings={this.state.userSettings}
                           oldWordsGoalUnveiled={this.state.oldWordsGoalUnveiled}
                           newWordsGoalUnveiled={this.state.newWordsGoalUnveiled}
                           yourSeenWordCount={this.state.yourSeenWordCount}

--- a/src/App.js
+++ b/src/App.js
@@ -859,6 +859,10 @@ class App extends Component {
       }
     });
 
+    // NOTE: this calculation is more forgiving than lesson material filter by
+    // familiarity so when space before output is set and {"roused": 1} appears
+    // in metWords, " roused" will show in the lesson as a "new word" but
+    // already be counted as seen on the progress page.
     let alreadyChecked = [];
     let wordsLeftToDiscover = [];
     for (let i = 0; i < len; ++i) {

--- a/src/App.js
+++ b/src/App.js
@@ -1422,13 +1422,6 @@ class App extends Component {
   }
 
   setupLesson(optionalAnnouncementMessage) {
-    if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom") && !this.state.lesson.path.endsWith("/lessons/custom/setup")) {
-      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path);
-      let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
-      writePersonalPreferences('lessonsProgress', lessonsProgress);
-      writePersonalPreferences('recentLessons', recentLessons);
-    }
-
     let newLesson = Object.assign({}, this.state.lesson);
 
     if ((typeof newLesson === 'object' && Object.entries(newLesson).length === 0 && newLesson.constructor === Object) || newLesson === null ) {
@@ -1599,6 +1592,13 @@ class App extends Component {
         totalNumberOfHintedWords: 0,
         lesson: newLesson,
         currentPhraseID: 0
+      }, () => {
+    if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom") && !this.state.lesson.path.endsWith("/lessons/custom/setup")) {
+      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path);
+      let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
+      writePersonalPreferences('lessonsProgress', lessonsProgress);
+      writePersonalPreferences('recentLessons', recentLessons);
+    }
       });
 
     });

--- a/src/App.js
+++ b/src/App.js
@@ -887,17 +887,12 @@ class App extends Component {
       }
     }
 
-    console.log({ wordsLeftToDiscover })
-    console.log({ seenAccumulator })
-    console.log({ memorisedAccumulator })
-
     let uniqueLowerCasedWordsLeftToDiscover = [...new Set(wordsLeftToDiscover)];
 
     let numberOfWordsToDiscover = 0;
     if (uniqueLowerCasedWordsLeftToDiscover && uniqueLowerCasedWordsLeftToDiscover.length > 0) {
       numberOfWordsToDiscover = uniqueLowerCasedWordsLeftToDiscover.length;
     }
-    console.log({ numberOfWordsToDiscover })
 
     // See comment above
     // FIXME

--- a/src/App.js
+++ b/src/App.js
@@ -887,12 +887,17 @@ class App extends Component {
       }
     }
 
+    console.log({ wordsLeftToDiscover })
+    console.log({ seenAccumulator })
+    console.log({ memorisedAccumulator })
+
     let uniqueLowerCasedWordsLeftToDiscover = [...new Set(wordsLeftToDiscover)];
 
     let numberOfWordsToDiscover = 0;
     if (uniqueLowerCasedWordsLeftToDiscover && uniqueLowerCasedWordsLeftToDiscover.length > 0) {
       numberOfWordsToDiscover = uniqueLowerCasedWordsLeftToDiscover.length;
     }
+    console.log({ numberOfWordsToDiscover })
 
     // See comment above
     // FIXME

--- a/src/components/Finished.js
+++ b/src/components/Finished.js
@@ -435,7 +435,15 @@ class Finished extends Component {
         );
       }
       emptyAndZeroStateMessage = (
-        <div className="text-center mt10 mx-auto"><span id="js-no-words-to-write" tabIndex="-1">There are no words to write.</span> {startFromWordOneButton}</div>
+        <div className="text-center mt10 mx-auto">
+          <span id="js-no-words-to-write" tabIndex="-1">There are no words to write.</span>
+          {startFromWordOneButton ||
+          (<div className="text-center">
+            <Link to={this.props.suggestedNext} className="button mt3 dib" style={{lineHeight: 2}} role="button">
+              Next lesson
+            </Link>
+          </div>) }
+        </div>
       );
       lessonSummary = '';
     } else {

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -541,23 +541,23 @@ class Progress extends Component {
     let lessonsProgressFromTypeyType = this.props.lessonsProgress;
     const linkList = this.props.lessonIndex.map( (lesson) => {
       let lessonsubtitle = '';
-      let lessonWordCount = 0;
-      let lessonWordCountInIndex = '';
+      let wordCountDenominator = 0;
       let numberOfWordsSeenOrMemorised = 0;
       let lessonCompletion;
       if (lesson.subtitle && lesson.subtitle.length > 0) {
         lessonsubtitle = ': '+lesson.subtitle;
       }
       if (lesson.wordCount && lesson.wordCount > 0) {
-        lessonWordCount = lesson.wordCount;
-        lessonWordCountInIndex = '' + lessonWordCount;
+        wordCountDenominator = lesson.wordCount;
       }
       if (lessonsProgressFromTypeyType && lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path]) {
-        let seen = lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path].numberOfWordsSeen || 0;
-        let memorised = lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path].numberOfWordsMemorised || 0;
+        let toDiscover = lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path]?.numberOfWordsToDiscover || 0;
+        let seen = lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path]?.numberOfWordsSeen || 0;
+        let memorised = lessonsProgressFromTypeyType[process.env.PUBLIC_URL + "/lessons" + lesson.path]?.numberOfWordsMemorised || 0;
         numberOfWordsSeenOrMemorised = seen + memorised;
-        if ((numberOfWordsSeenOrMemorised >= lessonWordCountInIndex) || (numberOfWordsSeenOrMemorised > 100)) {
-          if (numberOfWordsSeenOrMemorised >= lessonWordCountInIndex) { numberOfWordsSeenOrMemorised = lessonWordCountInIndex; }
+        wordCountDenominator = seen + memorised + toDiscover;
+        if ((numberOfWordsSeenOrMemorised >= wordCountDenominator) || (numberOfWordsSeenOrMemorised > 100)) {
+          if (numberOfWordsSeenOrMemorised >= wordCountDenominator) { numberOfWordsSeenOrMemorised = wordCountDenominator; }
           lessonCompletion = this.lessonComplete();
         } else if (numberOfWordsSeenOrMemorised > 0) {
           lessonCompletion = this.inProgress();
@@ -569,7 +569,7 @@ class Progress extends Component {
       }
       if (lesson.category === "Fundamentals" || (lesson.category === "Drills" && lesson.title.startsWith("Top 100")) || (lesson.category === "Drills" && lesson.title.startsWith("Top 200"))) {
         return(
-          <li className="unstyled-list-item mb1" key={ lesson.path }>{lessonCompletion} <Link to={`/lessons${lesson.path}`.replace(/lesson\.txt$/,'').replace(/\/{2,}/g,'/')} id={'ga--lesson-index-'+lesson.path.replace(/\/lesson\.txt/g,'').replace(/[/.]/g,'-')}>{lesson.title}{lessonsubtitle}</Link> · <small>{numberOfWordsSeenOrMemorised} of {lessonWordCountInIndex}</small></li>
+          <li className="unstyled-list-item mb1" key={ lesson.path }>{lessonCompletion} <Link to={`/lessons${lesson.path}`.replace(/lesson\.txt$/,'').replace(/\/{2,}/g,'/')} id={'ga--lesson-index-'+lesson.path.replace(/\/lesson\.txt/g,'').replace(/[/.]/g,'-')}>{lesson.title}{lessonsubtitle}</Link> · <small>{numberOfWordsSeenOrMemorised} of {wordCountDenominator}</small></li>
         )
       } else {
         return "";

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1027,7 +1027,7 @@ class Progress extends Component {
             </div>
 
             <h3>Vocabulary progress</h3>
-            <p>If you’ve changed your spacing settings, you can download a reformatted “progress file” to match your new setting. After downloading it, if you're happy it looks good you can load it back into Typey Type. Then visit each lesson to update lesson progress. Your current spacing setting is: {this.formatSpacePlacementValue(this.props.userSettings)}: <a href={downloadReformattedProgressHref} download={"typey-type-reformatted-progress-" + dashifiedDate + ".json"} onClick={this.downloadReformattedProgress.bind(this)}>Download reformatted progress file</a></p>
+            <p className="bg-slat pl1 pr1">If you’ve changed your spacing settings, you can download a reformatted “progress file” to match your new setting. After downloading it, if you're happy it looks good you can load it back into Typey Type. Then visit each lesson to update lesson progress. Your current spacing setting is: {this.formatSpacePlacementValue(this.props.userSettings)}. <a href={downloadReformattedProgressHref} download={"typey-type-reformatted-progress-" + dashifiedDate + ".json"} onClick={this.downloadReformattedProgress.bind(this)}>Download reformatted progress file</a></p>
             <p>Words you’ve seen and times you’ve typed them well:</p>
             <p id="js-metwords-from-typey-type" className="w-100 mt3 mb3 quote wrap"><small>{metWordsFromTypeyType}</small></p>
           </div>


### PR DESCRIPTION
This PR:

- Attempts to resolve confusing progress calculations identified in https://github.com/didoesdigital/typey-type/issues/27
    - Changes recorded "lessonsProgress" new/seen/memorised numbers to use simplified typography setting
    - Changes denominators on progress page from using the lesson word count in the lesson index to using the total of new/seen/memorised words, which de-duplicates repeated words
- Adds "Next lesson" button to lesson empty states that show "There are no words to write." — this makes it faster to click through completed lessons when restoring hefty progress files
- Adds "Download reformatted progress file" button to implement Option C in https://github.com/didoesdigital/typey-type/issues/53#issuecomment-887098392

✅ ~~TODO~~ if this PR resolves the issues, revert the commit containing console logs before merging