### PR TITLE
Add download link for lesson hint dictionaries to lesson pages

### DIFF
--- a/src/pages/dictionaries/DictionariesIndex.tsx
+++ b/src/pages/dictionaries/DictionariesIndex.tsx
@@ -370,6 +370,16 @@ const DictionariesIndex = ({
                 </OutboundLink>
                 .
               </p>
+
+              <p>
+                For lesson-specific dictionaries, you can now “Download lesson
+                hints as a dictionary” from individual lesson pages. For
+                example, see the bottom of the{" "}
+                <Link to="/lessons/drills/top-10000-project-gutenberg-words/">
+                  Top 10000 Project Gutenberg words lesson
+                </Link>
+                .
+              </p>
             </div>
           </div>
           <div className="mt1 mw-336 flex-grow">

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -213,6 +213,7 @@ class Lesson extends Component {
                 recommendationHistory={this.props.recommendationHistory}
                 setAnnouncementMessage={this.props.setAnnouncementMessage}
                 metadata={metadata}
+                lesson={this.props.lesson}
                 lessonLength={propsLesson.presentedMaterial.length}
                 lessonTitle={this.props.lessonTitle}
                 metWords={this.props.metWords}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -1,8 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
-import GoogleAnalytics from "react-ga4";
+import React, { useRef } from "react";
 import { IconClosingCross } from "../../components/Icon";
 import { Link, useLocation } from "react-router-dom";
-import makeDownloadHref from "../../utils/makeDownloadHref";
 import AnimateHeight from "react-animate-height";
 import DocumentTitle from "react-document-title";
 import LessonCanvasFooter from "./components/LessonCanvasFooter";
@@ -17,6 +15,7 @@ import AussieDictPrompt from "../../components/LessonPrompts/AussieDictPrompt";
 import SedSaidPrompt from "../../components/LessonPrompts/SedSaidPrompt";
 import WordBoundaryErrorPrompt from "../../components/LessonPrompts/WordBoundaryErrorPrompt";
 import PunctuationDescription from "./components/PunctuationDescription";
+import LessonFinePrintFooter from "./components/LessonFinePrintFooter";
 
 import type {
   ActualTypedText,
@@ -25,15 +24,9 @@ import type {
   Lesson,
   LessonSettings,
   LookupDictWithNamespacedDictsAndConfig,
-  StenoDictionary,
   Outline,
   UserSettings as UserSettingsType,
 } from "../../types";
-
-// fullURL = "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=lesson&entry.1202724812&entry.936119214";
-const googleFormURL =
-  "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=";
-const googleFormParam = "&entry.1202724812&entry.936119214";
 
 type Props = {
   createNewCustomLesson: JSX.Element | undefined;
@@ -92,8 +85,6 @@ type Props = {
   hideOtherSettings: boolean;
   toggleHideOtherSettings: () => void;
 };
-
-const initialLessonDict: StenoDictionary = {};
 
 const MainLessonView = ({
   createNewCustomLesson,
@@ -154,29 +145,6 @@ const MainLessonView = ({
 }: Props) => {
   const mainHeading = useRef(null);
   const location = useLocation();
-
-  const [lessonHintsAsDict, setLessonHintsAsDict] = useState({});
-
-  const downloadLessonAsDictHref = useMemo(
-    () => makeDownloadHref(lessonHintsAsDict),
-    [lessonHintsAsDict]
-  );
-
-  const downloadLessonAsDict = useCallback(() => {
-    let lessonHintsAsDict = lesson.sourceMaterial.reduce((prev, curr) => {
-      const dict = Object.assign({}, prev);
-      dict[curr["stroke"]] = curr["phrase"];
-      return dict;
-    }, initialLessonDict);
-
-    setLessonHintsAsDict(lessonHintsAsDict);
-
-    GoogleAnalytics.event({
-      category: "Downloads",
-      action: "Click",
-      label: `Dictionary: ${lessonTitle}`,
-    });
-  }, [lessonTitle, lesson.sourceMaterial]);
 
   return (
     <DocumentTitle title={"Typey Type | Lesson: " + lesson.title}>
@@ -341,36 +309,11 @@ const MainLessonView = ({
                   userSettings={userSettings}
                 />
               </div>
-              <p className="text-center">
-                <a
-                  href={
-                    googleFormURL +
-                    encodeURIComponent(location?.pathname || "") +
-                    googleFormParam
-                  }
-                  className="text-small mt0"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  id="ga--lesson--give-feedback"
-                >
-                  Give feedback on this lesson (form opens in a new tab)
-                </a>
-              </p>
-              <p className="text-center">
-                {!!lesson.path && (
-                  <a
-                    className="text-small mt0"
-                    href={downloadLessonAsDictHref}
-                    download={`${lesson.path
-                      .replace("/typey-type/lessons/", "")
-                      .replace("/lesson.txt", "")
-                      .replaceAll("/", "--")}-dictionary.json`}
-                    onClick={downloadLessonAsDict}
-                  >
-                    Download lesson hints as dictionary
-                  </a>
-                )}
-              </p>
+              <LessonFinePrintFooter
+                lesson={lesson}
+                lessonTitle={lessonTitle}
+                locationPathname={location?.pathname || ""}
+              />
             </div>
           </div>
           <div>

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -11,14 +11,10 @@ import FinishedActionButtons from "./FinishedActionButtons";
 import FinishedDataViz from "./FinishedDataViz";
 import FinishedMisstrokesSummary from "./FinishedMisstrokesSummary";
 import FinishedSummaryHeadings from "./FinishedSummaryHeadings";
+import LessonFinePrintFooter from "./LessonFinePrintFooter";
 import getNumericAccuracy from "../utilities/getNumericAccuracy";
 import type { ConfettiConfig } from "./FinishedSummaryHeadings";
 import type { FinishedProps, LessonData, TransformedData } from "../types";
-
-// fullURL = "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=lesson&entry.1202724812&entry.936119214";
-const googleFormURL =
-  "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=";
-const googleFormParam = "&entry.1202724812&entry.936119214";
 
 const calculateScores = (duration: number, wordCount: number) =>
   duration > 0
@@ -51,6 +47,7 @@ const Finished = ({
   handleStartFromWordChange,
   handleUpcomingWordsLayout,
   hideOtherSettings,
+  lesson,
   lessonLength,
   lessonTitle,
   metadata,
@@ -234,21 +231,11 @@ const Finished = ({
               userSettings={userSettings}
             />
           </div>
-          <p className="text-center">
-            <a
-              href={
-                googleFormURL +
-                encodeURIComponent(location?.pathname || "") +
-                googleFormParam
-              }
-              className="text-small mt0"
-              target="_blank"
-              rel="noopener noreferrer"
-              id="ga--lesson--give-feedback"
-            >
-              Give feedback on this lesson (form opens in a new tab)
-            </a>
-          </p>
+          <LessonFinePrintFooter
+            lesson={lesson}
+            lessonTitle={lessonTitle}
+            locationPathname={location?.pathname || ""}
+          />
         </div>
         <div>
           <UserSettings

--- a/src/pages/lessons/components/LessonFinePrintFooter.tsx
+++ b/src/pages/lessons/components/LessonFinePrintFooter.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useMemo, useState } from "react";
+import GoogleAnalytics from "react-ga4";
+import makeDownloadHref from "../../../utils/makeDownloadHref";
+
+import type { Lesson, StenoDictionary } from "../../../types";
+
+type Props = {
+  lesson: Lesson;
+  lessonTitle: string;
+  locationPathname: string;
+};
+
+// fullURL = "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=lesson&entry.1202724812&entry.936119214";
+const googleFormURL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSda64Wi5L-eVzZVo6HLJ2xnD9cu83H2-2af3WEE2atFiaoKyw/viewform?usp=pp_url&entry.1884511690=";
+const googleFormParam = "&entry.1202724812&entry.936119214";
+
+const initialLessonDict: StenoDictionary = {};
+
+const LessonFinePrintFooter = ({
+  lesson,
+  lessonTitle,
+  locationPathname,
+}: Props) => {
+  const [lessonHintsAsDict, setLessonHintsAsDict] = useState({});
+
+  const downloadLessonAsDictHref = useMemo(
+    () => makeDownloadHref(lessonHintsAsDict),
+    [lessonHintsAsDict]
+  );
+
+  const downloadLessonAsDict = useCallback(() => {
+    const lessonHintsAsDict = lesson.sourceMaterial.reduce((prev, curr) => {
+      const dict = Object.assign({}, prev);
+      dict[curr["stroke"]] = curr["phrase"];
+      return dict;
+    }, initialLessonDict);
+
+    setLessonHintsAsDict(lessonHintsAsDict);
+
+    GoogleAnalytics.event({
+      category: "Downloads",
+      action: "Click",
+      label: `Dictionary: ${lessonTitle}`,
+    });
+  }, [lessonTitle, lesson.sourceMaterial]);
+  return (
+    <div>
+      <p className="text-center">
+        <a
+          href={
+            googleFormURL +
+            encodeURIComponent(locationPathname) +
+            googleFormParam
+          }
+          className="text-small mt0"
+          target="_blank"
+          rel="noopener noreferrer"
+          id="ga--lesson--give-feedback"
+        >
+          Give feedback on this lesson (form opens in a new tab)
+        </a>
+      </p>
+      <p className="text-center">
+        {!!lesson.path && (
+          <a
+            className="text-small mt0"
+            href={downloadLessonAsDictHref}
+            download={`${lesson.path
+              .replace("/typey-type/lessons/", "")
+              .replace("/lesson.txt", "")
+              .replaceAll("/", "--")}-dictionary.json`}
+            onClick={downloadLessonAsDict}
+          >
+            Download lesson hints as dictionary
+          </a>
+        )}
+      </p>
+    </div>
+  );
+};
+
+export default LessonFinePrintFooter;

--- a/src/pages/lessons/components/LessonFinePrintFooter.tsx
+++ b/src/pages/lessons/components/LessonFinePrintFooter.tsx
@@ -72,7 +72,7 @@ const LessonFinePrintFooter = ({
               .replaceAll("/", "--")}-dictionary.json`}
             onClick={downloadLessonAsDict}
           >
-            Download lesson hints as dictionary
+            Download lesson hints as a dictionary
           </a>
         )}
       </p>

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -1,4 +1,11 @@
-import type { Lesson } from "../../types";
+import type {
+  // CurrentLessonStrokes,
+  GlobalUserSettings,
+  Lesson,
+  MetWords,
+  PrettyLessonTitle,
+  UserSettings,
+} from "../../types";
 
 export type LessonData = {
   version: number;
@@ -14,29 +21,29 @@ export type TransformedData = {
 } | null;
 
 export type FinishedProps = {
-  changeShowStrokesAs: any;
-  changeShowStrokesAsList: any;
-  changeShowStrokesOnMisstroke: any;
-  changeSortOrderUserSetting: any;
-  changeSpacePlacementUserSetting: any;
-  changeStenoLayout: any;
-  changeUserSetting: any;
-  chooseStudy: any;
-  currentLessonStrokes: any;
-  disableUserSettings: any;
-  globalUserSettings: any;
-  handleBeatsPerMinute: any;
-  handleDiagramSize: any;
-  handleLimitWordsChange: any;
-  handleRepetitionsChange: any;
-  handleStartFromWordChange: any;
-  handleUpcomingWordsLayout: any;
-  hideOtherSettings: any;
+  changeShowStrokesAs: (event: any) => void;
+  changeShowStrokesAsList: (event: any) => void;
+  changeShowStrokesOnMisstroke: (event: any) => void;
+  changeSortOrderUserSetting: (event: any) => void;
+  changeSpacePlacementUserSetting: (event: any) => void;
+  changeStenoLayout: (event: any) => void;
+  changeUserSetting: (event: any) => void;
+  chooseStudy: () => void;
+  currentLessonStrokes: any; // CurrentLessonStrokes;
+  disableUserSettings: boolean;
+  globalUserSettings: GlobalUserSettings;
+  handleBeatsPerMinute: (event: any) => void;
+  handleDiagramSize: (event: any) => void;
+  handleLimitWordsChange: (event: any) => void;
+  handleRepetitionsChange: (event: any) => void;
+  handleStartFromWordChange: (event: any) => void;
+  handleUpcomingWordsLayout: (event: any) => void;
+  hideOtherSettings: boolean;
   lesson: Lesson;
-  lessonLength: any;
-  lessonTitle: any;
+  lessonLength: number;
+  lessonTitle: PrettyLessonTitle;
   metadata: any;
-  metWords: any;
+  metWords: MetWords;
   path: any;
   restartLesson: any;
   reviseLesson: any;
@@ -57,5 +64,5 @@ export type FinishedProps = {
   totalWordCount: any;
   updateRevisionMaterial: any;
   updateTopSpeedPersonalBest: any;
-  userSettings: any;
+  userSettings: UserSettings;
 };

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -1,3 +1,5 @@
+import type { Lesson } from "../../types";
+
 export type LessonData = {
   version: number;
   lessonStrokes: any[];
@@ -30,6 +32,7 @@ export type FinishedProps = {
   handleStartFromWordChange: any;
   handleUpcomingWordsLayout: any;
   hideOtherSettings: any;
+  lesson: Lesson;
   lessonLength: any;
   lessonTitle: any;
   metadata: any;

--- a/src/pages/progress/components/DownloadProgressButton.tsx
+++ b/src/pages/progress/components/DownloadProgressButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import GoogleAnalytics from "react-ga4";
 import formatProgressFileDownloadName from "../utils/formatProgressFileDownloadName";
-import makeDownloadHref from "../utils/makeDownloadHref";
+import makeDownloadHref from "../../../utils/makeDownloadHref";
 import type { MetWords } from "../../../types";
 
 type Props = {

--- a/src/pages/progress/components/ReformatProgress.tsx
+++ b/src/pages/progress/components/ReformatProgress.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from "react";
 import GoogleAnalytics from "react-ga4";
 import formatSpacePlacementValue from "../utils/formatSpacePlacementValue";
-import makeDownloadHref from "../utils/makeDownloadHref";
+import makeDownloadHref from "../../../utils/makeDownloadHref";
 import trimAndSumUniqMetWords from "../../../utils/trimAndSumUniqMetWords";
 import formatProgressFileDownloadName from "../utils/formatProgressFileDownloadName";
 import type { MetWords, UserSettings } from "../../../types";

--- a/src/utils/makeDownloadHref.ts
+++ b/src/utils/makeDownloadHref.ts
@@ -1,4 +1,4 @@
-const makeDownloadHref = (json: { [metWord: string]: number }) =>
+const makeDownloadHref = (json: { [key: string]: number | string }) =>
   Blob !== undefined
     ? URL.createObjectURL(
         new Blob([JSON.stringify(json)], { type: "text/json" })


### PR DESCRIPTION
This PR adds download links for lesson hint dictionaries to lesson pages ahead of removing lesson-specific dictionaries from the dictionary index page.

<img width="943" alt="image" src="https://user-images.githubusercontent.com/2476974/232961854-52f60ed8-aaaa-4135-adbe-7abcfe448dc2.png">

<img width="943" alt="image" src="https://user-images.githubusercontent.com/2476974/232961933-2c1c3d32-28e5-41df-bd85-0881cf2c937d.png">

Unlike the Dictionaries index page's lesson dictionaries, the dictionaries on the lessons page are:

- generated on the fly, not fetched as JSON files
- not pretty formatted

To pretty format the lesson hint dictionaries in the future, change `makeDownloadHref.ts` so that the lesson dictionaries can use `JSON.stringify(json, null, 2)` and progress page reformatted dict can use `JSON.stringify(json)`

This PR also:

- Extracts a shared `src/pages/lessons/components/LessonFinePrintFooter.tsx` for main lesson view and finished lesson components
- Replaces some `any`s in `FinishedProps` type
