### PR TITLE
Upgrade react-ga to react-ga4 and switch universal analytics over to Google Analytics 4, and note Node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Typey Type avoids generic typing features, such as competing for speed and accur
 
 ### Requirements
 
-Install [yarn](https://yarnpkg.com/lang/en/docs/install/). Note: the project is currently built with Node version 14.
+Install [yarn](https://yarnpkg.com/lang/en/docs/install/). Note: the project is currently built with Node version 16.
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-chatbot-kit": "^2.0.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^17.0.2",
+    "react-ga4": "^2.1.0",
     "react-loadable": "^5.5.0",
     "react-modal": "^3.14.4",
     "react-numeric-input": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     ]
   },
   "engines": {
-    "node": ">=14.18.3"
+    "node": ">=16.15.0"
   },
   "eslintConfig": {
     "overrides": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-chatbot-kit": "^2.0.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^17.0.2",
-    "react-ga": "^2.5.0",
     "react-loadable": "^5.5.0",
     "react-modal": "^3.14.4",
     "react-numeric-input": "^2.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,7 @@ import {
 } from 'react-router-dom';
 import queryString from 'query-string';
 import DocumentTitle from 'react-document-title';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 import Loadable from 'react-loadable';
 import PageLoading from './components/PageLoading';
 import Announcements from './components/Announcements/Announcements';

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { IconClosingCross } from './Icon';
-// import GoogleAnalytics from 'react-ga';
+// import GoogleAnalytics from "react-ga4";
 
 class Notification extends Component {
   constructor(props) {

--- a/src/components/OutboundLink.tsx
+++ b/src/components/OutboundLink.tsx
@@ -1,5 +1,5 @@
-import GoogleAnalytics from "react-ga";
 import React from "react";
+import GoogleAnalytics from "react-ga4";
 
 type Props = {
   "aria-label"?: string;
@@ -20,19 +20,30 @@ const OutboundLink = ({
   style,
   to,
 }: Props) => {
+  const clickHandler: React.MouseEventHandler = (e) => {
+    GoogleAnalytics.event({
+      category: "Outbound",
+      action: "Click",
+      label: eventLabel,
+    });
+
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
   return (
-    <GoogleAnalytics.OutboundLink
-      eventLabel={eventLabel}
+    <a
+      href={to}
       aria-label={ariaLabel}
       className={className}
-      onClick={onClick}
+      onClick={clickHandler}
       style={style}
-      to={to}
       target="_blank"
       rel="noopener noreferrer"
     >
       {children}
-    </GoogleAnalytics.OutboundLink>
+    </a>
   );
 };
 

--- a/src/components/PseudoContentButton.js
+++ b/src/components/PseudoContentButton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Clipboard from 'clipboard';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 
 class PseudoContentButton extends Component {
   constructor(props) {

--- a/src/components/TypedText.js
+++ b/src/components/TypedText.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 
 class TypedText extends Component {
   componentWillUnmount() {

--- a/src/pages/break/Break.tsx
+++ b/src/pages/break/Break.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Link } from "react-router-dom";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import Subheader from "../../components/Subheader";
 
 type Props = {

--- a/src/pages/dictionaries/Dictionary.tsx
+++ b/src/pages/dictionaries/Dictionary.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import DocumentTitle from "react-document-title";
 import { Link, useLocation } from "react-router-dom";
 import DictionaryNotFound from "./DictionaryNotFound";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import PseudoContentButton from "../../components/PseudoContentButton";
 import { IconExternal } from "../../components/Icon";
 import { Tooltip } from "react-tippy";

--- a/src/pages/dictionaries/DictionaryManagement.jsx
+++ b/src/pages/dictionaries/DictionaryManagement.jsx
@@ -3,7 +3,7 @@ import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
 import SOURCE_NAMESPACES from '../../constant/sourceNamespaces';
 import React, { Component } from 'react';
 import DocumentTitle from 'react-document-title';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 import Notification from '../../components/Notification';
 import {
   getListOfValidDictionariesAddedAndInConfig,

--- a/src/pages/dictionaries/DictionaryNotFound.tsx
+++ b/src/pages/dictionaries/DictionaryNotFound.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import * as Sentry from "@sentry/browser";
 import DocumentTitle from "react-document-title";
 import { Link, useLocation } from "react-router-dom";

--- a/src/pages/games/components/Completed.jsx
+++ b/src/pages/games/components/Completed.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import { Link } from "react-router-dom";
 import { actions } from "../utilities/gameActions";
 import { ReactComponent as HappyRobot } from "../../../images/HappyRobot.svg";

--- a/src/pages/games/components/Hint.jsx
+++ b/src/pages/games/components/Hint.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 
 const handleHintClick = (event, setShowHint, gameName) => {
   event.preventDefault();

--- a/src/pages/games/utilities/LevelCompleted.jsx
+++ b/src/pages/games/utilities/LevelCompleted.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import { actions as SHUFLactions } from "../SHUFL/gameActions";
 import { actions as TPEUBGSZactions } from "../TPEUBGSZ/gameActions";
 import { ReactComponent as AlertRobot } from "../../../images/AlertRobot.svg";

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 import queryString from 'query-string';
 import DocumentTitle from 'react-document-title';
 import ErrorBoundary from '../../components/ErrorBoundary'

--- a/src/pages/lessons/LessonNotFound.tsx
+++ b/src/pages/lessons/LessonNotFound.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import * as Sentry from "@sentry/browser";
 import DocumentTitle from "react-document-title";
 import { Link, useLocation } from "react-router-dom";

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import { Link } from "react-router-dom";
 import { groups } from "d3-array";
 import type { LessonIndexEntry } from "../../../types";

--- a/src/pages/lessons/components/Metronome.tsx
+++ b/src/pages/lessons/components/Metronome.tsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Howl } from "howler";
 import { IconMetronome } from "../../../components/Icon";
 import { Tooltip } from "react-tippy";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import plink from "../../../sounds/digi_plink-with-silence.mp3";
 
 import type { UserSettings } from "../../../types";

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useReducer, useRef, useState } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import { actions } from "./generator/rulesActions";
 import Subheader from "../../../components/Subheader";
 import { useLocalStorage } from "usehooks-ts";

--- a/src/pages/lessons/flashcards/Flashcards.js
+++ b/src/pages/lessons/flashcards/Flashcards.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 import ReactModal from 'react-modal';
 import FlashcardsCarouselActionButtons from './components/FlashcardsCarouselActionButtons';
 import FlashcardsModal from './components/FlashcardsModal';

--- a/src/pages/pagenotfound/PageNotFound.tsx
+++ b/src/pages/pagenotfound/PageNotFound.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import OutboundLink from "../../components/OutboundLink";
 import * as Sentry from "@sentry/browser";
 import { Link } from "react-router-dom";

--- a/src/pages/progress/Progress.jsx
+++ b/src/pages/progress/Progress.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import GoogleAnalytics from 'react-ga';
+import GoogleAnalytics from "react-ga4";
 import ErrorBoundary from '../../components/ErrorBoundary'
 import PseudoContentButton from '../../components/PseudoContentButton';
 import RecommendationBox from './components/RecommendationBox';

--- a/src/pages/progress/components/DownloadProgressButton.tsx
+++ b/src/pages/progress/components/DownloadProgressButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import formatProgressFileDownloadName from "../utils/formatProgressFileDownloadName";
 import makeDownloadHref from "../utils/makeDownloadHref";
 import type { MetWords } from "../../../types";

--- a/src/pages/progress/components/FlashcardsBox.tsx
+++ b/src/pages/progress/components/FlashcardsBox.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import { Link } from "react-router-dom";
 import * as Utils from "../../../utils/utils";
 

--- a/src/pages/progress/components/FlashcardsSection.tsx
+++ b/src/pages/progress/components/FlashcardsSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import ErrorBoundary from "../../../components/ErrorBoundary";
 import FlashcardsBox from "./FlashcardsBox";
 import type {

--- a/src/pages/progress/components/RecommendationBox.tsx
+++ b/src/pages/progress/components/RecommendationBox.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import OutboundLink from "../../../components/OutboundLink";
 import RecommendationDescription from "./RecommendationDescription";
 import { IconExternal } from "../../../components/Icon";

--- a/src/pages/progress/components/ReformatProgress.tsx
+++ b/src/pages/progress/components/ReformatProgress.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import GoogleAnalytics from "react-ga";
+import GoogleAnalytics from "react-ga4";
 import formatSpacePlacementValue from "../utils/formatSpacePlacementValue";
 import makeDownloadHref from "../utils/makeDownloadHref";
 import trimAndSumUniqMetWords from "../../../utils/trimAndSumUniqMetWords";

--- a/src/pages/writer/Writer.tsx
+++ b/src/pages/writer/Writer.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import GoogleAnalytics from "react-ga4";
 import AmericanStenoDiagram from '../../StenoLayout/AmericanStenoDiagram';
 import NoNumberBarInnerThumbNumbersStenoDiagram from '../../StenoLayout/NoNumberBarInnerThumbNumbersStenoDiagram';
 import NoNumberBarOuterThumbNumbersStenoDiagram from '../../StenoLayout/NoNumberBarOuterThumbNumbersStenoDiagram';
@@ -23,7 +24,6 @@ import mapBriefToKoreanModernCStenoKeys from '../../utils/stenoLayouts/mapBriefT
 import mapBriefToPalantypeKeys from '../../utils/stenoLayouts/mapBriefToPalantypeKeys';
 import { fetchResource } from '../../utils/getData';
 import { Tooltip } from 'react-tippy';
-import GoogleAnalytics from 'react-ga';
 import Subheader from "../../components/Subheader";
 
 import type { Outline, UserSettings } from "../../types";
@@ -174,9 +174,9 @@ class Writer extends Component<Props, State> {
     if (!labelString) { labelString = "BAD_INPUT"; }
 
     GoogleAnalytics.event({
-      category: 'Writer',
-      action: 'Send stroke',
-      label: labelString
+      category: "Writer",
+      action: "Send stroke",
+      label: labelString,
     });
 
     this.setState({

--- a/src/utils/withAnalyticsTracker.tsx
+++ b/src/utils/withAnalyticsTracker.tsx
@@ -5,8 +5,7 @@ import { useHistory, useLocation } from "react-router-dom";
 if (process.env.NODE_ENV === "production" && !process.env.REACT_APP_QA) {
   GoogleAnalytics.initialize("G-VMN1E6BYC2");
 } else {
-  // GoogleAnalytics.initialize("G-VMN1E6BYC2", { testMode: true });
-  GoogleAnalytics.initialize("G-VMN1E6BYC2");
+  GoogleAnalytics.initialize("G-45R7RGF4FZ");
 }
 
 const withAnalyticsTracker = (

--- a/src/utils/withAnalyticsTracker.tsx
+++ b/src/utils/withAnalyticsTracker.tsx
@@ -1,34 +1,21 @@
-import React, { useEffect } from "react";
-import GoogleAnalytics from "react-ga";
+import React from "react";
+import GoogleAnalytics from "react-ga4";
 import { useHistory, useLocation } from "react-router-dom";
 
 if (process.env.NODE_ENV === "production" && !process.env.REACT_APP_QA) {
-  GoogleAnalytics.initialize("UA-113450929-1", { titleCase: false });
+  GoogleAnalytics.initialize("G-VMN1E6BYC2");
 } else {
-  // GoogleAnalytics.initialize('UA-113450929-2', { debug: true, titleCase: false });
-  GoogleAnalytics.initialize("UA-113450929-2", { titleCase: false });
+  // GoogleAnalytics.initialize("G-VMN1E6BYC2", { testMode: true });
+  GoogleAnalytics.initialize("G-VMN1E6BYC2");
 }
 
 const withAnalyticsTracker = (
   WrappedComponent: any,
   options = { anonymizeIp: true }
 ) => {
-  const trackPage = (page: Location["pathname"]) => {
-    GoogleAnalytics.set({
-      page,
-      ...options,
-    });
-    GoogleAnalytics.pageview(page);
-  };
-
   const HOC = () => {
     const location = useLocation();
     const history = useHistory();
-
-    useEffect(() => {
-      const page = process.env.PUBLIC_URL + location.pathname;
-      trackPage(page);
-    }, [location.pathname]);
 
     return <WrappedComponent location={location} history={history} />;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15631,11 +15631,6 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-ga@^2.5.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
-  integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
-
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15631,6 +15631,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"


### PR DESCRIPTION
This PR:

- replaces `react-ga` with `react-ga4` package
- updates tracker component for new GA4 behaviour that handles SPA page views automatically
- updates node engines field and README to use Node 16