### PR TITLE
Add key input to KAOES

### DIFF
--- a/src/StenoLayout/AmericanStenoDiagram.js
+++ b/src/StenoLayout/AmericanStenoDiagram.js
@@ -63,7 +63,7 @@ export default function AmericanStenoDiagram(props) {
   const handleClick = (event) => {
     if (props.handleOnClick) {
       const clickedKeyID = event.target["id"];
-      const key = (idKeyLookup[clickedKeyID]) ? idKeyLookup[clickedKeyID] : "";
+      const key = (idKeyLookup[clickedKeyID]) ? idKeyLookup[clickedKeyID] : 0;
 
       props.handleOnClick(key);
     }

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -243,80 +243,85 @@ export default function Game() {
                 />
               </div>
             </div>
+            <div className="mw-320 mx-auto">
+              <div className="flex flex-wrap items-center">
+                <Input
+                  onChangeInput={onChangeTextInput}
+                  previousCompletedPhraseAsTyped={
+                    previousCompletedPhraseAsTyped
+                  }
+                  round={state.roundIndex + 1}
+                  typedText={typedText}
+                  gameName={gameName}
+                />
+                <div className="ml1">
+                  (
+                  <button
+                    className="de-emphasized-button text-small"
+                    onClick={handleOpenModal}
+                  >
+                    help
+                  </button>
+                  <ReactModal
+                    isOpen={modalVisibility}
+                    aria={{
+                      labelledby: "aria-modal-heading",
+                      describedby: "aria-modal-description",
+                    }}
+                    ariaHideApp={true}
+                    closeTimeoutMS={300}
+                    role="dialog"
+                    onRequestClose={handleCloseModal}
+                    className={{
+                      "base": "modal",
+                      "afterOpen": "modal--after-open",
+                      "beforeClose": "modal--before-close",
+                    }}
+                    overlayClassName={{
+                      "base": "modal__overlay",
+                      "afterOpen": "modal__overlay--after-open",
+                      "beforeClose": "modal__overlay--before-close",
+                    }}
+                  >
+                    <div className="fr">
+                      <button
+                        className="de-emphasized-button hide-md"
+                        onClick={handleCloseModal}
+                      >
+                        Close
+                      </button>
+                    </div>
+                    <h3 id="aria-modal-heading">Typed KAOES input</h3>
+                    <div id="aria-modal-description">
+                      <p>
+                        To practice typing the keys instead of clicking on the
+                        diagram, you can turn off all of your steno dictionaries
+                        to produce raw steno output. That way, when you press
+                        the{" "}
+                        <kbd className="raw-steno-key raw-steno-key--subtle">
+                          S
+                        </kbd>{" "}
+                        key, the steno engine will output “S” instead of “is”.
+                        Likewise, pressing the{" "}
+                        <kbd className="raw-steno-key raw-steno-key--subtle">
+                          -T
+                        </kbd>{" "}
+                        key will output “-T” instead of “the”. The dash is
+                        necessary for keys on the right-hand side of the board.
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <button className="button" onClick={handleCloseModal}>
+                        OK
+                      </button>
+                    </div>
+                  </ReactModal>
+                  )
+                </div>
+              </div>
+            </div>
           </>
         )}
-        <div className="mw-320 mx-auto">
-          <div className="flex flex-wrap items-center">
-            <Input
-              onChangeInput={onChangeTextInput}
-              previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
-              round={state.roundIndex + 1}
-              typedText={typedText}
-              gameName={gameName}
-            />
-            <div className="ml1">
-              (
-              <button
-                className="de-emphasized-button text-small"
-                onClick={handleOpenModal}
-              >
-                help
-              </button>
-              <ReactModal
-                isOpen={modalVisibility}
-                aria={{
-                  labelledby: "aria-modal-heading",
-                  describedby: "aria-modal-description",
-                }}
-                ariaHideApp={true}
-                closeTimeoutMS={300}
-                role="dialog"
-                onRequestClose={handleCloseModal}
-                className={{
-                  "base": "modal",
-                  "afterOpen": "modal--after-open",
-                  "beforeClose": "modal--before-close",
-                }}
-                overlayClassName={{
-                  "base": "modal__overlay",
-                  "afterOpen": "modal__overlay--after-open",
-                  "beforeClose": "modal__overlay--before-close",
-                }}
-              >
-                <div className="fr">
-                  <button
-                    className="de-emphasized-button hide-md"
-                    onClick={handleCloseModal}
-                  >
-                    Close
-                  </button>
-                </div>
-                <h3 id="aria-modal-heading">Typed KAOES input</h3>
-                <div id="aria-modal-description">
-                  <p>
-                    To practice typing the keys instead of clicking on the
-                    diagram, you can turn off all of your steno dictionaries to
-                    produce raw steno output. That way, when you press the{" "}
-                    <kbd className="raw-steno-key raw-steno-key--subtle">S</kbd>{" "}
-                    key, the steno engine will output “S” instead of “is”.
-                    Likewise, pressing the{" "}
-                    <kbd className="raw-steno-key raw-steno-key--subtle">
-                      -T
-                    </kbd>{" "}
-                    key will output “-T” instead of “the”. The dash is necessary
-                    for keys on the right-hand side of the board.
-                  </p>
-                </div>
-                <div className="text-right">
-                  <button className="button" onClick={handleCloseModal}>
-                    OK
-                  </button>
-                </div>
-              </ReactModal>
-              )
-            </div>
-          </div>
-        </div>
         <p
           className={`text-center text-small ${
             state.gameComplete ? "mt10" : "mt1 mb0"

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import ReactModal from "react-modal";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import * as Confetti from "../../../utils/confetti.js";
 import { actions } from "../utilities/gameActions";
@@ -71,6 +72,7 @@ export default function Game() {
   const [previousCompletedPhraseAsTyped, setPreviousCompletedPhraseAsTyped] =
     useState("");
   const [typedText, setTypedText] = useState("");
+  const [modalVisibility, setModalVisibility] = useState(false);
 
   const [puzzleText, setPuzzleText] = useState("");
   const [stenoStroke, setStenoStroke] = useState(new Stroke());
@@ -83,7 +85,18 @@ export default function Game() {
   );
   useEffect(() => {
     setPuzzleText(choosePuzzleKey(""));
+    ReactModal.setAppElement("#js-app");
   }, []);
+
+  const handleOpenModal = (event) => {
+    event.preventDefault();
+    setModalVisibility(true);
+  };
+
+  const handleCloseModal = (event) => {
+    event.preventDefault();
+    setModalVisibility(false);
+  };
 
   const restartConfetti = useCallback(() => {
     particles.splice(0);
@@ -232,13 +245,78 @@ export default function Game() {
             </div>
           </>
         )}
-        <Input
-          onChangeInput={onChangeTextInput}
-          previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
-          round={state.roundIndex + 1}
-          typedText={typedText}
-          gameName={gameName}
-        />
+        <div className="mw-320 mx-auto">
+          <div className="flex flex-wrap items-center">
+            <Input
+              onChangeInput={onChangeTextInput}
+              previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
+              round={state.roundIndex + 1}
+              typedText={typedText}
+              gameName={gameName}
+            />
+            <div className="ml1">
+              (
+              <button
+                className="de-emphasized-button text-small"
+                onClick={handleOpenModal}
+              >
+                help
+              </button>
+              <ReactModal
+                isOpen={modalVisibility}
+                aria={{
+                  labelledby: "aria-modal-heading",
+                  describedby: "aria-modal-description",
+                }}
+                ariaHideApp={true}
+                closeTimeoutMS={300}
+                role="dialog"
+                onRequestClose={handleCloseModal}
+                className={{
+                  "base": "modal",
+                  "afterOpen": "modal--after-open",
+                  "beforeClose": "modal--before-close",
+                }}
+                overlayClassName={{
+                  "base": "modal__overlay",
+                  "afterOpen": "modal__overlay--after-open",
+                  "beforeClose": "modal__overlay--before-close",
+                }}
+              >
+                <div className="fr">
+                  <button
+                    className="de-emphasized-button hide-md"
+                    onClick={handleCloseModal}
+                  >
+                    Close
+                  </button>
+                </div>
+                <h3 id="aria-modal-heading">Typed KAOES input</h3>
+                <div id="aria-modal-description">
+                  <p>
+                    To practice typing the keys instead of clicking on the
+                    diagram, you can turn off all of your steno dictionaries to
+                    produce raw steno output. That way, when you press the{" "}
+                    <kbd className="raw-steno-key raw-steno-key--subtle">S</kbd>{" "}
+                    key, the steno engine will output “S” instead of “is”.
+                    Likewise, pressing the{" "}
+                    <kbd className="raw-steno-key raw-steno-key--subtle">
+                      -T
+                    </kbd>{" "}
+                    key will output “-T” instead of “the”. The dash is necessary
+                    for keys on the right-hand side of the board.
+                  </p>
+                </div>
+                <div className="text-right">
+                  <button className="button" onClick={handleCloseModal}>
+                    OK
+                  </button>
+                </div>
+              </ReactModal>
+              )
+            </div>
+          </div>
+        </div>
         <p
           className={`text-center text-small ${
             state.gameComplete ? "mt10" : "mt1 mb0"

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -64,6 +64,21 @@ const neutralDarkColor = "#504C57";
 const neutralLightColor = "#F2F1F4";
 const diagramWidth = 568;
 
+const GiveKAOESfeedback = ({ idModifier = "" }) => (
+  <p className={"text-center text-small"}>
+    Got a suggestion?{" "}
+    <a
+      href="https://forms.gle/L8vGQTtLwKujLtFb7"
+      className="mt0"
+      target="_blank"
+      rel="noopener noreferrer"
+      id={`ga--KAOES--give-feedback${idModifier}`}
+    >
+      Give feedback (form opens in new tab)
+    </a>
+  </p>
+);
+
 export default function Game() {
   const canvasRef = useRef(null);
   const canvasWidth = Math.floor(window.innerWidth);
@@ -170,7 +185,12 @@ export default function Game() {
           className="fixed top-0 left-0 celebration-canvas pointer-none"
         />
         {state.gameComplete ? (
-          <Completed gameName={gameName} dispatch={dispatch} />
+          <>
+            <Completed gameName={gameName} dispatch={dispatch} />
+            <div className="mt10">
+              <GiveKAOESfeedback />
+            </div>
+          </>
         ) : (
           <>
             <div className="flex flex-wrap pb1">
@@ -311,6 +331,9 @@ export default function Game() {
                         key will output “-T” instead of “the”. The dash is
                         necessary for keys on the right-hand side of the board.
                       </p>
+                      <div className={"mt1 mb0"}>
+                        <GiveKAOESfeedback idModifier="--from-modal" />
+                      </div>
                     </div>
                     <div className="text-right">
                       <button className="button" onClick={handleCloseModal}>
@@ -324,22 +347,6 @@ export default function Game() {
             </div>
           </>
         )}
-        <p
-          className={`text-center text-small ${
-            state.gameComplete ? "mt10" : "mt1 mb0"
-          }`}
-        >
-          Got a suggestion?{" "}
-          <a
-            href="https://forms.gle/L8vGQTtLwKujLtFb7"
-            className="mt0"
-            target="_blank"
-            rel="noopener noreferrer"
-            id="ga--KAOES--give-feedback"
-          >
-            Give feedback (form opens in new tab)
-          </a>
-        </p>
       </div>
     </div>
   );

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -15,7 +15,7 @@ import Input from "../components/Input";
 import GameProgress from "../components/GameProgress";
 import StenoLayoutDiagram from "../../../StenoLayout/AmericanStenoDiagram";
 import Stroke from "../../../utils/stroke";
-import mapBriefsFunction from '../../../utils/stenoLayouts/mapBriefToAmericanStenoKeys';
+import mapBriefsFunction from "../../../utils/stenoLayouts/mapBriefToAmericanStenoKeys";
 import Puzzle from "./Puzzle";
 import { ReactComponent as MischievousRobot } from "../../../images/MischievousRobot.svg";
 import { choosePuzzleKey, prettyKey } from "./utilities";

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -11,6 +11,7 @@ import { actions } from "../utilities/gameActions";
 import { initConfig, gameReducer, roundToWin } from "./gameReducer";
 import Completed from "../components/Completed";
 import Intro from "../components/Intro";
+import Input from "../components/Input";
 import GameProgress from "../components/GameProgress";
 import StenoLayoutDiagram from "../../../StenoLayout/AmericanStenoDiagram";
 import Stroke from "../../../utils/stroke";
@@ -18,6 +19,39 @@ import mapBriefsFunction from '../../../utils/stenoLayouts/mapBriefToAmericanSte
 import Puzzle from "./Puzzle";
 import { ReactComponent as MischievousRobot } from "../../../images/MischievousRobot.svg";
 import { choosePuzzleKey, prettyKey } from "./utilities";
+import * as stroke from "../../../utils/stroke";
+
+const stenoTypedTextToKeysMapping = {
+  "-Z": stroke.Z,
+  "-D": stroke.D,
+  "-S": stroke.RS,
+  "-T": stroke.RT,
+  "-G": stroke.G,
+  "-L": stroke.L,
+  "-B": stroke.B,
+  "-P": stroke.RP,
+  "-R": stroke.RR,
+  "-F": stroke.F,
+  "U": stroke.U,
+  "E": stroke.E,
+  "*": stroke.STAR,
+  "O": stroke.O,
+  "A": stroke.A,
+  "R": stroke.R,
+  "H": stroke.H,
+  "W": stroke.W,
+  "P": stroke.P,
+  "K": stroke.K,
+  "T": stroke.T,
+  "S": stroke.S,
+  "#": stroke.HASH,
+  "Z": stroke.Z,
+  "D": stroke.D,
+  "G": stroke.G,
+  "L": stroke.L,
+  "B": stroke.B,
+  "F": stroke.F,
+};
 
 const particles = [];
 const gameName = "KAOES";
@@ -33,6 +67,10 @@ export default function Game() {
   const canvasRef = useRef(null);
   const canvasWidth = Math.floor(window.innerWidth);
   const canvasHeight = Math.floor(window.innerHeight);
+
+  const [previousCompletedPhraseAsTyped, setPreviousCompletedPhraseAsTyped] =
+    useState("");
+  const [typedText, setTypedText] = useState("");
 
   const [puzzleText, setPuzzleText] = useState("");
   const [stenoStroke, setStenoStroke] = useState(new Stroke());
@@ -66,6 +104,33 @@ export default function Game() {
     const tmpBoard = new Stroke();
     const clickedKey = tmpBoard.set(key).toString();
     if (puzzleText === clickedKey) {
+      setPreviousCompletedPhraseAsTyped("");
+      restartConfetti();
+      setPuzzleText(choosePuzzleKey(clickedKey));
+      setStenoStroke(new Stroke());
+      setRightWrongColor(rightColor);
+      dispatch({ type: actions.roundCompleted });
+    } else {
+      setStenoStroke(stenoStroke.set(key));
+      setRightWrongColor(wrongColor);
+    }
+    setPreviousStenoStroke(tmpBoard.set(key));
+    dispatch({ type: actions.makeGuess });
+  };
+
+  const onChangeTextInput = (typedStenoKey) => {
+    setTypedText(typedStenoKey);
+    const trimmedTypedKey = typedStenoKey.trim().toUpperCase();
+    const key = stenoTypedTextToKeysMapping[trimmedTypedKey]
+      ? stenoTypedTextToKeysMapping[trimmedTypedKey]
+      : "";
+
+    const tmpBoard = new Stroke();
+    const clickedKey = tmpBoard.set(key).toString();
+
+    if (puzzleText === clickedKey) {
+      setTypedText("");
+      setPreviousCompletedPhraseAsTyped(typedStenoKey);
       restartConfetti();
       setPuzzleText(choosePuzzleKey(clickedKey));
       setStenoStroke(new Stroke());
@@ -167,6 +232,13 @@ export default function Game() {
             </div>
           </>
         )}
+        <Input
+          onChangeInput={onChangeTextInput}
+          previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
+          round={state.roundIndex + 1}
+          typedText={typedText}
+          gameName={gameName}
+        />
         <p
           className={`text-center text-small ${
             state.gameComplete ? "mt10" : "mt1 mb0"

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -244,16 +244,18 @@ export default function Game() {
               </div>
             </div>
             <div className="mw-320 mx-auto">
-              <div className="flex flex-wrap items-center">
-                <Input
-                  onChangeInput={onChangeTextInput}
-                  previousCompletedPhraseAsTyped={
-                    previousCompletedPhraseAsTyped
-                  }
-                  round={state.roundIndex + 1}
-                  typedText={typedText}
-                  gameName={gameName}
-                />
+              <div className="flex flex-wrap items-center justify-center">
+                <div className="mw-240">
+                  <Input
+                    onChangeInput={onChangeTextInput}
+                    previousCompletedPhraseAsTyped={
+                      previousCompletedPhraseAsTyped
+                    }
+                    round={state.roundIndex + 1}
+                    typedText={typedText}
+                    gameName={gameName}
+                  />
+                </div>
                 <div className="ml1">
                   (
                   <button

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -123,7 +123,7 @@ export default function Game() {
     const trimmedTypedKey = typedStenoKey.trim().toUpperCase();
     const key = stenoTypedTextToKeysMapping[trimmedTypedKey]
       ? stenoTypedTextToKeysMapping[trimmedTypedKey]
-      : "";
+      : 0;
 
     const tmpBoard = new Stroke();
     const clickedKey = tmpBoard.set(key).toString();

--- a/src/pages/games/components/Completed.jsx
+++ b/src/pages/games/components/Completed.jsx
@@ -82,7 +82,7 @@ export default React.memo(function Completed({ gameName, dispatch }) {
       />
       <div
         id="you-win"
-        tabIndex="0"
+        tabIndex={0}
         onClick={restartConfetti}
         onKeyDown={restartConfetti}
         className="w-100 pt1"

--- a/src/pages/games/components/Input.jsx
+++ b/src/pages/games/components/Input.jsx
@@ -27,7 +27,7 @@ export default function Input({
         htmlFor={`${gameName}-input`}
         className="inline-block mb05 visually-hidden"
       >
-        Enter the correct word:
+        Enter the correct text:
       </label>
       <div className="relative">
         <samp className="pointer-none absolute absolute--fill w-100">

--- a/src/pages/games/utilities/gameActions.js
+++ b/src/pages/games/utilities/gameActions.js
@@ -1,4 +1,5 @@
 export const actions = {
   gameRestarted: "gameRestarted",
   roundCompleted: "roundCompleted",
+  makeGuess: "makeGuess"
 };


### PR DESCRIPTION
This PR adds the text input below the KAOES diagram:

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/2476974/213830121-0db35dda-5361-4faf-8c17-3155b65c4645.png">
