### PR TITLE
Fix metronome preventing mac sleep

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,7 +14,7 @@ export const parameters = {
   options: {
     storySort: {
       method: "alphabetical",
-      order: ["Pages", ["Home"], "Lessons", ["Custom", "Flashcards", "Speed chart"], "Games", ["Games index", "KAOES game", "SHUFL game", "TPEUBGSZ game", "KHAERT game", "Completed"], "Material"]
+      order: ["Pages", ["Home"], "Lessons", ["Custom", "Flashcards", "Speed chart", "Metronome"], "Games", ["Games index", "KAOES game", "SHUFL game", "TPEUBGSZ game", "KHAERT game", "Completed"], "Material"]
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/d3-scale": "^4.0.2",
     "@types/d3-selection": "^3.0.2",
     "@types/d3-shape": "^3.1.0",
+    "@types/howler": "^2.2.7",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.0.0",
     "@types/react": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "d3-shape": "^3.0.1",
     "d3-time": "^3.0.0",
     "d3-time-format": "^4.1.0",
-    "howler": "^2.2.0",
+    "howler": "^2.2.3",
     "npm-run-all": "^4.1.1",
     "pure-react-carousel": "https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback",
     "query-string": "^6.2.0",

--- a/src/components/Metronome.test.js
+++ b/src/components/Metronome.test.js
@@ -1,217 +1,107 @@
-import {
-  bpmBracketsSprite,
-  playId
-} from './Metronome';
+import { bpmBracketsSprite, playId } from "./Metronome";
 
-describe('playId', () => {
-  it('for 0BPM should round up and return bpm10', () => {
-    expect(playId(0)).toEqual('bpm10');
+describe("playId", () => {
+  it("for 0BPM should round up and return bpm10", () => {
+    expect(playId(0)).toEqual("bpm10");
   });
 });
 
-describe('playId', () => {
-  it('for 0.7BPM should not explode on floating point math', () => {
-    expect(playId(0.7)).toEqual('bpm10');
+describe("playId", () => {
+  it("for 0.7BPM should not explode on floating point math", () => {
+    expect(playId(0.7)).toEqual("bpm10");
   });
 });
 
-describe('playId', () => {
-  it('for 9BPM should round up and return bpm10', () => {
-    expect(playId(9)).toEqual('bpm10');
+describe("playId", () => {
+  it("for 9BPM should round up and return bpm10", () => {
+    expect(playId(9)).toEqual("bpm10");
   });
 });
 
-describe('playId', () => {
-  it('for 10BPM should return bpm10', () => {
-    expect(playId(10)).toEqual('bpm10');
+describe("playId", () => {
+  it("for 10BPM should return bpm10", () => {
+    expect(playId(10)).toEqual("bpm10");
   });
 });
 
-describe('playId', () => {
-  it('for 11BPM should round up and return bpm20', () => {
-    expect(playId(11)).toEqual('bpm20');
+describe("playId", () => {
+  it("for 11BPM should round up and return bpm20", () => {
+    expect(playId(11)).toEqual("bpm20");
   });
 });
 
-describe('playId', () => {
-  it('for 360BPM should return bpm360', () => {
-    expect(playId(360)).toEqual('bpm360');
+describe("playId", () => {
+  it("for 360BPM should return bpm360", () => {
+    expect(playId(360)).toEqual("bpm360");
   });
 });
 
-describe('playId', () => {
-  it('over 360BPM should return bpm360', () => {
-    expect(playId(760)).toEqual('bpm360');
+describe("playId", () => {
+  it("over 360BPM should return bpm360", () => {
+    expect(playId(760)).toEqual("bpm360");
   });
 });
 
-describe('playId', () => {
-  it('of any nonsense BPM like -3.5BPM should return bpm10', () => {
-    expect(playId(-3.5)).toEqual('bpm10');
+describe("playId", () => {
+  it("of any nonsense BPM like -3.5BPM should return bpm10", () => {
+    expect(playId(-3.5)).toEqual("bpm10");
   });
 });
 
-describe('playId', () => {
-  it('of any nonsense input like asdf should return bpm10', () => {
-    expect(playId('asdf')).toEqual('bpm10');
+describe("playId", () => {
+  it("of any nonsense input like asdf should return bpm10", () => {
+    expect(playId("asdf")).toEqual("bpm10");
   });
 });
 
-describe('bpm brackets', () => {
-  it('should include a minimum bracket of 10BPM with 6000 milliseconds of audio', () => {
-    expect(Object.entries(bpmBracketsSprite())[0]).toEqual(["bpm10", [0, 6000]]);
+describe("bpm brackets", () => {
+  it("should include a minimum bracket of 10BPM with 6000 milliseconds of audio", () => {
+    expect(Object.entries(bpmBracketsSprite())[0]).toEqual([
+      "bpm10",
+      [0, 6000],
+    ]);
   });
-  it('should include 36 brackets', () => {
+  it("should include 36 brackets", () => {
     expect(Object.entries(bpmBracketsSprite()).length).toEqual(36);
   });
-  it('should match this object', () => {
-    expect(bpmBracketsSprite()).toEqual(
-      {
-        "bpm10": [
-          0,
-          6000
-        ],
-        "bpm20": [
-          0,
-          3000
-        ],
-        "bpm30": [
-          0,
-          2000
-        ],
-        "bpm40": [
-          0,
-          1500
-        ],
-        "bpm50": [
-          0,
-          1200
-        ],
-        "bpm60": [
-          0,
-          1000
-        ],
-        "bpm70": [
-          0,
-          857.1428571428571
-        ],
-        "bpm80": [
-          0,
-          750
-        ],
-        "bpm90": [
-          0,
-          666.6666666666666
-        ],
-        "bpm100": [
-          0,
-          600
-        ],
-        "bpm110": [
-          0,
-          545.4545454545455
-        ],
-        "bpm120": [
-          0,
-          500
-        ],
-        "bpm130": [
-          0,
-          461.53846153846155
-        ],
-        "bpm140": [
-          0,
-          428.57142857142856
-        ],
-        "bpm150": [
-          0,
-          400
-        ],
-        "bpm160": [
-          0,
-          375
-        ],
-        "bpm170": [
-          0,
-          352.94117647058823
-        ],
-        "bpm180": [
-          0,
-          333.3333333333333
-        ],
-        "bpm190": [
-          0,
-          315.7894736842105
-        ],
-        "bpm200": [
-          0,
-          300
-        ],
-        "bpm210": [
-          0,
-          285.7142857142857
-        ],
-        "bpm220": [
-          0,
-          272.72727272727275
-        ],
-        "bpm230": [
-          0,
-          260.8695652173913
-        ],
-        "bpm240": [
-          0,
-          250
-        ],
-        "bpm250": [
-          0,
-          240
-        ],
-        "bpm260": [
-          0,
-          230.76923076923077
-        ],
-        "bpm270": [
-          0,
-          222.22222222222223
-        ],
-        "bpm280": [
-          0,
-          214.28571428571428
-        ],
-        "bpm290": [
-          0,
-          206.89655172413794
-        ],
-        "bpm300": [
-          0,
-          200
-        ],
-        "bpm310": [
-          0,
-          193.5483870967742
-        ],
-        "bpm320": [
-          0,
-          187.5
-        ],
-        "bpm330": [
-          0,
-          181.8181818181818
-        ],
-        "bpm340": [
-          0,
-          176.47058823529412
-        ],
-        "bpm350": [
-          0,
-          171.42857142857142
-        ],
-        "bpm360": [
-          0,
-          166.66666666666666
-        ]
-      }
-    );
+  it("should match this object", () => {
+    expect(bpmBracketsSprite()).toEqual({
+      "bpm10": [0, 6000],
+      "bpm20": [0, 3000],
+      "bpm30": [0, 2000],
+      "bpm40": [0, 1500],
+      "bpm50": [0, 1200],
+      "bpm60": [0, 1000],
+      "bpm70": [0, 857.1428571428571],
+      "bpm80": [0, 750],
+      "bpm90": [0, 666.6666666666666],
+      "bpm100": [0, 600],
+      "bpm110": [0, 545.4545454545455],
+      "bpm120": [0, 500],
+      "bpm130": [0, 461.53846153846155],
+      "bpm140": [0, 428.57142857142856],
+      "bpm150": [0, 400],
+      "bpm160": [0, 375],
+      "bpm170": [0, 352.94117647058823],
+      "bpm180": [0, 333.3333333333333],
+      "bpm190": [0, 315.7894736842105],
+      "bpm200": [0, 300],
+      "bpm210": [0, 285.7142857142857],
+      "bpm220": [0, 272.72727272727275],
+      "bpm230": [0, 260.8695652173913],
+      "bpm240": [0, 250],
+      "bpm250": [0, 240],
+      "bpm260": [0, 230.76923076923077],
+      "bpm270": [0, 222.22222222222223],
+      "bpm280": [0, 214.28571428571428],
+      "bpm290": [0, 206.89655172413794],
+      "bpm300": [0, 200],
+      "bpm310": [0, 193.5483870967742],
+      "bpm320": [0, 187.5],
+      "bpm330": [0, 181.8181818181818],
+      "bpm340": [0, 176.47058823529412],
+      "bpm350": [0, 171.42857142857142],
+      "bpm360": [0, 166.66666666666666],
+    });
   });
 });

--- a/src/components/Metronome.test.ts
+++ b/src/components/Metronome.test.ts
@@ -48,12 +48,6 @@ describe("playId", () => {
   });
 });
 
-describe("playId", () => {
-  it("of any nonsense input like -1 should return bpm10", () => {
-    expect(playId(-1)).toEqual("bpm10");
-  });
-});
-
 describe("bpm brackets", () => {
   it("should include a minimum bracket of 10BPM with 6000 milliseconds of audio", () => {
     expect(Object.entries(bpmBracketsSprite())[0]).toEqual([

--- a/src/components/Metronome.test.ts
+++ b/src/components/Metronome.test.ts
@@ -49,8 +49,8 @@ describe("playId", () => {
 });
 
 describe("playId", () => {
-  it("of any nonsense input like asdf should return bpm10", () => {
-    expect(playId("asdf")).toEqual("bpm10");
+  it("of any nonsense input like -1 should return bpm10", () => {
+    expect(playId(-1)).toEqual("bpm10");
   });
 });
 

--- a/src/components/Metronome.tsx
+++ b/src/components/Metronome.tsx
@@ -5,8 +5,19 @@ import { Tooltip } from 'react-tippy';
 import GoogleAnalytics from 'react-ga';
 import plink from '../sounds/digi_plink-with-silence.mp3';
 
+import type { UserSettings } from "../types";
+
+type Props = {
+  userSettings: UserSettings
+  setAnnouncementMessage: (app: any, content: string | Object) => void
+}
+
+type Options = {
+  id: string
+}
+
 function bpmBracketsSprite() {
-  let spriteObj = {};
+  let spriteObj: {[key: string]: [number, number]} = {};
   for (let bpm = 10; bpm <= 360; bpm += 10) {
     spriteObj[playId(bpm)] = [0, 60000 / bpm];
   }
@@ -19,7 +30,7 @@ const sound = new Howl({
   sprite: bpmBracketsSprite()
 });
 
-function playMetronome(options, withAnalytics) {
+function playMetronome(options: Options, withAnalytics?: string) {
   let id = 'bpm10';
   if (options && options.id) {
     id = options.id;
@@ -37,7 +48,7 @@ function playMetronome(options, withAnalytics) {
   }
 }
 
-function stopMetronome(withAnalytics) {
+function stopMetronome(withAnalytics?: string) {
   sound.stop();
 
   if (withAnalytics) {
@@ -49,7 +60,7 @@ function stopMetronome(withAnalytics) {
   }
 }
 
-function playId(beatsPerMinute) {
+function playId(beatsPerMinute: number) {
   if (!(beatsPerMinute) || typeof beatsPerMinute === 'string') {
     beatsPerMinute = 10;
   }
@@ -57,8 +68,8 @@ function playId(beatsPerMinute) {
   return `bpm${bpmBracket}`
 }
 
-class Metronome extends Component {
-  componentDidUpdate(prevProps, prevState) {
+class Metronome extends Component<Props> {
+  componentDidUpdate(prevProps: {[keyName: string]: any}) {
     if (this.props.userSettings && prevProps.userSettings.beatsPerMinute !== this.props.userSettings.beatsPerMinute && sound.playing()) {
       stopMetronome();
       playMetronome({id: playId(this.props.userSettings.beatsPerMinute)});
@@ -73,6 +84,7 @@ class Metronome extends Component {
     return (
       <p>
         <button aria-label="Start metronome" className="button button--secondary mr2" onClick={() => playMetronome({id: playId(this.props.userSettings.beatsPerMinute)}, 'withAnalytics')}>
+          {/* @ts-ignore */}
           <Tooltip
             title="Start the metronome for finger drills and improving rhythm"
             className="mw-240"
@@ -89,6 +101,7 @@ class Metronome extends Component {
           </Tooltip>
         </button>
         <button aria-label="Stop metronome" className="button button--secondary" onClick={() => stopMetronome('withAnalytics')}>
+          {/* @ts-ignore */}
           <Tooltip
             title="Stop the metronome"
             className="mw-240"

--- a/src/components/Metronome.tsx
+++ b/src/components/Metronome.tsx
@@ -1,23 +1,23 @@
-import React, { Component } from 'react';
-import { Howl } from 'howler';
-import { IconMetronome } from './Icon';
-import { Tooltip } from 'react-tippy';
-import GoogleAnalytics from 'react-ga';
-import plink from '../sounds/digi_plink-with-silence.mp3';
+import React, { Component } from "react";
+import { Howl } from "howler";
+import { IconMetronome } from "./Icon";
+import { Tooltip } from "react-tippy";
+import GoogleAnalytics from "react-ga";
+import plink from "../sounds/digi_plink-with-silence.mp3";
 
 import type { UserSettings } from "../types";
 
 type Props = {
-  userSettings: UserSettings
-  setAnnouncementMessage: (app: any, content: string | Object) => void
-}
+  userSettings: UserSettings;
+  setAnnouncementMessage: (app: any, content: string | Object) => void;
+};
 
 type Options = {
-  id: string
-}
+  id: string;
+};
 
 function bpmBracketsSprite() {
-  let spriteObj: {[key: string]: [number, number]} = {};
+  let spriteObj: { [key: string]: [number, number] } = {};
   for (let bpm = 10; bpm <= 360; bpm += 10) {
     spriteObj[playId(bpm)] = [0, 60000 / bpm];
   }
@@ -27,11 +27,11 @@ function bpmBracketsSprite() {
 const sound = new Howl({
   src: plink,
   loop: true,
-  sprite: bpmBracketsSprite()
+  sprite: bpmBracketsSprite(),
 });
 
 function playMetronome(options: Options, withAnalytics?: string) {
-  let id = 'bpm10';
+  let id = "bpm10";
   if (options && options.id) {
     id = options.id;
   }
@@ -41,9 +41,9 @@ function playMetronome(options: Options, withAnalytics?: string) {
 
   if (withAnalytics) {
     GoogleAnalytics.event({
-      category: 'Metronome',
-      action: 'Click button',
-      label: 'Start'
+      category: "Metronome",
+      action: "Click button",
+      label: "Start",
     });
   }
 }
@@ -53,26 +53,31 @@ function stopMetronome(withAnalytics?: string) {
 
   if (withAnalytics) {
     GoogleAnalytics.event({
-      category: 'Metronome',
-      action: 'Click button',
-      label: 'Stop'
+      category: "Metronome",
+      action: "Click button",
+      label: "Stop",
     });
   }
 }
 
 function playId(beatsPerMinute: number) {
-  if (!(beatsPerMinute) || typeof beatsPerMinute === 'string') {
+  if (!beatsPerMinute || typeof beatsPerMinute === "string") {
     beatsPerMinute = 10;
   }
-  let bpmBracket = (Math.min(Math.ceil(Math.abs(beatsPerMinute) / 10), 36)) * 10;
-  return `bpm${bpmBracket}`
+  let bpmBracket = Math.min(Math.ceil(Math.abs(beatsPerMinute) / 10), 36) * 10;
+  return `bpm${bpmBracket}`;
 }
 
 class Metronome extends Component<Props> {
-  componentDidUpdate(prevProps: {[keyName: string]: any}) {
-    if (this.props.userSettings && prevProps.userSettings.beatsPerMinute !== this.props.userSettings.beatsPerMinute && sound.playing()) {
+  componentDidUpdate(prevProps: { [keyName: string]: any }) {
+    if (
+      this.props.userSettings &&
+      prevProps.userSettings.beatsPerMinute !==
+        this.props.userSettings.beatsPerMinute &&
+      sound.playing()
+    ) {
       stopMetronome();
-      playMetronome({id: playId(this.props.userSettings.beatsPerMinute)});
+      playMetronome({ id: playId(this.props.userSettings.beatsPerMinute) });
     }
   }
 
@@ -83,7 +88,16 @@ class Metronome extends Component<Props> {
   render() {
     return (
       <p>
-        <button aria-label="Start metronome" className="button button--secondary mr2" onClick={() => playMetronome({id: playId(this.props.userSettings.beatsPerMinute)}, 'withAnalytics')}>
+        <button
+          aria-label="Start metronome"
+          className="button button--secondary mr2"
+          onClick={() =>
+            playMetronome(
+              { id: playId(this.props.userSettings.beatsPerMinute) },
+              "withAnalytics"
+            )
+          }
+        >
           {/* @ts-ignore */}
           <Tooltip
             title="Start the metronome for finger drills and improving rhythm"
@@ -97,10 +111,21 @@ class Metronome extends Component<Props> {
             trigger="mouseenter focus click"
             onShow={this.props.setAnnouncementMessage}
           >
-            <IconMetronome role="presentation" iconWidth="24" iconHeight="24" className="svg-icon-wrapper svg-baseline" title="Metronome" /> Start
+            <IconMetronome
+              role="presentation"
+              iconWidth="24"
+              iconHeight="24"
+              className="svg-icon-wrapper svg-baseline"
+              title="Metronome"
+            />{" "}
+            Start
           </Tooltip>
         </button>
-        <button aria-label="Stop metronome" className="button button--secondary" onClick={() => stopMetronome('withAnalytics')}>
+        <button
+          aria-label="Stop metronome"
+          className="button button--secondary"
+          onClick={() => stopMetronome("withAnalytics")}
+        >
           {/* @ts-ignore */}
           <Tooltip
             title="Stop the metronome"
@@ -114,7 +139,14 @@ class Metronome extends Component<Props> {
             trigger="mouseenter focus click"
             onShow={this.props.setAnnouncementMessage}
           >
-            <IconMetronome role="presentation" iconWidth="24" iconHeight="24" className="svg-icon-wrapper svg-baseline" title="Metronome" /> Stop
+            <IconMetronome
+              role="presentation"
+              iconWidth="24"
+              iconHeight="24"
+              className="svg-icon-wrapper svg-baseline"
+              title="Metronome"
+            />{" "}
+            Stop
           </Tooltip>
         </button>
       </p>
@@ -123,7 +155,4 @@ class Metronome extends Component<Props> {
 }
 
 export default Metronome;
-export {
-  bpmBracketsSprite,
-  playId
-};
+export { bpmBracketsSprite, playId };

--- a/src/pages/lessons/components/LessonCanvasFooter.tsx
+++ b/src/pages/lessons/components/LessonCanvasFooter.tsx
@@ -21,7 +21,10 @@ const LessonCanvasFooter = ({
 }: LessonCanvasFooterProps) => {
   return (
     <div className="flex flex-wrap mx-auto mw-1440 justify-between text-small">
-      <Metronome userSettings={userSettings} />
+      <Metronome
+        setAnnouncementMessage={setAnnouncementMessage}
+        userSettings={userSettings}
+      />
       <div className="flex flex-wrap">
         <fieldset className="dc hide-sm">
           {/* @ts-ignore */}

--- a/src/pages/lessons/components/LessonCanvasFooter.tsx
+++ b/src/pages/lessons/components/LessonCanvasFooter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Metronome from "../../../components/Metronome";
+import Metronome from "./Metronome";
 import { Tooltip } from "react-tippy";
 
 type LessonCanvasFooterProps = {

--- a/src/pages/lessons/components/Metronome.stories.jsx
+++ b/src/pages/lessons/components/Metronome.stories.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Metronome from "./Metronome";
+import userSettings from "../../../stories/fixtures/userSettings";
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  title: "Lessons/Metronome",
+  component: Metronome,
+  id: "metronome", // permalink
+};
+
+const Template = (args) => {
+  return (
+    <Metronome
+      setAnnouncementMessage={() => console.log("announce")}
+      userSettings={userSettings}
+      {...args}
+    />
+  );
+};
+
+export const MetronomeStory = Template.bind({});
+MetronomeStory.storyName = "Metronome";

--- a/src/pages/lessons/components/Metronome.test.ts
+++ b/src/pages/lessons/components/Metronome.test.ts
@@ -1,4 +1,4 @@
-import { bpmBracketsSprite, playId } from "../../../components/Metronome";
+import { bpmBracketsSprite, playId } from "./Metronome";
 
 describe("playId", () => {
   it("for 0BPM should round up and return bpm10", () => {

--- a/src/pages/lessons/components/Metronome.test.ts
+++ b/src/pages/lessons/components/Metronome.test.ts
@@ -1,4 +1,4 @@
-import { bpmBracketsSprite, playId } from "./Metronome";
+import { bpmBracketsSprite, playId } from "../../../components/Metronome";
 
 describe("playId", () => {
   it("for 0BPM should round up and return bpm10", () => {

--- a/src/pages/lessons/components/Metronome.tsx
+++ b/src/pages/lessons/components/Metronome.tsx
@@ -17,7 +17,7 @@ type Options = {
 };
 
 function bpmBracketsSprite() {
-  let spriteObj: { [key: string]: [number, number] } = {};
+  const spriteObj: { [key: string]: [number, number] } = {};
   for (let bpm = 10; bpm <= 360; bpm += 10) {
     spriteObj[playId(bpm)] = [0, 60000 / bpm];
   }
@@ -64,7 +64,8 @@ function playId(beatsPerMinute: number) {
   if (!beatsPerMinute || typeof beatsPerMinute === "string") {
     beatsPerMinute = 10;
   }
-  let bpmBracket = Math.min(Math.ceil(Math.abs(beatsPerMinute) / 10), 36) * 10;
+  const bpmBracket =
+    Math.min(Math.ceil(Math.abs(beatsPerMinute) / 10), 36) * 10;
   return `bpm${bpmBracket}`;
 }
 

--- a/src/pages/lessons/components/Metronome.tsx
+++ b/src/pages/lessons/components/Metronome.tsx
@@ -7,6 +7,11 @@ import plink from "../../../sounds/digi_plink-with-silence.mp3";
 
 import type { UserSettings } from "../../../types";
 
+type State = {
+  player: null | Howl;
+  userGestureToStartMetronome: boolean;
+};
+
 type Props = {
   userSettings: UserSettings;
   setAnnouncementMessage: (app: any, content: string | Object) => void;
@@ -79,7 +84,7 @@ function playId(beatsPerMinute: number) {
   return `bpm${bpmBracket}`;
 }
 
-class Metronome extends Component<Props> {
+class Metronome extends Component<Props, State> {
   constructor(props: any) {
     super(props);
     this.state = {
@@ -90,7 +95,6 @@ class Metronome extends Component<Props> {
 
   componentDidUpdate(prevProps: { [keyName: string]: any }) {
     if (
-      // @ts-ignore Property 'userGestureToStartMetronome' does not exist on type
       this.state.userGestureToStartMetronome &&
       this.props.userSettings &&
       prevProps.userSettings.beatsPerMinute !==

--- a/src/pages/lessons/components/Metronome.tsx
+++ b/src/pages/lessons/components/Metronome.tsx
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
 import { Howl } from "howler";
-import { IconMetronome } from "./Icon";
+import { IconMetronome } from "../../../components/Icon";
 import { Tooltip } from "react-tippy";
 import GoogleAnalytics from "react-ga";
-import plink from "../sounds/digi_plink-with-silence.mp3";
+import plink from "../../../sounds/digi_plink-with-silence.mp3";
 
-import type { UserSettings } from "../types";
+import type { UserSettings } from "../../../types";
 
 type Props = {
   userSettings: UserSettings;

--- a/src/pages/lessons/components/Metronome.tsx
+++ b/src/pages/lessons/components/Metronome.tsx
@@ -53,10 +53,7 @@ function playMetronome(options: Options, withAnalytics?: string) {
   // @ts-ignore 'this' implicitly has type 'any'
   this.setState({ userGestureToStartMetronome: true });
 
-  let id = "bpm10";
-  if (options && options.id) {
-    id = options.id;
-  }
+  const id = options?.id ? options.id : "bpm10";
   if (!sound.playing()) {
     sound.play(id);
   }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="react-scripts" />
+
+declare module '*.mp3' {
+  const src: string;
+  export default src;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10864,10 +10864,10 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-howler@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.0.tgz#0e2c780997ae65ab9a1a186333031beac1c63c6b"
-  integrity sha512-sGPkrAQy7jh5mNDbkRNG0F82R2HFDYNsQXBcX4smXQT0y0F4UMsa/+jXaGwWvcrajWr2tDB7JUkH7G5qSnuIyQ==
+howler@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.3.tgz#a2eff9b08b586798e7a2ee17a602a90df28715da"
+  integrity sha512-QM0FFkw0LRX1PR8pNzJVAY25JhIWvbKMBFM4gqk+QdV+kPXOhleWGCB6AiAF/goGjIHK2e/nIElplvjQwhr0jg==
 
 hpack.js@^2.1.6:
   version "2.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5365,6 +5365,11 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/howler@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/howler/-/howler-2.2.7.tgz#5acfbed57f9e1d99b8dabe1b824729e1c1ea1fae"
+  integrity sha512-PEZldwZqJJw1PWRTpupyC7ajVTZA8aHd8nB/Y0n6zRZi5u8ktYDntsHj13ltEiBRqWwF06pASxBEvCTxniG8eA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"


### PR DESCRIPTION
This PR fixes: https://github.com/didoesdigital/typey-type/issues/105

It also delays the creation of the Howler fixing the console warning: `An AudioContext was prevented from starting automatically. It must be created or resumed after a user gesture on the page.`

<img width="937" alt="image" src="https://user-images.githubusercontent.com/2476974/205266808-9843d470-f472-4fb1-930c-615787beb33b.png">

Modern browsers prevent auto-playing sound without first receiving a user gesture that suggests they _want_ to hear sound (such as hitting a "Play" button). The Howler play method was never actually called before the user gesture of hitting the play button but the mere creation of the Howler before the gesture causes the warning.