### PR TITLE
Add "hidden" upcoming words setting

### DIFF
--- a/src/components/Material.js
+++ b/src/components/Material.js
@@ -1,6 +1,7 @@
 import React from "react";
 import SingleLineMaterial from "./Material/SingleLineMaterial";
 import MultiLineMaterial from "./Material/MultiLineMaterial";
+import OnePhraseMaterial from "./Material/OnePhraseMaterial";
 
 export default function Material(props) {
   return props.userSettings.upcomingWordsLayout === "multiline" ? (
@@ -10,6 +11,15 @@ export default function Material(props) {
       currentPhraseID={props.currentPhraseID}
       presentedMaterial={props.lesson.presentedMaterial}
       settings={props.settings}
+      userSettings={props.userSettings}
+    />
+  ) : props.userSettings.upcomingWordsLayout === "hidden" ? (
+    <OnePhraseMaterial
+      actualText={props.actualText}
+      completedPhrases={props.completedPhrases}
+      currentPhrase={props.currentPhrase}
+      settings={props.settings}
+      upcomingPhrases={props.upcomingPhrases}
       userSettings={props.userSettings}
     />
   ) : (

--- a/src/components/Material/OnePhraseMaterial.js
+++ b/src/components/Material/OnePhraseMaterial.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { matchSplitText } from "../../utils/typey-type";
 
-export default function SingleLineMaterial({
+export default function OnePhraseMaterial({
   actualText,
   completedPhrases,
   currentPhrase,

--- a/src/components/Material/OnePhraseMaterial.js
+++ b/src/components/Material/OnePhraseMaterial.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { matchSplitText } from "../../utils/typey-type";
+
+export default function SingleLineMaterial({
+  actualText,
+  completedPhrases,
+  currentPhrase,
+  settings,
+  upcomingPhrases,
+  userSettings,
+}) {
+  const [matched, unmatched] = matchSplitText(
+    currentPhrase,
+    actualText,
+    settings,
+    userSettings
+  );
+  const completedPhrasesClasses =
+    "dib de-emphasized fw4 left-0 absolute text-right completed-phrases-transform";
+  const currentAndUpcomingPhrasesClasses = `dib current-and-upcoming-phrases${
+    userSettings.blurMaterial ? " blur-words" : ""
+  }`;
+
+  return (
+    <div className="mb1 nt1">
+      <div className="expected">
+        <div className="visually-hidden">
+          Matching and unmatching material typed, upcoming words, and previous
+          words:
+        </div>
+        <div className="material mx-auto py1">
+          <pre className="relative translateX-10px">
+            <span className={completedPhrasesClasses}>
+              {completedPhrases.join(" ")}&#8203;
+              {userSettings.spacePlacement === "spaceBeforeOutput" ? "" : " "}
+            </span>
+            <div className={currentAndUpcomingPhrasesClasses}>
+              <strong className="fw7" tabIndex="0">
+                <span className="matched steno-material">{matched}</span>
+                <span className="steno-material">{unmatched}</span>
+              </strong>
+            </div>
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -598,6 +598,7 @@ class UserSettings extends Component {
                       <select id="upcomingWordsLayout" name="upcomingWordsLayout" value={this.props.userSettings.upcomingWordsLayout} onChange={this.props.handleUpcomingWordsLayout} disabled={this.props.disableUserSettings} className="text-small form-control w-144">
                         <option value="singleLine">Single line</option>
                         <option value="multiline">Multiline</option>
+                        <option value="hidden">Hidden</option>
                       </select>
                     </div>
                   </li>


### PR DESCRIPTION
This PR adds a new "Upcoming words" setting option of "Hidden" to hide upcoming words for "practicing reacting to a word instead of thinking ahead":

<img width="336" alt="image" src="https://user-images.githubusercontent.com/2476974/187054548-f12aebc1-859b-4814-a802-790ec4e5e46f.png">

Here's how the lesson looks while it's running with this setting:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2476974/187054537-a8c48de6-e410-4081-b89f-6c5ebf1e643e.png">
