### PR TITLE
Add sort by word length, longest or shortest

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1522,7 +1522,9 @@ class App extends Component {
           'sortOff',
           'sortNew',
           'sortOld',
-          'sortRandom'
+          'sortRandom',
+          'sortLongest',
+          'sortShortest'
         ];
 
         if (param === 'sortOrder' && sortOrderValidValues.includes(paramVal)) {
@@ -2619,6 +2621,20 @@ function sortLesson(presentedMaterial, met = this.state.metWords, userSettings =
       let seenA = met[spaceBefore + a.phrase + spaceAfter] || 0;
       let seenB = met[spaceBefore + b.phrase + spaceAfter] || 0;
       return userSettings.sortOrder === 'sortNew' ? seenA - seenB : seenB - seenA;
+    });
+  }
+  else if (userSettings.sortOrder === 'sortShortest') {
+    presentedMaterial.sort((a, b) => {
+      const aLength = [...a.phrase].length;
+      const bLength = [...b.phrase].length;
+      return aLength < bLength ? -1 : aLength > bLength ? 1 : 0;
+    });
+  }
+  else if (userSettings.sortOrder === 'sortLongest') {
+    presentedMaterial.sort((a, b) => {
+      const aLength = [...a.phrase].length;
+      const bLength = [...b.phrase].length;
+      return bLength < aLength ? -1 : bLength > aLength ? 1 : 0;
     });
   }
   return presentedMaterial;

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -218,6 +218,8 @@ class UserSettings extends Component {
                         <option value="sortRandom">Random</option>
                         <option value="sortNew">Newest words first</option>
                         <option value="sortOld">Oldest words first</option>
+                        <option value="sortShortest">Shortest words first</option>
+                        <option value="sortLongest">Longest words first</option>
                       </select>
                     </div>
                   </li>


### PR DESCRIPTION
Closes: https://github.com/didoesdigital/typey-type/issues/44

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/2476974/180758176-0f027a78-0ae3-4490-b1fd-f062832605a3.png">
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2476974/180758218-e0268ded-3e94-4e40-8fc2-36f9445f8cf3.png">

This approach to the sorting comparison function is crude and does some kinda weird things with emoji and probably across JavaScript engines:

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/2476974/180758858-0a630729-4b29-47b1-acf1-530aa6ac2d66.png">
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/2476974/180758941-86361331-7744-4a3e-80b9-4642a96f4cbe.png">

Here's that test lesson's material:
```
88888888	TEFT
7777777	TEFT
666666	TEFT
55555	TEFT
4444	TEFT
333	TEFT
22	TEFT
1	TEFT
👩‍👩‍👧‍👧	TEFT
👩‍👩‍👧	TEFT
👩‍👧‍👧	TEFT
👩‍👧	TEFT
🧍‍♀️	TEFT
```
