### PR TITLE
Add level to game

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
-import '../src/index.scss';
+import React from "react";
+import { BrowserRouter as Router, Route } from "react-router-dom";
+import "../src/index.scss";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -8,5 +10,16 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};
 
+export const decorators = [
+  (Story) => {
+    return (
+      <Router basename="/typey-type">
+        <Route>
+          <Story />
+        </Route>
+      </Router>
+    );
+  },
+];

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -200,18 +200,18 @@ class Home extends Component {
           <div className="bg-white landing-page-section">
             <div className="p3 mx-auto mw-1024">
               <div className="mw-584 ml-auto text-right">
-                <h3>Want to get involved?</h3>
-                <p>Support DiDoesDigital, create lessons, or share your feedback. Every bit helps.</p>
-                <Link to='/contribute/' className="link-button dib" style={{lineHeight: 2}}>Contribute</Link>
+                <h3>Games</h3>
+                <p>Play games to mix it up, have fun, and increase your speed.</p>
+                <Link to='/games/' className="link-button dib" style={{lineHeight: 2}}>Play</Link>
               </div>
             </div>
           </div>
           <div className="bg-info landing-page-section">
             <div className="p3 mx-auto mw-1024">
               <div className="mw-584">
-                <h3>Games</h3>
-                <p>Play games to mix it up, have fun, and increase your speed.</p>
-                <Link to='/games/' className="link-button dib" style={{lineHeight: 2}}>Play</Link>
+                <h3>Want to get involved?</h3>
+                <p>Support DiDoesDigital, create lessons, or share your feedback. Every bit helps.</p>
+                <Link to='/contribute/' className="link-button dib" style={{lineHeight: 2}}>Contribute</Link>
               </div>
             </div>
           </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -614,6 +614,7 @@ input:focus::placeholder {
 .mw-1440 { max-width: 1440px; }
 .mw-1024 { max-width: 1024px; }
 .mw-844  { max-width: 844px; }
+.mw-824  { max-width: 816px; }
 .mw-584  { max-width: 584px; }
 .mw-568  { max-width: 568px; }
 .mw-504  { max-width: 504px; }

--- a/src/pages/games/Games.jsx
+++ b/src/pages/games/Games.jsx
@@ -64,7 +64,9 @@ const Games = ({
         path={`${match.url}/SHUFL`}
         render={() => (
           <AsyncSHUFL
+            fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
+            personalDictionaries={personalDictionaries}
             startingMetWordsToday={startingMetWordsToday}
             updateMetWords={updateMetWords}
           />

--- a/src/pages/games/GamesIndex.jsx
+++ b/src/pages/games/GamesIndex.jsx
@@ -46,18 +46,6 @@ export default function GamesIndex() {
               }
             />
             <GameBox
-              title="KHAERT (chatter)"
-              description="Have a yarn with the Aussie bot. Practise simple convo."
-              linkTo="/games/KHAERT"
-              linkText="Start KHAERT"
-              robot={
-                <AussieRobot
-                  role="img"
-                  aria-labelledby="aussie-robot-title"
-                />
-              }
-            />
-            <GameBox
               title="SHUFL (shuffle)"
               description="Solve the puzzle to straighten out shuffled words."
               linkTo="/games/SHUFL"
@@ -75,6 +63,18 @@ export default function GamesIndex() {
                 <ThinkingRobot
                   role="img"
                   aria-labelledby="thinking-robot-title"
+                />
+              }
+            />
+            <GameBox
+              title="KHAERT (chatter)"
+              description="Have a yarn with the Aussie bot. Practise simple convo."
+              linkTo="/games/KHAERT"
+              linkText="Start KHAERT"
+              robot={
+                <AussieRobot
+                  role="img"
+                  aria-labelledby="aussie-robot-title"
                 />
               }
             />

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -161,6 +161,18 @@ export default function Game() {
                 />
               </div>
             </div>
+            <p className="text-center mt10 text-small">
+              Got a suggestion?{" "}
+              <a
+                href="https://forms.gle/L8vGQTtLwKujLtFb7"
+                className="mt0"
+                target="_blank"
+                rel="noopener noreferrer"
+                id="ga--KAOES--give-feedback"
+              >
+                Give feedback
+              </a>
+            </p>
           </>
         )}
       </div>

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -70,7 +70,7 @@ export default function Game() {
       setPuzzleText(choosePuzzleKey(clickedKey));
       setStenoStroke(new Stroke());
       setRightWrongColor(rightColor);
-      dispatch({ type: actions.moveToNextRound });
+      dispatch({ type: actions.roundCompleted });
     } else {
       setStenoStroke(stenoStroke.set(key));
       setRightWrongColor(wrongColor);

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -8,7 +8,7 @@ import React, {
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import * as Confetti from "../../../utils/confetti.js";
 import { actions } from "../utilities/gameActions";
-import { initConfig, gameReducer } from "./gameReducer";
+import { initConfig, gameReducer, roundToWin } from "./gameReducer";
 import Completed from "../components/Completed";
 import Intro from "../components/Intro";
 import RoundProgress from "../components/RoundProgress";
@@ -107,7 +107,10 @@ export default function Game() {
                 }
               />
               <div id={"good-guess"}>
-                <RoundProgress round={state.roundIndex + 1} />
+                <RoundProgress
+                  round={state.roundIndex + 1}
+                  roundToWin={roundToWin}
+                />
               </div>
             </div>
             <Puzzle puzzleText={prettyKey(puzzleText)} />

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -164,20 +164,24 @@ export default function Game() {
                 />
               </div>
             </div>
-            <p className="text-center mt10 text-small">
-              Got a suggestion?{" "}
-              <a
-                href="https://forms.gle/L8vGQTtLwKujLtFb7"
-                className="mt0"
-                target="_blank"
-                rel="noopener noreferrer"
-                id="ga--KAOES--give-feedback"
-              >
-                Give feedback (form opens in new tab)
-              </a>
-            </p>
           </>
         )}
+        <p
+          className={`text-center text-small ${
+            state.gameComplete ? "mt10" : "mt1"
+          }`}
+        >
+          Got a suggestion?{" "}
+          <a
+            href="https://forms.gle/L8vGQTtLwKujLtFb7"
+            className="mt0"
+            target="_blank"
+            rel="noopener noreferrer"
+            id="ga--KAOES--give-feedback"
+          >
+            Give feedback (form opens in new tab)
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -170,7 +170,7 @@ export default function Game() {
                 rel="noopener noreferrer"
                 id="ga--KAOES--give-feedback"
               >
-                Give feedback
+                Give feedback (form opens in new tab)
               </a>
             </p>
           </>

--- a/src/pages/games/KAOES/Game.stories.jsx
+++ b/src/pages/games/KAOES/Game.stories.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Game from "./Game";
-import { BrowserRouter as Router, Route } from "react-router-dom";
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -9,13 +8,9 @@ export default {
 };
 
 const Template = (args) => (
-  <Router basename="/typey-type">
-    <div className="p3">
-      <Route>
-        <Game {...args} />
-      </Route>
-    </div>
-  </Router>
+  <div className="p3">
+    <Game {...args} />
+  </div>
 );
 
 export const KAOESGameStory = Template.bind({});

--- a/src/pages/games/KAOES/gameReducer.js
+++ b/src/pages/games/KAOES/gameReducer.js
@@ -1,6 +1,6 @@
 import { actions } from "../utilities/gameActions";
 
-const roundToWin = 10;
+export const roundToWin = 8;
 
 const defaultState = {
   firstGuess: true,

--- a/src/pages/games/KAOES/gameReducer.js
+++ b/src/pages/games/KAOES/gameReducer.js
@@ -20,7 +20,7 @@ export const gameReducer = (state, action) => {
         ...state,
         firstGuess: false,
       };
-    case actions.moveToNextRound:
+    case actions.roundCompleted:
       return state.roundIndex + 1 === roundToWin
         ? {
             ...state,
@@ -31,7 +31,7 @@ export const gameReducer = (state, action) => {
             ...state,
             roundIndex: state.roundIndex + 1,
           };
-    case actions.restartGame:
+    case actions.gameRestarted:
       return {
         ...state,
         firstGuess: true,

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -1,4 +1,5 @@
 import { shuffle } from "d3-array";
+import { timeMonth } from "d3-time";
 
 class ActionProvider {
   constructor(createChatBotMessage, setStateFunc, createClientMessage) {
@@ -79,6 +80,17 @@ class ActionProvider {
       phraseToLookup: strippedUserMessage,
       messages: [...prevState.messages, botMessage],
     }));
+  }
+
+  handleAgeQuestions(userMessage) {
+    const ageInMonths = timeMonth.count(new Date(2022, 5, 25), Date.now());
+    const reply = userMessage.includes("age")
+      ? `My age? I'm ${ageInMonths} month${ageInMonths > 1 ? "s" : ""} old`
+      : `How old am I? I'm ${ageInMonths} month${
+          ageInMonths > 1 ? "s" : ""
+        } old`;
+    const botMessage = this.createChatBotMessage(reply);
+    this.updateChatbotState(botMessage);
   }
 
   handleWhatQuestions(userMessage) {

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -99,6 +99,16 @@ class ActionProvider {
     this.updateChatbotState(botMessage);
   }
 
+  handleLocationQuestions() {
+    const reply = shuffle([
+      "I come from a little town called Broome in Western Australia",
+      "I'm on holiday in South Australia",
+      "I live inside Typey Type!",
+    ]).slice(0, 1);
+    const botMessage = this.createChatBotMessage(reply);
+    this.updateChatbotState(botMessage);
+  }
+
   handleWhatQuestions(userMessage) {
     const reply = userMessage.includes("steno")
       ? "Stenography is the process of writing shorthand and with a stenotype machine or fancy keyboard you can write over 200 words per minute"

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -99,6 +99,16 @@ class ActionProvider {
     this.updateChatbotState(botMessage);
   }
 
+  handleFavouriteQuestions() {
+    const reply = shuffle([
+      "I like to go boop, boop, boop!",
+      "My fave thing about steno is going boop, boop!",
+      "Boop, boop!",
+    ]).slice(0, 1);
+    const botMessage = this.createChatBotMessage(reply);
+    this.updateChatbotState(botMessage);
+  }
+
   handleLocationQuestions() {
     const reply = shuffle([
       "I come from a little town called Broome in Western Australia",

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -82,6 +82,12 @@ class ActionProvider {
     }));
   }
 
+  handleNameQuestions() {
+    const reply = "I'm Shazza!";
+    const botMessage = this.createChatBotMessage(reply);
+    this.updateChatbotState(botMessage);
+  }
+
   handleAgeQuestions(userMessage) {
     const ageInMonths = timeMonth.count(new Date(2022, 5, 25), Date.now());
     const reply = userMessage.includes("age")

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -1,5 +1,6 @@
 import { shuffle } from "d3-array";
 import { timeMonth } from "d3-time";
+import { botName } from "./config";
 
 class ActionProvider {
   constructor(createChatBotMessage, setStateFunc, createClientMessage) {
@@ -83,7 +84,7 @@ class ActionProvider {
   }
 
   handleNameQuestions() {
-    const reply = "I'm Shazza!";
+    const reply = `I'm ${botName}!`;
     const botMessage = this.createChatBotMessage(reply);
     this.updateChatbotState(botMessage);
   }

--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -92,8 +92,8 @@ class ActionProvider {
   handleAgeQuestions(userMessage) {
     const ageInMonths = timeMonth.count(new Date(2022, 5, 25), Date.now());
     const reply = userMessage.includes("age")
-      ? `My age? I'm ${ageInMonths} month${ageInMonths > 1 ? "s" : ""} old`
-      : `How old am I? I'm ${ageInMonths} month${
+      ? `My age? I'm nearly ${ageInMonths} month${ageInMonths > 1 ? "s" : ""} old`
+      : `How old am I? I am ${ageInMonths} month${
           ageInMonths > 1 ? "s" : ""
         } old`;
     const botMessage = this.createChatBotMessage(reply);

--- a/src/pages/games/KHAERT/Game.jsx
+++ b/src/pages/games/KHAERT/Game.jsx
@@ -67,7 +67,7 @@ export default function Game({ globalLookupDictionary }) {
                 messageParser={MessageParser}
                 actionProvider={ActionProvider}
                 headerText={`Convo with ${botName}`}
-                placeholderText="Write here and hit return (R-R)"
+                placeholderText="Write here, hit enter (R-R)"
               />
             </div>
             <p>

--- a/src/pages/games/KHAERT/Game.stories.jsx
+++ b/src/pages/games/KHAERT/Game.stories.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Game from "./Game";
-import { BrowserRouter as Router, Route } from "react-router-dom";
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -9,13 +8,9 @@ export default {
 };
 
 const Template = (args) => (
-  <Router basename="/typey-type">
-    <div className="p3">
-      <Route>
-        <Game {...args} />
-      </Route>
-    </div>
-  </Router>
+  <div className="p3">
+    <Game {...args} />
+  </div>
 );
 
 export const KHAERTStory = Template.bind({});

--- a/src/pages/games/KHAERT/MessageParser.js
+++ b/src/pages/games/KHAERT/MessageParser.js
@@ -1,4 +1,5 @@
 import {
+  ageQuestions,
   greetings,
   goodbyes,
   howQuestions,
@@ -56,6 +57,11 @@ class MessageParser {
 
     if (messageMatchesAKeyword(lowerCaseMessage, goodbyes)) {
       this.actionProvider.handleGoodbye();
+      foundSomething = true;
+    }
+
+    if (messageMatchesAKeyword(lowerCaseMessage, ageQuestions)) {
+      this.actionProvider.handleAgeQuestions(message);
       foundSomething = true;
     }
 

--- a/src/pages/games/KHAERT/MessageParser.js
+++ b/src/pages/games/KHAERT/MessageParser.js
@@ -1,12 +1,13 @@
 import {
   ageQuestions,
-  nameQuestions,
-  greetings,
   goodbyes,
+  greetings,
   howQuestions,
   keyboardFunctions,
   learningKeywords,
+  locationQuestions,
   lookupKeywords,
+  nameQuestions,
   whatQuestions,
 } from "./constants.js";
 import { escapeRegExp } from "../../../utils/utils";
@@ -66,6 +67,14 @@ class MessageParser {
       lowerCaseMessage.includes("?")
     ) {
       this.actionProvider.handleAgeQuestions(message);
+      foundSomething = true;
+    }
+
+    if (
+      messageMatchesAKeyword(lowerCaseMessage, locationQuestions) &&
+      lowerCaseMessage.includes("?")
+    ) {
+      this.actionProvider.handleLocationQuestions(message);
       foundSomething = true;
     }
 

--- a/src/pages/games/KHAERT/MessageParser.js
+++ b/src/pages/games/KHAERT/MessageParser.js
@@ -1,5 +1,6 @@
 import {
   ageQuestions,
+  nameQuestions,
   greetings,
   goodbyes,
   howQuestions,
@@ -60,8 +61,19 @@ class MessageParser {
       foundSomething = true;
     }
 
-    if (messageMatchesAKeyword(lowerCaseMessage, ageQuestions)) {
+    if (
+      messageMatchesAKeyword(lowerCaseMessage, ageQuestions) &&
+      lowerCaseMessage.includes("?")
+    ) {
       this.actionProvider.handleAgeQuestions(message);
+      foundSomething = true;
+    }
+
+    if (
+      messageMatchesAKeyword(lowerCaseMessage, nameQuestions) &&
+      lowerCaseMessage.includes("?")
+    ) {
+      this.actionProvider.handleNameQuestions(message);
       foundSomething = true;
     }
 

--- a/src/pages/games/KHAERT/MessageParser.js
+++ b/src/pages/games/KHAERT/MessageParser.js
@@ -1,6 +1,7 @@
 import {
   ageQuestions,
   goodbyes,
+  favouriteQuestions,
   greetings,
   howQuestions,
   keyboardFunctions,
@@ -83,6 +84,14 @@ class MessageParser {
       lowerCaseMessage.includes("?")
     ) {
       this.actionProvider.handleNameQuestions(message);
+      foundSomething = true;
+    }
+
+    if (
+      messageMatchesAKeyword(lowerCaseMessage, favouriteQuestions) &&
+      lowerCaseMessage.includes("?")
+    ) {
+      this.actionProvider.handleFavouriteQuestions(message);
       foundSomething = true;
     }
 

--- a/src/pages/games/KHAERT/constants.js
+++ b/src/pages/games/KHAERT/constants.js
@@ -52,6 +52,8 @@ export const lookupKeywords = [
   "write",
 ];
 
+export const favouriteQuestions = ["favourite", "fave", "favorite"];
+
 export const nameQuestions = ["name", botName];
 
 export const locationQuestions = ["where", "location", "live"];

--- a/src/pages/games/KHAERT/constants.js
+++ b/src/pages/games/KHAERT/constants.js
@@ -1,3 +1,5 @@
+import { botName } from "./config";
+
 export const ageQuestions = ["how old", "age"];
 
 export const greetings = [
@@ -49,5 +51,7 @@ export const lookupKeywords = [
   "type",
   "write",
 ];
+
+export const nameQuestions = ["name", botName];
 
 export const whatQuestions = ["what is", "what does"];

--- a/src/pages/games/KHAERT/constants.js
+++ b/src/pages/games/KHAERT/constants.js
@@ -54,4 +54,6 @@ export const lookupKeywords = [
 
 export const nameQuestions = ["name", botName];
 
+export const locationQuestions = ["where", "location", "live"];
+
 export const whatQuestions = ["what is", "what does"];

--- a/src/pages/games/KHAERT/constants.js
+++ b/src/pages/games/KHAERT/constants.js
@@ -1,3 +1,5 @@
+export const ageQuestions = ["how old", "age"];
+
 export const greetings = [
   "hello",
   "hi",

--- a/src/pages/games/SHUFL/Game.jsx
+++ b/src/pages/games/SHUFL/Game.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer, useState } from "react";
 import { actions } from "./gameActions";
-import { initConfig, gameReducer } from "./gameReducer";
+import { initConfig, gameReducer, roundToWin, levelToWin } from "./gameReducer";
 import Completed from "../components/Completed";
 import Hint from "../components/Hint";
 import Input from "../components/Input";
@@ -12,7 +12,7 @@ import { ReactComponent as RaverRobot } from "../../../images/RaverRobot.svg";
 
 const gameName = "SHUFL";
 const introText =
-  "The steno robots have been dancing too much and shuffled all the letters out of order! You need to type the correct word to get them all back in order.";
+  "The steno robots have been dancing too much and shuffled all the letters! You need to type the correct word to get them all back in order.";
 
 export default function Game({
   globalLookupDictionary,
@@ -74,8 +74,10 @@ export default function Game({
                 }
               />
               <RoundProgress
-                round={gameState.roundIndex + 1}
                 level={gameState.level}
+                levelToWin={levelToWin}
+                round={gameState.roundIndex + 1}
+                roundToWin={roundToWin}
               />
             </div>
             {gameState.levelComplete ? (

--- a/src/pages/games/SHUFL/Game.jsx
+++ b/src/pages/games/SHUFL/Game.jsx
@@ -104,6 +104,18 @@ export default function Game({
                 />
               </>
             )}
+            <p className="text-center mt10 text-small">
+              Got a suggestion?{" "}
+              <a
+                href="https://forms.gle/wtU8phNLPpDsGdCZ7"
+                className="mt0"
+                target="_blank"
+                rel="noopener noreferrer"
+                id="ga--SHUFL--give-feedback"
+              >
+                Give feedback
+              </a>
+            </p>
           </>
         )}
       </div>

--- a/src/pages/games/SHUFL/Game.jsx
+++ b/src/pages/games/SHUFL/Game.jsx
@@ -106,20 +106,20 @@ export default function Game({
                 />
               </>
             )}
-            <p className="text-center mt10 text-small">
-              Got a suggestion?{" "}
-              <a
-                href="https://forms.gle/wtU8phNLPpDsGdCZ7"
-                className="mt0"
-                target="_blank"
-                rel="noopener noreferrer"
-                id="ga--SHUFL--give-feedback"
-              >
-                Give feedback (form opens in new tab)
-              </a>
-            </p>
           </>
         )}
+        <p className="text-center mt10 text-small">
+          Got a suggestion?{" "}
+          <a
+            href="https://forms.gle/wtU8phNLPpDsGdCZ7"
+            className="mt0"
+            target="_blank"
+            rel="noopener noreferrer"
+            id="ga--SHUFL--give-feedback"
+          >
+            Give feedback (form opens in new tab)
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/games/SHUFL/Game.jsx
+++ b/src/pages/games/SHUFL/Game.jsx
@@ -6,6 +6,7 @@ import Hint from "../components/Hint";
 import Input from "../components/Input";
 import Intro from "../components/Intro";
 import RoundProgress from "../components/RoundProgress";
+import LevelCompleted from "./LevelCompleted";
 import Puzzle from "./Puzzle";
 import { ReactComponent as RaverRobot } from "../../../images/RaverRobot.svg";
 
@@ -77,20 +78,32 @@ export default function Game({
                 level={gameState.level}
               />
             </div>
-            <Puzzle puzzleText={gameState.puzzleText} />
-            <Input
-              onChangeInput={onChangeSHUFLInput}
-              previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
-              round={gameState.roundIndex + 1}
-              typedText={typedText}
-              gameName={gameName}
-            />
-            <Hint
-              currentStroke={gameState.currentHint}
-              gameName={gameName}
-              setShowHint={setShowHint}
-              showHint={showHint}
-            />
+            {gameState.levelComplete ? (
+              <LevelCompleted
+                dispatch={dispatch}
+                gameName={gameName}
+                level={gameState.level}
+              />
+            ) : (
+              <>
+                <Puzzle puzzleText={gameState.puzzleText} />
+                <Input
+                  onChangeInput={onChangeSHUFLInput}
+                  previousCompletedPhraseAsTyped={
+                    previousCompletedPhraseAsTyped
+                  }
+                  round={gameState.roundIndex + 1}
+                  typedText={typedText}
+                  gameName={gameName}
+                />
+                <Hint
+                  currentStroke={gameState.currentHint}
+                  gameName={gameName}
+                  setShowHint={setShowHint}
+                  showHint={showHint}
+                />
+              </>
+            )}
           </>
         )}
       </div>

--- a/src/pages/games/SHUFL/Game.jsx
+++ b/src/pages/games/SHUFL/Game.jsx
@@ -113,7 +113,7 @@ export default function Game({
                 rel="noopener noreferrer"
                 id="ga--SHUFL--give-feedback"
               >
-                Give feedback
+                Give feedback (form opens in new tab)
               </a>
             </p>
           </>

--- a/src/pages/games/SHUFL/Game.stories.jsx
+++ b/src/pages/games/SHUFL/Game.stories.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Game from "./Game";
 import metWordsBeginner from "../../../fixtures/metWordsBeginner.json";
-import { BrowserRouter as Router, Route } from "react-router-dom";
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -12,13 +11,13 @@ export default {
 const fauxUpdateMetWords = (metWord) => console.log(metWord);
 
 const Template = (args) => (
-  <Router basename="/typey-type">
-    <div className="p3">
-      <Route>
-        <Game globalLookupDictionary={new Map()} updateMetWords={fauxUpdateMetWords} {...args} />
-      </Route>
-    </div>
-  </Router>
+  <div className="p3">
+    <Game
+      globalLookupDictionary={new Map()}
+      updateMetWords={fauxUpdateMetWords}
+      {...args}
+    />
+  </div>
 );
 
 export const SHUFLGameStory = Template.bind({});

--- a/src/pages/games/SHUFL/Index.jsx
+++ b/src/pages/games/SHUFL/Index.jsx
@@ -2,8 +2,10 @@ import React, { useEffect, useRef } from "react";
 import Game from "./Game";
 
 export default function Index({
+  fetchAndSetupGlobalDict,
   globalLookupDictionary,
   startingMetWordsToday,
+  personalDictionaries,
   updateMetWords,
 }) {
   const mainHeading = useRef(null);
@@ -12,6 +14,20 @@ export default function Index({
       mainHeading.current.focus();
     }
   }, []);
+
+  useEffect(() => {
+    const shouldUsePersonalDictionaries =
+      personalDictionaries &&
+      Object.entries(personalDictionaries).length > 0 &&
+      !!personalDictionaries.dictionariesNamesAndContents;
+
+    fetchAndSetupGlobalDict(
+      false,
+      shouldUsePersonalDictionaries ? personalDictionaries : null
+    ).catch((error) => {
+      console.error(error);
+    });
+  }, [fetchAndSetupGlobalDict, personalDictionaries]);
 
   return (
     <main id="main">

--- a/src/pages/games/SHUFL/LevelCompleted.jsx
+++ b/src/pages/games/SHUFL/LevelCompleted.jsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import GoogleAnalytics from "react-ga";
+import { actions } from "./gameActions";
+import { ReactComponent as AlertRobot } from "../../../images/AlertRobot.svg";
+import * as Confetti from "../../../utils/confetti.js";
+
+const particles = [];
+const ConfettiConfig = { sparsity: 240, colors: 5 };
+
+const handleActionClick = (event, gameName, dispatch) => {
+  event.preventDefault();
+
+  if (dispatch) {
+    dispatch({ type: actions.levelRestarted });
+  }
+
+  GoogleAnalytics.event({
+    category: gameName,
+    action: "Click",
+    label: "Play again",
+  });
+};
+
+export default React.memo(function LevelCompleted({ gameName, level, dispatch }) {
+  const actionbutton = useRef(null);
+  const canvasRef = useRef(null);
+  const canvasWidth = Math.floor(window.innerWidth);
+  const canvasHeight = Math.floor(window.innerHeight);
+
+  useEffect(() => {
+    if (actionbutton) {
+      actionbutton.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    Confetti.setupCanvas(ConfettiConfig, "level-completed", particles);
+    if (canvasRef.current) {
+      Confetti.restartAnimation(
+        particles,
+        canvasRef.current,
+        canvasWidth,
+        canvasHeight
+      );
+    }
+    return function cleanup() {
+      Confetti.cancelAnimation();
+    };
+  }, [canvasRef, canvasWidth, canvasHeight]);
+
+  const restartConfetti = useCallback(
+    (event) => {
+      if (
+        event &&
+        ((event.keyCode && event.keyCode === 13) || event.type === "click")
+      ) {
+        particles.splice(0);
+        Confetti.cancelAnimation();
+        Confetti.setupCanvas(ConfettiConfig, "level-completed", particles);
+        Confetti.restartAnimation(
+          particles,
+          canvasRef.current,
+          canvasWidth,
+          canvasHeight
+        );
+      }
+    },
+    [canvasRef, canvasWidth, canvasHeight]
+  );
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        width={canvasWidth}
+        height={canvasHeight}
+        className="fixed celebration-canvas top-0 left-0 pointer-none"
+      />
+      <div
+        tabIndex="0"
+        onClick={restartConfetti}
+        onKeyDown={restartConfetti}
+        className="w-100 pt1"
+      >
+        <div className="w-100 mw-48 mx-auto" id="level-completed">
+          <AlertRobot />
+        </div>
+        <p className="text-center w-100"><strong>Level {level - 1} complete!</strong></p>
+      </div>
+      <p className="mx-auto text-center">
+        <button
+          ref={actionbutton}
+          className="button"
+          onClick={(event) => handleActionClick(event, gameName, dispatch)}
+        >
+          Next level
+        </button>
+      </p>
+    </>
+  );
+});

--- a/src/pages/games/SHUFL/LevelCompleted.jsx
+++ b/src/pages/games/SHUFL/LevelCompleted.jsx
@@ -80,7 +80,7 @@ export default React.memo(function LevelCompleted({ gameName, level, dispatch })
         tabIndex="0"
         onClick={restartConfetti}
         onKeyDown={restartConfetti}
-        className="w-100 pt1"
+        className="w-100"
       >
         <div className="w-100 mw-48 mx-auto" id="level-completed">
           <AlertRobot />

--- a/src/pages/games/SHUFL/gameActions.js
+++ b/src/pages/games/SHUFL/gameActions.js
@@ -1,4 +1,5 @@
 export const actions = {
   gameRestarted: "gameRestarted",
+  gameStarted: "gameStarted",
   roundCompleted: "roundCompleted",
 };

--- a/src/pages/games/SHUFL/gameActions.js
+++ b/src/pages/games/SHUFL/gameActions.js
@@ -1,5 +1,6 @@
 export const actions = {
   gameRestarted: "gameRestarted",
   gameStarted: "gameStarted",
+  levelRestarted: "levelRestarted",
   roundCompleted: "roundCompleted",
 };

--- a/src/pages/games/SHUFL/gameReducer.js
+++ b/src/pages/games/SHUFL/gameReducer.js
@@ -1,10 +1,29 @@
-import { actions } from "../utilities/gameActions";
+import { actions } from "./gameActions";
+import {
+  getLevelMaterial,
+  getRightAnswers,
+  pickAWord,
+  selectMaterial,
+  shuffleWord,
+} from "./utilities";
+import { createStrokeHintForPhrase } from "../../../utils/transformingDictionaries";
 
-const roundToWin = 10;
+const roundToWin = 3;
+const levelToWin = 4;
+
+const initialProgress = {
+  gameComplete: false,
+  level: 1,
+  roundIndex: 0,
+};
 
 const defaultState = {
-  roundIndex: 0,
-  gameComplete: false,
+  ...initialProgress,
+  currentHint: "",
+  globalLookupDictionary: new Map(),
+  material: {},
+  puzzleText: "",
+  rightAnswers: [],
 };
 
 export const initConfig = (state) => ({
@@ -12,25 +31,117 @@ export const initConfig = (state) => ({
   ...state,
 });
 
+const getGameStartedState = (state, action) => {
+  const material = selectMaterial(action.payload.startingMetWordsToday);
+  const firstPickedWord = pickAWord(getLevelMaterial(material, 1));
+  return {
+    ...state,
+    ...initialProgress,
+    globalLookupDictionary: action.payload.globalLookupDictionary,
+    material,
+    currentHint: createStrokeHintForPhrase(
+      firstPickedWord.trim(),
+      state.globalLookupDictionary
+    ),
+    rightAnswers: getRightAnswers(
+      getLevelMaterial(material, 1),
+      firstPickedWord
+    ),
+    puzzleText: shuffleWord(firstPickedWord),
+  };
+};
+
+const getGameRestartedState = (state) => {
+  const pickedWord = pickAWord(getLevelMaterial(state.material, 1));
+  return {
+    ...state,
+    ...initialProgress,
+    currentHint: createStrokeHintForPhrase(
+      pickedWord.trim(),
+      state.globalLookupDictionary
+    ),
+    rightAnswers: getRightAnswers(
+      getLevelMaterial(state.material, 1),
+      pickedWord
+    ),
+    puzzleText: shuffleWord(pickedWord),
+  };
+};
+
+const getAllLevelsCompletedState = (state) => {
+  const roundCompletedPickedWord = pickAWord(
+    getLevelMaterial(state.material, 1)
+  );
+  return {
+    ...state,
+    ...initialProgress,
+    gameComplete: true,
+    rightAnswers: getRightAnswers(
+      getLevelMaterial(state.material, 1),
+      roundCompletedPickedWord
+    ),
+    currentHint: createStrokeHintForPhrase(
+      roundCompletedPickedWord.trim(),
+      state.globalLookupDictionary
+    ),
+    puzzleText: shuffleWord(roundCompletedPickedWord),
+  };
+};
+
+const getEarlyLevelCompletedState = (state) => {
+  const increasedLevel = state.level + 1;
+  const roundCompletedPickedWord = pickAWord(
+    getLevelMaterial(state.material, increasedLevel)
+  );
+  return {
+    ...state,
+    level: increasedLevel,
+    roundIndex: 0,
+    rightAnswers: getRightAnswers(
+      getLevelMaterial(state.material, increasedLevel),
+      roundCompletedPickedWord
+    ),
+    currentHint: createStrokeHintForPhrase(
+      roundCompletedPickedWord.trim(),
+      state.globalLookupDictionary
+    ),
+    puzzleText: shuffleWord(roundCompletedPickedWord),
+  };
+};
+
+const getEarlyRoundCompletedState = (state) => {
+  const roundCompletedPickedWord = pickAWord(
+    getLevelMaterial(state.material, state.level)
+  );
+  return {
+    ...state,
+    roundIndex: state.roundIndex + 1,
+    rightAnswers: getRightAnswers(
+      getLevelMaterial(state.material, state.level),
+      roundCompletedPickedWord
+    ),
+    currentHint: createStrokeHintForPhrase(
+      roundCompletedPickedWord.trim(),
+      state.globalLookupDictionary
+    ),
+    puzzleText: shuffleWord(roundCompletedPickedWord),
+  };
+};
+
 export const gameReducer = (state, action) => {
   switch (action?.type) {
-    case actions.moveToNextRound:
-      return state.roundIndex + 1 === roundToWin
-        ? {
-            ...state,
-            gameComplete: true,
-            roundIndex: 0,
-          }
-        : {
-            ...state,
-            roundIndex: state.roundIndex + 1,
-          };
-    case actions.restartGame:
-      return {
-        ...state,
-        gameComplete: false,
-        roundIndex: 0,
-      };
+    case actions.gameStarted:
+      return getGameStartedState(state, action);
+
+    case actions.gameRestarted:
+      return getGameRestartedState(state, action);
+
+    case actions.roundCompleted:
+      return state.roundIndex + 1 === roundToWin && state.level === levelToWin
+        ? getAllLevelsCompletedState(state)
+        : state.roundIndex + 1 === roundToWin
+        ? getEarlyLevelCompletedState(state)
+        : getEarlyRoundCompletedState(state);
 
     default:
       return state;

--- a/src/pages/games/SHUFL/gameReducer.js
+++ b/src/pages/games/SHUFL/gameReducer.js
@@ -34,6 +34,10 @@ export const initConfig = (state) => ({
 const getGameStartedState = (state, action) => {
   const material = selectMaterial(action.payload.startingMetWordsToday);
   const firstPickedWord = pickAWord(getLevelMaterial(material, 1));
+  const rightAnswers = getRightAnswers(
+    getLevelMaterial(material, 1),
+    firstPickedWord
+  );
   return {
     ...state,
     ...initialProgress,
@@ -43,16 +47,17 @@ const getGameStartedState = (state, action) => {
       firstPickedWord.trim(),
       state.globalLookupDictionary
     ),
-    rightAnswers: getRightAnswers(
-      getLevelMaterial(material, 1),
-      firstPickedWord
-    ),
-    puzzleText: shuffleWord(firstPickedWord),
+    puzzleText: shuffleWord(firstPickedWord, rightAnswers),
+    rightAnswers,
   };
 };
 
 const getGameRestartedState = (state) => {
   const pickedWord = pickAWord(getLevelMaterial(state.material, 1));
+  const rightAnswers = getRightAnswers(
+    getLevelMaterial(state.material, 1),
+    pickedWord
+  );
   return {
     ...state,
     ...initialProgress,
@@ -60,11 +65,8 @@ const getGameRestartedState = (state) => {
       pickedWord.trim(),
       state.globalLookupDictionary
     ),
-    rightAnswers: getRightAnswers(
-      getLevelMaterial(state.material, 1),
-      pickedWord
-    ),
-    puzzleText: shuffleWord(pickedWord),
+    puzzleText: shuffleWord(pickedWord, rightAnswers),
+    rightAnswers,
   };
 };
 
@@ -72,19 +74,20 @@ const getAllLevelsCompletedState = (state) => {
   const roundCompletedPickedWord = pickAWord(
     getLevelMaterial(state.material, 1)
   );
+  const rightAnswers = getRightAnswers(
+    getLevelMaterial(state.material, 1),
+    roundCompletedPickedWord
+  );
   return {
     ...state,
     ...initialProgress,
     gameComplete: true,
-    rightAnswers: getRightAnswers(
-      getLevelMaterial(state.material, 1),
-      roundCompletedPickedWord
-    ),
     currentHint: createStrokeHintForPhrase(
       roundCompletedPickedWord.trim(),
       state.globalLookupDictionary
     ),
-    puzzleText: shuffleWord(roundCompletedPickedWord),
+    rightAnswers,
+    puzzleText: shuffleWord(roundCompletedPickedWord, rightAnswers),
   };
 };
 
@@ -93,19 +96,20 @@ const getEarlyLevelCompletedState = (state) => {
   const roundCompletedPickedWord = pickAWord(
     getLevelMaterial(state.material, increasedLevel)
   );
+  const rightAnswers = getRightAnswers(
+    getLevelMaterial(state.material, increasedLevel),
+    roundCompletedPickedWord
+  );
   return {
     ...state,
     level: increasedLevel,
     roundIndex: 0,
-    rightAnswers: getRightAnswers(
-      getLevelMaterial(state.material, increasedLevel),
-      roundCompletedPickedWord
-    ),
     currentHint: createStrokeHintForPhrase(
       roundCompletedPickedWord.trim(),
       state.globalLookupDictionary
     ),
-    puzzleText: shuffleWord(roundCompletedPickedWord),
+    rightAnswers,
+    puzzleText: shuffleWord(roundCompletedPickedWord, rightAnswers),
   };
 };
 
@@ -113,18 +117,19 @@ const getEarlyRoundCompletedState = (state) => {
   const roundCompletedPickedWord = pickAWord(
     getLevelMaterial(state.material, state.level)
   );
+  const rightAnswers = getRightAnswers(
+    getLevelMaterial(state.material, state.level),
+    roundCompletedPickedWord
+  );
   return {
     ...state,
     roundIndex: state.roundIndex + 1,
-    rightAnswers: getRightAnswers(
-      getLevelMaterial(state.material, state.level),
-      roundCompletedPickedWord
-    ),
     currentHint: createStrokeHintForPhrase(
       roundCompletedPickedWord.trim(),
       state.globalLookupDictionary
     ),
-    puzzleText: shuffleWord(roundCompletedPickedWord),
+    rightAnswers,
+    puzzleText: shuffleWord(roundCompletedPickedWord, rightAnswers),
   };
 };
 

--- a/src/pages/games/SHUFL/gameReducer.js
+++ b/src/pages/games/SHUFL/gameReducer.js
@@ -8,8 +8,8 @@ import {
 } from "./utilities";
 import { createStrokeHintForPhrase } from "../../../utils/transformingDictionaries";
 
-const roundToWin = 3;
-const levelToWin = 4;
+export const roundToWin = 3;
+export const levelToWin = 4;
 
 const initialProgress = {
   gameComplete: false,

--- a/src/pages/games/SHUFL/gameReducer.js
+++ b/src/pages/games/SHUFL/gameReducer.js
@@ -13,6 +13,7 @@ const levelToWin = 4;
 
 const initialProgress = {
   gameComplete: false,
+  levelComplete: false,
   level: 1,
   roundIndex: 0,
 };
@@ -103,6 +104,7 @@ const getEarlyLevelCompletedState = (state) => {
   return {
     ...state,
     level: increasedLevel,
+    levelComplete: true,
     roundIndex: 0,
     currentHint: createStrokeHintForPhrase(
       roundCompletedPickedWord.trim(),
@@ -140,6 +142,9 @@ export const gameReducer = (state, action) => {
 
     case actions.gameRestarted:
       return getGameRestartedState(state, action);
+
+    case actions.levelRestarted:
+      return { ...state, levelComplete: false };
 
     case actions.roundCompleted:
       return state.roundIndex + 1 === roundToWin && state.level === levelToWin

--- a/src/pages/games/SHUFL/utilities.js
+++ b/src/pages/games/SHUFL/utilities.js
@@ -9,49 +9,84 @@ import {
   hasOnlyLowercaseLetters,
 } from "../../../utils/dictEntryPredicates";
 
-export const getRightAnswers = (material, pickedWord) =>
-  material.reduce((prevArr, currentWord) => {
+export const getLevelMaterial = (material, level) => {
+  switch (level) {
+    case 1:
+      return material.has3Letters;
+    case 2:
+      return material.has4Letters;
+    case 3:
+      return material.has5Letters;
+    case 4:
+      return material.has6Letters;
+    default:
+      return material.has3Letters;
+  }
+};
+
+export const getRightAnswers = (levelMaterial, pickedWord) =>
+  levelMaterial.reduce((prevArr, currentWord) => {
     return [...currentWord.trim()].sort().join("") ===
       [...pickedWord.trim()].sort().join("")
       ? [currentWord.trim(), ...prevArr]
       : prevArr;
   }, []);
 
-export const pickAWord = (filteredMetWords) =>
-  shuffle(filteredMetWords.slice()).slice(0, 1)[0].trim();
+export const pickAWord = (levelMaterial) =>
+  shuffle(levelMaterial.slice()).slice(0, 1)[0].trim();
 
-const defaultWords = [
-  "was",
-  "her",
-  "out",
-  "them",
-  "when",
-  "more",
-  "your",
-  "than",
-  "time",
-  "their",
-  "might",
-  "place",
-  "course",
-  "turned",
-  "friend",
-];
+const defaultWords = {
+  has3Letters: ["was", "her", "out"],
+  has4Letters: ["them", "when", "more", "your", "than", "time"],
+  has5Letters: ["their", "might", "place"],
+  has6Letters: ["course", "turned", "friend"],
+};
 
 export const selectMaterial = (startingMetWordsToday) => {
   if (!startingMetWordsToday) return defaultWords;
-  const result = Object.keys(
-    trimAndSumUniqMetWords(startingMetWordsToday)
-  ).filter(
-    (translation) =>
-      hasFewerThan7Letters(translation) &&
-      hasMoreThan2Letters(translation) &&
-      hasNoRepeatLetters(translation) &&
-      hasOnlyLowercaseLetters(translation)
-  );
+  const result = Object.keys(trimAndSumUniqMetWords(startingMetWordsToday))
+    .filter(
+      (translation) =>
+        hasFewerThan7Letters(translation) &&
+        hasMoreThan2Letters(translation) &&
+        hasNoRepeatLetters(translation) &&
+        hasOnlyLowercaseLetters(translation)
+    )
+    .reduce(
+      (previous, currentWord) => {
+        switch (currentWord.length) {
+          case 3:
+            previous.has3Letters.push(currentWord);
+            break;
+          case 4:
+            previous.has4Letters.push(currentWord);
+            break;
+          case 5:
+            previous.has5Letters.push(currentWord);
+            break;
+          case 6:
+            previous.has6Letters.push(currentWord);
+            break;
 
-  if (result.length < 15) {
-    result.push(...defaultWords);
+          default:
+            break;
+        }
+        return previous;
+      },
+      { has3Letters: [], has4Letters: [], has5Letters: [], has6Letters: [] }
+    );
+
+  if (result.has3Letters.length < 3) {
+    result.has3Letters.push(...defaultWords.has3Letters);
+  }
+  if (result.has4Letters.length < 3) {
+    result.has4Letters.push(...defaultWords.has4Letters);
+  }
+  if (result.has5Letters.length < 3) {
+    result.has5Letters.push(...defaultWords.has5Letters);
+  }
+  if (result.has6Letters.length < 3) {
+    result.has6Letters.push(...defaultWords.has6Letters);
   }
 
   return result;

--- a/src/pages/games/SHUFL/utilities.js
+++ b/src/pages/games/SHUFL/utilities.js
@@ -60,5 +60,12 @@ export const selectMaterial = (startingMetWordsToday) => {
   return result;
 };
 
-export const shuffleWord = (pickedWord) =>
-  shuffle(Array.from(pickedWord)).join("");
+const shuffleLetters = (word) => shuffle(Array.from(word)).join("");
+
+export const shuffleWord = (pickedWord, rightAnswers) => {
+  let shuffleWord = shuffleLetters(pickedWord);
+  if (rightAnswers.includes(shuffleWord)) {
+    shuffleWord = shuffleLetters(pickedWord);
+  }
+  return shuffleWord;
+};

--- a/src/pages/games/SHUFL/utilities.js
+++ b/src/pages/games/SHUFL/utilities.js
@@ -9,20 +9,8 @@ import {
   hasOnlyLowercaseLetters,
 } from "../../../utils/dictEntryPredicates";
 
-export const getLevelMaterial = (material, level) => {
-  switch (level) {
-    case 1:
-      return material.has3Letters;
-    case 2:
-      return material.has4Letters;
-    case 3:
-      return material.has5Letters;
-    case 4:
-      return material.has6Letters;
-    default:
-      return material.has3Letters;
-  }
-};
+export const getLevelMaterial = (material, level) =>
+  material[level + 2] || material[3];
 
 export const getRightAnswers = (levelMaterial, pickedWord) =>
   levelMaterial.reduce((prevArr, currentWord) => {
@@ -36,10 +24,10 @@ export const pickAWord = (levelMaterial) =>
   shuffle(levelMaterial.slice()).slice(0, 1)[0].trim();
 
 const defaultWords = {
-  has3Letters: ["was", "her", "out"],
-  has4Letters: ["them", "when", "more", "your", "than", "time"],
-  has5Letters: ["their", "might", "place"],
-  has6Letters: ["course", "turned", "friend"],
+  3: ["was", "her", "out"],
+  4: ["them", "when", "more", "your", "than", "time"],
+  5: ["their", "might", "place"],
+  6: ["course", "turned", "friend"],
 };
 
 export const selectMaterial = (startingMetWordsToday) => {
@@ -54,40 +42,20 @@ export const selectMaterial = (startingMetWordsToday) => {
     )
     .reduce(
       (previous, currentWord) => {
-        switch (currentWord.length) {
-          case 3:
-            previous.has3Letters.push(currentWord);
-            break;
-          case 4:
-            previous.has4Letters.push(currentWord);
-            break;
-          case 5:
-            previous.has5Letters.push(currentWord);
-            break;
-          case 6:
-            previous.has6Letters.push(currentWord);
-            break;
-
-          default:
-            break;
+        if (currentWord.length >= 3 && currentWord.length <= 6) {
+          previous[currentWord.length].push(currentWord);
         }
+
         return previous;
       },
-      { has3Letters: [], has4Letters: [], has5Letters: [], has6Letters: [] }
+      { 3: [], 4: [], 5: [], 6: [] }
     );
 
-  if (result.has3Letters.length < 3) {
-    result.has3Letters.push(...defaultWords.has3Letters);
-  }
-  if (result.has4Letters.length < 3) {
-    result.has4Letters.push(...defaultWords.has4Letters);
-  }
-  if (result.has5Letters.length < 3) {
-    result.has5Letters.push(...defaultWords.has5Letters);
-  }
-  if (result.has6Letters.length < 3) {
-    result.has6Letters.push(...defaultWords.has6Letters);
-  }
+  [3, 4, 5, 6].forEach((wordLength) => {
+    if (result[wordLength].length < 3) {
+      result[wordLength].push(...defaultWords[wordLength]);
+    }
+  });
 
   return result;
 };

--- a/src/pages/games/SHUFL/utilities.test.js
+++ b/src/pages/games/SHUFL/utilities.test.js
@@ -1,13 +1,70 @@
-import { getRightAnswers } from "./utilities";
+import { getRightAnswers, selectMaterial } from "./utilities";
 
-const material = ["each", "bade", "bead", "deaf", "fade", "last", "salt"];
+describe("selectMaterial", () => {
+  const material = {
+    maw: 1,
+    bye: 1,
+    mow: 1,
+    gal: 1,
+    herb: 1,
+    duly: 1,
+    face: 1,
+    risk: 1,
+    winds: 1,
+    gamed: 1,
+    brake: 1,
+    tidal: 1,
+    hacked: 1,
+    blamed: 1,
+    coding: 1,
+    radish: 1,
+  };
+
+  it("returns grouped material by word length", () => {
+    const result = selectMaterial(material);
+    expect(result.has3Letters.slice().sort()).toEqual([
+      "bye",
+      "gal",
+      "maw",
+      "mow",
+    ]);
+    expect(result.has4Letters.slice().sort()).toEqual([
+      "duly",
+      "face",
+      "herb",
+      "risk",
+    ]);
+    expect(result.has5Letters.slice().sort()).toEqual([
+      "brake",
+      "gamed",
+      "tidal",
+      "winds",
+    ]);
+    expect(result.has6Letters.slice().sort()).toEqual([
+      "blamed",
+      "coding",
+      "hacked",
+      "radish",
+    ]);
+  });
+});
 
 describe("getRightAnswers", () => {
+  const levelMaterial = [
+    "each",
+    "bade",
+    "bead",
+    "deaf",
+    "fade",
+    "last",
+    "salt",
+  ];
+
   it("returns multiple options for many right answers", () => {
-    expect(getRightAnswers(material, "ebda")).toEqual(["bead", "bade"]);
+    expect(getRightAnswers(levelMaterial, "ebda")).toEqual(["bead", "bade"]);
   });
 
   it("returns one item for one right answer", () => {
-    expect(getRightAnswers(material, "ahec")).toEqual(["each"]);
+    expect(getRightAnswers(levelMaterial, "ahec")).toEqual(["each"]);
   });
 });

--- a/src/pages/games/SHUFL/utilities.test.js
+++ b/src/pages/games/SHUFL/utilities.test.js
@@ -22,25 +22,20 @@ describe("selectMaterial", () => {
 
   it("returns grouped material by word length", () => {
     const result = selectMaterial(material);
-    expect(result.has3Letters.slice().sort()).toEqual([
-      "bye",
-      "gal",
-      "maw",
-      "mow",
-    ]);
-    expect(result.has4Letters.slice().sort()).toEqual([
+    expect(result[3].slice().sort()).toEqual(["bye", "gal", "maw", "mow"]);
+    expect(result[4].slice().sort()).toEqual([
       "duly",
       "face",
       "herb",
       "risk",
     ]);
-    expect(result.has5Letters.slice().sort()).toEqual([
+    expect(result[5].slice().sort()).toEqual([
       "brake",
       "gamed",
       "tidal",
       "winds",
     ]);
-    expect(result.has6Letters.slice().sort()).toEqual([
+    expect(result[6].slice().sort()).toEqual([
       "blamed",
       "coding",
       "hacked",

--- a/src/pages/games/TPEUBGSZ/Game.jsx
+++ b/src/pages/games/TPEUBGSZ/Game.jsx
@@ -44,7 +44,7 @@ export default function Game() {
       setPuzzleText(madeUpWord);
       setCurrentStroke(hint);
       setShowHint(false);
-      dispatch({ type: actions.moveToNextRound });
+      dispatch({ type: actions.roundCompleted });
     }
   };
 

--- a/src/pages/games/TPEUBGSZ/Game.jsx
+++ b/src/pages/games/TPEUBGSZ/Game.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer, useState } from "react";
 import { actions } from "../utilities/gameActions";
-import { initConfig, gameReducer } from "./gameReducer";
+import { initConfig, gameReducer, roundToWin } from "./gameReducer";
 import Completed from "../components/Completed";
 import Hint from "../components/Hint";
 import Input from "../components/Input";
@@ -69,7 +69,7 @@ export default function Game() {
                   />
                 }
               />
-              <RoundProgress round={state.roundIndex + 1} />
+              <RoundProgress round={state.roundIndex + 1} roundToWin={roundToWin} />
             </div>
             <Puzzle puzzleText={puzzleText} />
             <Input

--- a/src/pages/games/TPEUBGSZ/Game.jsx
+++ b/src/pages/games/TPEUBGSZ/Game.jsx
@@ -96,7 +96,7 @@ export default function Game() {
             rel="noopener noreferrer"
             id="ga--TPEUBGSZ--give-feedback"
           >
-            Give feedback
+            Give feedback (form opens in new tab)
           </a>
         </p>
       </div>

--- a/src/pages/games/TPEUBGSZ/Game.jsx
+++ b/src/pages/games/TPEUBGSZ/Game.jsx
@@ -87,6 +87,18 @@ export default function Game() {
             />
           </>
         )}
+        <p className="text-center mt10 text-small">
+          Got a suggestion?{" "}
+          <a
+            href="https://forms.gle/P1tMjotG2w17CyyNA"
+            className="mt0"
+            target="_blank"
+            rel="noopener noreferrer"
+            id="ga--TPEUBGSZ--give-feedback"
+          >
+            Give feedback
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/games/TPEUBGSZ/Game.stories.jsx
+++ b/src/pages/games/TPEUBGSZ/Game.stories.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Game from "./Game";
-import { BrowserRouter as Router, Route } from "react-router-dom";
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -9,13 +8,9 @@ export default {
 };
 
 const Template = (args) => (
-  <Router basename="/typey-type">
-    <div className="p3">
-      <Route>
-        <Game {...args} />
-      </Route>
-    </div>
-  </Router>
+  <div className="p3">
+    <Game {...args} />
+  </div>
 );
 
 export const TPEUBGSZGameStory = Template.bind({});

--- a/src/pages/games/TPEUBGSZ/gameReducer.js
+++ b/src/pages/games/TPEUBGSZ/gameReducer.js
@@ -14,7 +14,7 @@ export const initConfig = (state) => ({
 
 export const gameReducer = (state, action) => {
   switch (action?.type) {
-    case actions.moveToNextRound:
+    case actions.roundCompleted:
       return state.roundIndex + 1 === roundToWin
         ? {
             ...state,
@@ -25,7 +25,7 @@ export const gameReducer = (state, action) => {
             ...state,
             roundIndex: state.roundIndex + 1,
           };
-    case actions.restartGame:
+    case actions.gameRestarted:
       return {
         ...state,
         gameComplete: false,

--- a/src/pages/games/TPEUBGSZ/gameReducer.js
+++ b/src/pages/games/TPEUBGSZ/gameReducer.js
@@ -1,6 +1,6 @@
 import { actions } from "../utilities/gameActions";
 
-const roundToWin = 10;
+export const roundToWin = 8;
 
 const defaultState = {
   roundIndex: 0,

--- a/src/pages/games/components/Completed.jsx
+++ b/src/pages/games/components/Completed.jsx
@@ -10,7 +10,7 @@ const handlePlayAgainClick = (event, gameName, dispatch) => {
   event.preventDefault();
 
   if (dispatch) {
-    dispatch({ type: actions.restartGame });
+    dispatch({ type: actions.gameRestarted });
   }
 
   GoogleAnalytics.event({

--- a/src/pages/games/components/Completed.jsx
+++ b/src/pages/games/components/Completed.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import GoogleAnalytics from "react-ga";
+import { Link } from "react-router-dom";
 import { actions } from "../utilities/gameActions";
 import { ReactComponent as HappyRobot } from "../../../images/HappyRobot.svg";
 import * as Confetti from "../../../utils/confetti.js";
@@ -99,6 +100,9 @@ export default React.memo(function Completed({ gameName, dispatch }) {
         >
           Play again
         </button>
+      </p>
+      <p className="mx-auto text-center mt3">
+        <Link to="/games" className="text-center py1">Games</Link>
       </p>
     </>
   );

--- a/src/pages/games/components/Intro.jsx
+++ b/src/pages/games/components/Intro.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Intro({ introText, robot }) {
   return (
-    <div className="mw-844 mr3 flex-grow">
+    <div className="mw-824 mr3 flex-grow">
       <div className="flex">
         <div className="w-100 mw-48 mr3">{robot}</div>
         <p>{introText}</p>

--- a/src/pages/games/components/RoundProgress.jsx
+++ b/src/pages/games/components/RoundProgress.jsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
-export default function RoundProgress({ round, level }) {
+export default function RoundProgress({
+  round,
+  level,
+  roundToWin,
+  levelToWin,
+}) {
   return (
     <div className="flex flex-grow">
       <p className="text-right w-100">
@@ -10,9 +15,14 @@ export default function RoundProgress({ round, level }) {
           <CSSTransition timeout={500} classNames="bloop" appear={true}>
             <strong className="dib">{round}</strong>
           </CSSTransition>
-        </TransitionGroup>
+        </TransitionGroup>{" "}
+        of {roundToWin}
         <br />
-        Level: {level || 1}
+        {level && (
+          <>
+            Level: <strong>{level || 1}</strong> of {levelToWin}
+          </>
+        )}
       </p>
     </div>
   );

--- a/src/pages/games/components/RoundProgress.jsx
+++ b/src/pages/games/components/RoundProgress.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
-export default function RoundProgress({ round }) {
+export default function RoundProgress({ round, level }) {
   return (
     <div className="flex flex-grow">
       <p className="text-right w-100">
@@ -12,7 +12,7 @@ export default function RoundProgress({ round }) {
           </CSSTransition>
         </TransitionGroup>
         <br />
-        Level: 1
+        Level: {level || 1}
       </p>
     </div>
   );

--- a/src/utils/dictEntryPredicates.js
+++ b/src/utils/dictEntryPredicates.js
@@ -1,5 +1,5 @@
 export const hasFewerThan7Letters = (translation) => {
-  if (process.env.NODE_ENV === 'development') {return translation.trim().length < 5;}
+  // if (process.env.NODE_ENV === 'development') {return translation.trim().length < 5;}
   return translation.trim().length < 7;
 };
 


### PR DESCRIPTION
This PR:

- adds the concept of "levels" to the SHUFL game
- shuffles words twice if it matches words in right answers lists
- updates KHAERT dialog (name, age, location)
- updates games index ordering and completed games link back to games index
- fetches the global lookup dict when SHUFL game is first page load
- adds feedback forms to game pages
- reorders game section on homepage

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/2476974/177778532-c52a7e95-5a3c-4c2e-a47d-3f0e969eef52.png">

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/2476974/177778299-b8845b25-2df9-449d-b77d-e494d9940843.png">
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/2476974/177778357-dd27f818-0029-43fa-93ed-bc7ad498e8f6.png">
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2476974/177778469-2f29c4b1-7873-4879-8f17-fc04a39b9dd0.png">

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2476974/177777677-fb4315f8-8ab1-4004-ba72-c0c44e1c0830.png">
