### PR TITLE
Reduce Initial WPM Spike

### DIFF
--- a/src/components/Finished.js
+++ b/src/components/Finished.js
@@ -414,7 +414,7 @@ class Finished extends Component {
                   <p className="text-left de-emphasized mb0"><span style={{ backgroundColor: "transparent", borderBottom: "2px solid transparent", }} role="img" aria-label=" correct" >👏</span> means you typed the phrase within the target number of strokes</p>
                   <p className="text-left de-emphasized mb1"><span aria-label="(hinted)" role="img">ℹ️</span> means the hint was shown</p>
                 </div>
-                <p className="text-left de-emphasized" id="chart-notes">Note: The first 4 words are averaged to reduce the impact of early spikes. Typey&nbsp;Type starts recording the instant you start typing, so instead of recording the first word at infinity words per minute, it’s set to&nbsp;zero. </p>
+                <p className="text-left de-emphasized" id="chart-notes">Note: The first 4 words are averaged to reduce the impact of early instabilities. Typey&nbsp;Type starts recording the instant you start typing, so instead of recording the first word at infinity words per minute, it’s set to&nbsp;zero. </p>
               </details>
             )}
           </ErrorBoundary>

--- a/src/components/Finished.js
+++ b/src/components/Finished.js
@@ -168,7 +168,7 @@ class Finished extends Component {
   calculateScores(timer, totalNumberOfMatchedWords) {
     let wordsPerMinute;
     if (this.props.timer > 0) {
-      wordsPerMinute = Math.round(totalNumberOfMatchedWords/(timer/60/1000));
+      wordsPerMinute = Math.round(Math.max(totalNumberOfMatchedWords - 1, 0)/(timer/60/1000));
     } else {
       wordsPerMinute = 0;
     }


### PR DESCRIPTION
This change reduces the initial wpm spike by computing one less word.

Because stenography aims to enter words in a single stroke, the actual time of typing a completing a word is nearly none. Meanwhile, Typey-type starts its timer when any letter is typed into the text field. This creates a problem where the time elapsed to type n words only truly measures the time elapsed to type n-1 words. This problem takes the form of an initial spike in the wpm chart. Typey-type have attempted to mitigate this problem by averaging the wpm first 4 words, but the problem largely remains the same. 

One mathematically-correct solution is to start the timer only when the first word is correctly typed. But that may prove to be more difficult. 

The other solution (which is this pull request) is just to subtract one from the total amount of words when computing wpm. 

Although this solution reduces early spikes, it introduces early dips when the first word takes time to input (eg. a multi-stroke word, or a mistake in the typing). But in my opinion, a dip is way better than a spike. 