### PR TITLE
Prevent `yarn` from timing out on `git://` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "flow-bin": "^0.59.0",
     "howler": "^2.2.0",
     "npm-run-all": "^4.1.1",
-    "pure-react-carousel": "git://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback",
+    "pure-react-carousel": "https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback",
     "query-string": "^6.2.0",
     "react": "^16.8.6",
     "react-animate-height": "^2.0.5",
@@ -28,7 +28,7 @@
     "react-modal": "^3.11.1",
     "react-numeric-input": "^2.2.0",
     "react-router-dom": "^4.2.2",
-    "react-tippy": "git://github.com/tvkhoa/react-tippy.git",
+    "react-tippy": "https://github.com/tvkhoa/react-tippy.git",
     "react-transition-group": "^2.4.0",
     "sass": "^1.49.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13298,9 +13298,9 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-"pure-react-carousel@git://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback":
+"pure-react-carousel@https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback":
   version "1.12.2"
-  resolved "git://github.com/didoesdigital/pure-react-carousel.git#89d6974180a8cafa99dc328bd41691a70f3d3840"
+  resolved "https://github.com/didoesdigital/pure-react-carousel.git#89d6974180a8cafa99dc328bd41691a70f3d3840"
   dependencies:
     deep-freeze "0.0.1"
     deepmerge "^1.3.2"
@@ -13807,9 +13807,9 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-"react-tippy@git://github.com/tvkhoa/react-tippy.git":
-  version "1.3.4"
-  resolved "git://github.com/tvkhoa/react-tippy.git#36581085040ca6d71a0a1df3a181f5f779640237"
+"react-tippy@https://github.com/tvkhoa/react-tippy.git":
+  version "1.4.0"
+  resolved "https://github.com/tvkhoa/react-tippy.git#c6e6169e3f2cabe05f1bfbd7e0dea1ddef4debe8"
   dependencies:
     popper.js "^1.11.1"
 


### PR DESCRIPTION
GitHub does not support unauthenticated access via the `git://` protocol anymore: https://github.blog/2021-09-01-improving-git-protocol-security-github/