### PR TITLE
Add "Customise lesson"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,6 +60,7 @@ import setAnnouncementMessageString from './components/Announcements/setAnnounce
 import sortLesson from './utils/lessons/sortLesson';
 import Zipper from './utils/zipper';
 import generateCustomLesson from './pages/lessons/custom/generator/utilities/generateCustomLesson';
+import customiseLesson from './pages/lessons/utilities/customiseLesson';
 
 const AsyncBreak = Loadable({
   loader: () => import("./pages/break/Break"),
@@ -2378,6 +2379,7 @@ class App extends Component {
                         <Lessons
                           generateCustomLesson={generateCustomLesson.bind(this)}
                           customLesson={this.state.customLesson}
+                          customiseLesson={customiseLesson.bind(this)}
                           customLessonMaterial={this.state.customLessonMaterial}
                           customLessonMaterialValidationState={this.state.customLessonMaterialValidationState}
                           customLessonMaterialValidationMessages={this.state.customLessonMaterialValidationMessages}

--- a/src/components/StrokesForWords.js
+++ b/src/components/StrokesForWords.js
@@ -71,12 +71,12 @@ class StrokesForWords extends Component {
     return (
       this.props.globalLookupDictionaryLoaded ?
         <React.Fragment>
-          <label htmlFor="words-for-strokes" className="input-textarea-label input-textarea-label--large mb1">Enter words to look up</label>
+          <label htmlFor="words-for-strokes" className="input-textarea-label input-textarea-label--large mb1 overflow-hidden">Enter words to look up</label>
           <textarea
             autoCapitalize="off"
             autoComplete="off"
             autoCorrect="off"
-            className="input-textarea input-textarea--large mb3 w-100"
+            className="input-textarea input-textarea--large mb3 w-100 overflow-hidden"
             id="words-for-strokes"
             onChange={this.handleWordsOnChange.bind(this)}
             placeholder="e.g. quadruplicate"

--- a/src/components/TypedText.js
+++ b/src/components/TypedText.js
@@ -132,8 +132,8 @@ class TypedText extends Component {
                 aria-describedby="punctuation-description"
                 onChange={this.props.updateMarkup}
                 onKeyPress={this.keyPress.bind(this)}
-                rows="1"
-                spellCheck="false"
+                rows={1}
+                spellCheck={false}
                 value={this.props.actualText}
                 wrap="off"
               ></textarea>

--- a/src/components/TypedText.js
+++ b/src/components/TypedText.js
@@ -125,7 +125,7 @@ class TypedText extends Component {
                 autoCapitalize="off"
                 autoComplete="off"
                 autoCorrect="off"
-                className={`input-textarea typed-text-input-positioning typed-text-input-textarea${
+                className={`input-textarea typed-text-input-positioning typed-text-input-textarea overflow-hidden${
                   isMultiline ? " text-center" : ""
                 }`}
                 id="your-typed-text"

--- a/src/index.scss
+++ b/src/index.scss
@@ -1251,7 +1251,6 @@ $textarea-padding-x: 8px;
   font-size: 1rem;
   line-height: 1.5;
   padding: $textarea-padding-y $textarea-padding-x;
-  overflow: hidden;
 }
 
 .input-textarea-label.input-textarea-label--large {
@@ -1278,6 +1277,7 @@ $textarea-padding-x: 8px;
   border: $textarea-border solid transparent;
   font-weight: 400;
   line-height: 1.5;
+  overflow: hidden;
   transform: translateX(0);
   width: 640px;
   z-index: $z-index-successfully-typed-text;

--- a/src/index.scss
+++ b/src/index.scss
@@ -664,6 +664,9 @@ input:focus::placeholder {
 .lh-double        { line-height: 2; }
 .fr               { float: right; display: inline; }
 
+// Tailwind:
+.content-center   { align-content: center; }
+
 .hide-soft-hyphen {
   -webkit-hyphenate-character: '';
   // hyphenate-character: '';

--- a/src/pages/games/components/Input.jsx
+++ b/src/pages/games/components/Input.jsx
@@ -53,9 +53,7 @@ export default function Input({
           autoCapitalize="off"
           autoComplete="off"
           autoCorrect="off"
-          className={
-            "input-textarea w-100 typed-text-input-textarea text-center mx-auto"
-          }
+          className="input-textarea w-100 typed-text-input-textarea text-center mx-auto overflow-hidden"
           id={`${gameName}-input`}
           onChange={onChangeTypedText}
           rows="1"

--- a/src/pages/games/components/Input.jsx
+++ b/src/pages/games/components/Input.jsx
@@ -56,8 +56,8 @@ export default function Input({
           className="input-textarea w-100 typed-text-input-textarea text-center mx-auto overflow-hidden"
           id={`${gameName}-input`}
           onChange={onChangeTypedText}
-          rows="1"
-          spellCheck="false"
+          rows={1}
+          spellCheck={false}
           value={typedText}
           wrap="off"
         ></textarea>

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -123,6 +123,11 @@ class Lesson extends Component {
     });
   }
 
+  stopAndCustomiseLesson() {
+    this.props.stopLesson();
+    this.props.customiseLesson();
+  }
+
   render() {
     if (this.props.lessonNotFound) {
       return <LessonNotFound path={this.props.path} location={this.props.location} lessonIndex={this.props.lessonIndex} />
@@ -140,7 +145,14 @@ class Lesson extends Component {
         Edit custom lesson
       </Link>
     ) : (
-      undefined
+      <Link
+        to="/lessons/custom/setup"
+        onClick={this.stopAndCustomiseLesson.bind(this)}
+        className="link-button link-button-ghost table-cell mr1"
+        role="button"
+      >
+        Customise lesson
+      </Link>
     );
 
     const metadata = getLessonMetadata(

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -346,6 +346,7 @@ const Lessons = ({
             customLesson={customLesson}
             handleLesson={handleLesson}
             lesson={lesson}
+            lessonNotFound={true}
             lessonIndex={lessonIndex}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -10,6 +10,7 @@ import PageLoading from "../../components/PageLoading";
 
 type LessonsRoutingProps = {
   customLesson: any;
+  customiseLesson: () => void;
   generateCustomLesson: any;
   handleLesson: any;
   lesson: any;
@@ -32,6 +33,7 @@ const Lessons = ({
   customLessonMaterial,
   customLessonMaterialValidationMessages,
   customLessonMaterialValidationState,
+  customiseLesson,
   fetchAndSetupGlobalDict,
   generateCustomLesson,
   globalLookupDictionary,
@@ -129,6 +131,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
@@ -149,6 +152,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
@@ -169,6 +173,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
@@ -190,6 +195,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
@@ -211,6 +217,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
@@ -232,6 +239,7 @@ const Lessons = ({
         render={(props) => (
           <Lesson
             customLesson={customLesson}
+            customiseLesson={customiseLesson}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}

--- a/src/pages/lessons/MainLessonView.stories.jsx
+++ b/src/pages/lessons/MainLessonView.stories.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Link, Route, Switch } from "react-router-dom";
 import MainLessonView from "./MainLessonView";
 import userSettings from "../../stories/fixtures/userSettings";
 import Zipper from "../../utils/zipper";
@@ -86,6 +86,17 @@ const lessonIndex = [
 const handleLesson = (path) => undefined;
 const stopLesson = () => undefined;
 
+const createNewCustomLesson = (
+  <Link
+    to="/lessons/custom/setup"
+    onClick={() => console.log("Stop lesson and edit custom lesson")}
+    className="link-button link-button-ghost table-cell mr1"
+    role="button"
+  >
+    Edit custom lesson
+  </Link>
+);
+
 const Template = (args) => {
   return (
     <Switch>
@@ -93,6 +104,7 @@ const Template = (args) => {
         render={(props) => (
           <div>
             <MainLessonView
+              createNewCustomLesson={createNewCustomLesson}
               customLesson={customLesson}
               fetchAndSetupGlobalDict={() => Promise.resolve(true)}
               globalLookupDictionary={globalLookupDictionary}

--- a/src/pages/lessons/components/LessonCanvasFooter.tsx
+++ b/src/pages/lessons/components/LessonCanvasFooter.tsx
@@ -25,7 +25,7 @@ const LessonCanvasFooter = ({
         setAnnouncementMessage={setAnnouncementMessage}
         userSettings={userSettings}
       />
-      <div className="flex flex-wrap">
+      <div className="flex flex-wrap content-center">
         <fieldset className="dc hide-sm">
           {/* @ts-ignore */}
           <Tooltip

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -164,7 +164,7 @@ export default function LessonList({ lessonIndex, url }: LessonListProps) {
         <input
           ref={searchInputRef}
           id="lesson-search-filter"
-          className="caret-color w-100 bg-white dark:bg-coolgrey-1000 input-textarea mb3"
+          className="caret-color w-100 bg-white dark:bg-coolgrey-1000 input-textarea mb3 overflow-hidden"
           autoCapitalize="off"
           autoComplete="off"
           autoCorrect="off"

--- a/src/pages/lessons/components/LessonSubheader.tsx
+++ b/src/pages/lessons/components/LessonSubheader.tsx
@@ -43,7 +43,8 @@ const LessonSubheader = React.forwardRef(
           </header>
         </div>
         <div className="flex flex-wrap mxn2">
-          {createNewCustomLesson ? createNewCustomLesson : overviewLink}
+          {createNewCustomLesson ? createNewCustomLesson : undefined}
+          {overviewLink ? overviewLink : undefined}
           {!path.includes("custom") && !path.includes("progress") ? (
             <Link
               to={path

--- a/src/pages/lessons/utilities/customiseLesson.ts
+++ b/src/pages/lessons/utilities/customiseLesson.ts
@@ -1,0 +1,36 @@
+import Zipper from "../../../utils/zipper";
+
+import type { CustomLesson } from "../../../types";
+
+function generateCustomLesson() {
+  // @ts-ignore 'this' implicitly has type 'any' because it does not have a type annotation.
+  const existingLesson = this.state.lesson;
+
+  const customisedLesson: CustomLesson = {
+    sourceMaterial: existingLesson.sourceMaterial.slice(),
+    presentedMaterial: existingLesson.presentedMaterial.slice(),
+    settings: { ignoredChars: "" },
+    title: "Custom", // "Start custom lesson" overrides this anyway
+    subtitle: "",
+    // @ts-ignore FIXME: might be a Zipper typing issue
+    newPresentedMaterial: new Zipper(existingLesson.sourceMaterial.slice()),
+    path: process.env.PUBLIC_URL + "/lessons/custom",
+  };
+
+  const validationState = "success";
+
+  const newCustomLessonMaterial = customisedLesson.presentedMaterial
+    .map((materialItem) => `${materialItem.phrase}	${materialItem.stroke}`)
+    .join("\n");
+
+  // @ts-ignore 'this' implicitly has type 'any' because it does not have a type annotation.
+  this.setState({
+    lesson: customisedLesson,
+    currentPhraseID: 0,
+    customLesson: customisedLesson,
+    customLessonMaterial: newCustomLessonMaterial,
+    customLessonMaterialValidationState: validationState,
+  });
+}
+
+export default generateCustomLesson;

--- a/src/pages/writer/Writer.tsx
+++ b/src/pages/writer/Writer.tsx
@@ -349,7 +349,7 @@ class Writer extends Component<Props, State> {
                       autoCapitalize="off"
                       autoComplete="off"
                       autoCorrect="off"
-                      className="input-textarea"
+                      className="input-textarea overflow-hidden"
                       onChange={this.updateQWERTYSteno.bind(this)}
                       placeholder="e.g. rnm"
                       value={this.state.valueQWERTYSteno}
@@ -383,7 +383,7 @@ class Writer extends Component<Props, State> {
                       autoCapitalize="off"
                       autoComplete="off"
                       autoCorrect="off"
-                      className="input-textarea"
+                      className="input-textarea overflow-hidden"
                       onChange={this.updateRawSteno.bind(this)}
                       placeholder={placeholderRawSteno}
                       value={this.state.valueRawSteno}


### PR DESCRIPTION
This PR adds "Customise lesson" functionality to jump straight from an existing lesson to the custom lesson setup page with the existing lesson's material pre-filled for editing:

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/2476974/219922672-6e962af5-6adf-4351-bba2-75ae9c9ffd35.png">
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/2476974/219922679-e6b977be-0ac9-441c-a4d3-25da0d5ef7a6.png">

This PR also fixes:

- vertical alignment of the lesson canvas footer study type options
- `overflow: scroll` on the custom lesson material `textarea`
- 404 not found page causing an unhandled error on URLs like `/typey-type/lessons/404`

Another example of the new customise lesson feature:
<img width="547" alt="image" src="https://user-images.githubusercontent.com/2476974/219922808-526522e9-79cc-412e-acd1-60e7bee1a7a9.png">

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/2476974/219922756-cdf96781-8392-4d62-9449-79f396e6dd68.png">
