### PR TITLE
Add outline regex and translation regex rules to lesson generator 

### DIFF
--- a/src/pages/lessons/custom/CustomLessonGenerator.stories.jsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.stories.jsx
@@ -1,4 +1,7 @@
 import React from "react";
+import { screen, within, userEvent } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+
 import CustomLessonGenerator from "./CustomLessonGenerator";
 
 // eslint-disable-next-line import/no-anonymous-default-export
@@ -57,3 +60,15 @@ const Template = (args) => {
 };
 
 export const CustomLessonGeneratorStory = Template.bind({});
+
+export const CustomLessonGeneratorHelp = Template.bind({});
+CustomLessonGeneratorHelp.storyName = "Show generator help";
+CustomLessonGeneratorHelp.play = async ({ canvasElement }) => {
+  const canvas = await within(canvasElement);
+
+  const submitButton = canvas.getByRole("button", { name: "Show help" });
+  await userEvent.click(submitButton);
+
+  const textElement = screen.getByText(/To use the lesson generator/i);
+  await expect(textElement).toBeVisible();
+};

--- a/src/pages/lessons/custom/CustomLessonGenerator.stories.jsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.stories.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import CustomLessonGenerator from "./CustomLessonGenerator";
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  title: "Pages/CustomLessonGenerator",
+  component: CustomLessonGenerator,
+};
+
+const globalLookupDictionary = new Map([
+  ["huh", [["H*U", "typey:typey-type.json"]]],
+  ["gonna", [["TKPW*G", "typey:typey-type.json"]]],
+  [
+    "{!}",
+    [
+      ["KPHR", "user:punctuation-di.json"],
+      ["SKHRAPL", "typey:typey-type.json"],
+      ["TP-BG", "plover:plover-main-3-jun-2018.json"],
+      ["STKPWHR-FPLT", "plover:plover-main-3-jun-2018.json"],
+    ],
+  ],
+]);
+const sourceMaterial = [
+  {
+    phrase: ".",
+    stroke: "TP-PL",
+  },
+  {
+    phrase: "and the",
+    stroke: "SKP-T",
+  },
+];
+
+const Template = (args) => {
+  return (
+    <CustomLessonGenerator
+      createCustomLesson={() => console.log("create custom lesson")}
+      customLesson={{
+        sourceMaterial,
+        presentedMaterial: sourceMaterial,
+        settings: { ignoredChars: "" },
+        title: "Test",
+        subtitle: "",
+        newPresentedMaterial: sourceMaterial,
+        path: "/lessons/fundamentals/test/",
+      }}
+      customLessonMaterial={""}
+      customLessonMaterialValidationMessages={[]}
+      customLessonMaterialValidationState={"success"}
+      fetchAndSetupGlobalDict={() => Promise.resolve(true)}
+      generateCustomLesson={() => console.log("generate custom lesson")}
+      globalLookupDictionary={globalLookupDictionary}
+      personalDictionaries={{ dictionariesNamesAndContents: null }}
+      {...args}
+    />
+  );
+};
+
+export const CustomLessonGeneratorStory = Template.bind({});

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -94,18 +94,6 @@ const CustomLessonGenerator = ({
     });
   };
 
-  const onChangeOutlineRegex: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    dispatchRulesWithData({
-      type: rulesWithDataActions.setRegexRuleData,
-      payload: {
-        entryPart: event.target.id.replace("-regex", ""),
-        regexText: event.target.value,
-      },
-    });
-  };
-
   const onChangeTranslationRule: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
@@ -118,7 +106,7 @@ const CustomLessonGenerator = ({
     });
   };
 
-  const onChangeTranslationRegex: React.ChangeEventHandler<HTMLInputElement> = (
+  const onChangeEntryRegex: React.ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
     dispatchRulesWithData({
@@ -319,7 +307,7 @@ const CustomLessonGenerator = ({
                               autoCapitalize="off"
                               autoComplete="off"
                               autoCorrect="off"
-                              onChange={onChangeOutlineRegex}
+                              onChange={onChangeEntryRegex}
                               placeholder=".*[DZ]$"
                               spellCheck={false}
                               type="text"
@@ -360,7 +348,7 @@ const CustomLessonGenerator = ({
                               autoCapitalize="off"
                               autoComplete="off"
                               autoCorrect="off"
-                              onChange={onChangeTranslationRegex}
+                              onChange={onChangeEntryRegex}
                               placeholder=".*(ation|cean)$"
                               spellCheck={false}
                               type="text"

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -14,9 +14,11 @@ import {
 } from "./generator/rulesWithDataReducer";
 import { Link, useRouteMatch } from "react-router-dom";
 import RuleOptions from "./generator/components/RuleOptions";
+import RegexRuleSetting from "./generator/components/RegexRuleSetting";
 import availableRulePrettyNames from "./generator/utilities/availableRulePrettyNames";
 import maxItems from "./generator/constants/maxItems";
 import GeneratorHelp from "./GeneratorHelp";
+
 import type {
   CustomLesson,
   LookupDictWithNamespacedDicts,
@@ -265,88 +267,30 @@ const CustomLessonGenerator = ({
                         </div>
                         <p className="mb1 flex items-center">Advanced:</p>
                         <div className="pb3">
-                          <div className="flex flex-wrap gap-4">
-                            <p className="mb1 flex items-center">
-                              <select
-                                id={"translationMatching"}
-                                name={"translationMatching"}
-                                value={rulesWithDataState.translationMatching}
-                                onChange={onChangeEntryRegexRule}
-                                data-rule-status={
-                                  rulesWithDataState.translationMatching
-                                }
-                                className="rule-select text-small form-control w-80 mr1"
-                              >
-                                <option value="on">On</option>
-                                <option value="off">Off</option>
-                                <option value="ignored">Ignored</option>
-                              </select>
-                              <label
-                                className="dib lh-single"
-                                htmlFor={"translationMatching"}
-                              >
-                                has translation matching
-                              </label>
-                            </p>
-                            <p className="flex flex-wrap items-center gap-4 mb1">
-                              <label htmlFor="translation-regex">
-                                translation regex:
-                              </label>
-                              <input
-                                id="translation-regex"
-                                className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
-                                autoCapitalize="off"
-                                autoComplete="off"
-                                autoCorrect="off"
-                                onChange={onChangeEntryRegex}
-                                placeholder=".*(ation|cean)$"
-                                spellCheck={false}
-                                type="text"
-                                value={rulesWithDataState.translationRegexText}
-                              ></input>
-                            </p>
-                          </div>
-                          <div className="flex flex-wrap gap-4">
-                            <p className="mb1 flex items-center">
-                              <select
-                                id={"outlineMatching"}
-                                name={"outlineMatching"}
-                                value={rulesWithDataState.outlineMatching}
-                                onChange={onChangeEntryRegexRule}
-                                data-rule-status={
-                                  rulesWithDataState.outlineMatching
-                                }
-                                className="rule-select text-small form-control w-80 mr1"
-                              >
-                                <option value="on">On</option>
-                                <option value="off">Off</option>
-                                <option value="ignored">Ignored</option>
-                              </select>
-                              <label
-                                className="dib lh-single"
-                                htmlFor={"outlineMatching"}
-                              >
-                                has outline matching
-                              </label>
-                            </p>
-                            <p className="flex flex-wrap items-center gap-4 mb1">
-                              <label htmlFor="outline-regex">
-                                outline regex:
-                              </label>
-                              <input
-                                id="outline-regex"
-                                className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
-                                autoCapitalize="off"
-                                autoComplete="off"
-                                autoCorrect="off"
-                                onChange={onChangeEntryRegex}
-                                placeholder=".*[DZ]$"
-                                spellCheck={false}
-                                type="text"
-                                value={rulesWithDataState.outlineRegexText}
-                              ></input>
-                            </p>
-                          </div>
+                          <RegexRuleSetting
+                            regexRuleName={"translationMatching"}
+                            regexRuleStatus={
+                              rulesWithDataState.translationMatching
+                            }
+                            regexRuleDataValue={
+                              rulesWithDataState.translationRegexText
+                            }
+                            entryPart={"translation"}
+                            onChangeEntryRegexStatus={onChangeEntryRegexRule}
+                            onChangeEntryRegexData={onChangeEntryRegex}
+                            placeholder={".*(ation|cean)$"}
+                          />
+                          <RegexRuleSetting
+                            regexRuleName={"outlineMatching"}
+                            regexRuleStatus={rulesWithDataState.outlineMatching}
+                            regexRuleDataValue={
+                              rulesWithDataState.outlineRegexText
+                            }
+                            entryPart={"outline"}
+                            onChangeEntryRegexStatus={onChangeEntryRegexRule}
+                            onChangeEntryRegexData={onChangeEntryRegex}
+                            placeholder={".*[DZ]$"}
+                          />
                         </div>
                       </div>
                     </details>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -133,9 +133,9 @@ const CustomLessonGenerator = ({
   );
 
   const regexRules: RegexRules = {
-    outlineRule: rulesWithDataState.outlineRule,
+    outlineMatching: rulesWithDataState.outlineMatching,
     outlineRegexText: rulesWithDataState.outlineRegexText,
-    translationRule: rulesWithDataState.translationRule,
+    translationMatching: rulesWithDataState.translationMatching,
     translationRegexText: rulesWithDataState.translationRegexText,
   };
 
@@ -267,12 +267,12 @@ const CustomLessonGenerator = ({
                         <div className="flex flex-wrap gap-4">
                           <p className="mb1 flex items-center">
                             <select
-                              id={"translationRule"}
-                              name={"translationRule"}
-                              value={rulesWithDataState.translationRule}
+                              id={"translationMatching"}
+                              name={"translationMatching"}
+                              value={rulesWithDataState.translationMatching}
                               onChange={onChangeEntryRegexRule}
                               data-rule-status={
-                                rulesWithDataState.translationRule
+                                rulesWithDataState.translationMatching
                               }
                               className="rule-select text-small form-control w-80 mr1"
                             >
@@ -282,7 +282,7 @@ const CustomLessonGenerator = ({
                             </select>
                             <label
                               className="dib lh-single"
-                              htmlFor={"translationRule"}
+                              htmlFor={"translationMatching"}
                             >
                               has translation matching
                             </label>
@@ -308,11 +308,11 @@ const CustomLessonGenerator = ({
                         <div className="pb3 flex flex-wrap gap-4">
                           <p className="mb1 flex items-center">
                             <select
-                              id={"outlineRule"}
-                              name={"outlineRule"}
-                              value={rulesWithDataState.outlineRule}
+                              id={"outlineMatching"}
+                              name={"outlineMatching"}
+                              value={rulesWithDataState.outlineMatching}
                               onChange={onChangeEntryRegexRule}
-                              data-rule-status={rulesWithDataState.outlineRule}
+                              data-rule-status={rulesWithDataState.outlineMatching}
                               className="rule-select text-small form-control w-80 mr1"
                             >
                               <option value="on">On</option>
@@ -321,7 +321,7 @@ const CustomLessonGenerator = ({
                             </select>
                             <label
                               className="dib lh-single"
-                              htmlFor={"outlineRule"}
+                              htmlFor={"outlineMatching"}
                             >
                               has outline matching
                             </label>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -267,45 +267,6 @@ const CustomLessonGenerator = ({
                         <div className="flex flex-wrap gap-4">
                           <p className="mb1 flex items-center">
                             <select
-                              id={"outlineRule"}
-                              name={"outlineRule"}
-                              value={rulesWithDataState.outlineRule}
-                              onChange={onChangeEntryRegexRule}
-                              data-rule-status={rulesWithDataState.outlineRule}
-                              className="rule-select text-small form-control w-80 mr1"
-                            >
-                              <option value="on">On</option>
-                              <option value="off">Off</option>
-                              <option value="ignored">Ignored</option>
-                            </select>
-                            <label
-                              className="dib lh-single"
-                              htmlFor={"outlineRule"}
-                            >
-                              has outline matching
-                            </label>
-                          </p>
-                          <p className="flex flex-wrap items-center gap-4 mb1">
-                            <label htmlFor="outline-regex">
-                              outline regex:
-                            </label>
-                            <input
-                              id="outline-regex"
-                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
-                              autoCapitalize="off"
-                              autoComplete="off"
-                              autoCorrect="off"
-                              onChange={onChangeEntryRegex}
-                              placeholder=".*[DZ]$"
-                              spellCheck={false}
-                              type="text"
-                              value={rulesWithDataState.outlineRegexText}
-                            ></input>
-                          </p>
-                        </div>
-                        <div className="pb3 flex flex-wrap gap-4">
-                          <p className="mb1 flex items-center">
-                            <select
                               id={"translationRule"}
                               name={"translationRule"}
                               value={rulesWithDataState.translationRule}
@@ -341,6 +302,45 @@ const CustomLessonGenerator = ({
                               spellCheck={false}
                               type="text"
                               value={rulesWithDataState.translationRegexText}
+                            ></input>
+                          </p>
+                        </div>
+                        <div className="pb3 flex flex-wrap gap-4">
+                          <p className="mb1 flex items-center">
+                            <select
+                              id={"outlineRule"}
+                              name={"outlineRule"}
+                              value={rulesWithDataState.outlineRule}
+                              onChange={onChangeEntryRegexRule}
+                              data-rule-status={rulesWithDataState.outlineRule}
+                              className="rule-select text-small form-control w-80 mr1"
+                            >
+                              <option value="on">On</option>
+                              <option value="off">Off</option>
+                              <option value="ignored">Ignored</option>
+                            </select>
+                            <label
+                              className="dib lh-single"
+                              htmlFor={"outlineRule"}
+                            >
+                              has outline matching
+                            </label>
+                          </p>
+                          <p className="flex flex-wrap items-center gap-4 mb1">
+                            <label htmlFor="outline-regex">
+                              outline regex:
+                            </label>
+                            <input
+                              id="outline-regex"
+                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+                              autoCapitalize="off"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              onChange={onChangeEntryRegex}
+                              placeholder=".*[DZ]$"
+                              spellCheck={false}
+                              type="text"
+                              value={rulesWithDataState.outlineRegexText}
                             ></input>
                           </p>
                         </div>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -211,44 +211,6 @@ const CustomLessonGenerator = ({
                       Language is messy. These rules use heuristics and make
                       imperfect guesses.
                     </p>
-                    <div className="flex flex-wrap gap-4">
-                      <p className="mb1 flex items-center">
-                        <select
-                          id={"outlineRule"}
-                          name={"outlineRule"}
-                          value={outlineRule}
-                          onChange={onChangeOutlineRule}
-                          data-rule-status={outlineRule}
-                          className="rule-select text-small form-control w-80 mr1"
-                        >
-                          <option value="on">On</option>
-                          <option value="off">Off</option>
-                          <option value="ignored">Ignored</option>
-                        </select>
-                        <label
-                          className="dib lh-single"
-                          htmlFor={"outlineRule"}
-                        >
-                          Outline
-                        </label>
-                      </p>
-                      <p className="flex flex-wrap items-center gap-4 mb1">
-                        <label htmlFor="outline-regex">
-                          Outline regex:
-                        </label>
-                        <input
-                          id="outline-regex"
-                          className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden"
-                          autoCapitalize="off"
-                          autoComplete="off"
-                          autoCorrect="off"
-                          onChange={onChangeOutlineRegex}
-                          spellCheck={false}
-                          type="text"
-                          value={outlineRegexText}
-                        ></input>
-                      </p>
-                    </div>
                     <div className="pb1 columns-2 columns-xs gap-4">
                       {availableRulePrettyNames
                         .slice(0, numberOfVisibleOptions)
@@ -268,18 +230,58 @@ const CustomLessonGenerator = ({
                           More options…
                         </p>
                       </summary>
-                      <div className="pb3 columns-2 columns-xs gap-4">
-                        {availableRulePrettyNames
-                          .slice(numberOfVisibleOptions)
-                          .map((rule) => (
-                            <RuleOptions
-                              key={rule.ruleName}
-                              ruleName={rule.ruleName}
-                              prettyName={rule.prettyName}
-                              rulesState={rulesState}
-                              onChangeRuleStatus={onChangeRuleStatus}
-                            />
-                          ))}
+                      <div>
+                        <div className="columns-2 columns-xs gap-4 pb1">
+                          {availableRulePrettyNames
+                            .slice(numberOfVisibleOptions)
+                            .map((rule) => (
+                              <RuleOptions
+                                key={rule.ruleName}
+                                ruleName={rule.ruleName}
+                                prettyName={rule.prettyName}
+                                rulesState={rulesState}
+                                onChangeRuleStatus={onChangeRuleStatus}
+                              />
+                            ))}
+                        </div>
+                        <div className="pb3 flex flex-wrap gap-4">
+                          <p className="mb1 flex items-center">
+                            <select
+                              id={"outlineRule"}
+                              name={"outlineRule"}
+                              value={outlineRule}
+                              onChange={onChangeOutlineRule}
+                              data-rule-status={outlineRule}
+                              className="rule-select text-small form-control w-80 mr1"
+                            >
+                              <option value="on">On</option>
+                              <option value="off">Off</option>
+                              <option value="ignored">Ignored</option>
+                            </select>
+                            <label
+                              className="dib lh-single"
+                              htmlFor={"outlineRule"}
+                            >
+                              has outline matching
+                            </label>
+                          </p>
+                          <p className="flex flex-wrap items-center gap-4 mb1">
+                            <label htmlFor="outline-regex">
+                              outline regex:
+                            </label>
+                            <input
+                              id="outline-regex"
+                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+                              autoCapitalize="off"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              onChange={onChangeOutlineRegex}
+                              spellCheck={false}
+                              type="text"
+                              value={outlineRegexText}
+                            ></input>
+                          </p>
+                        </div>
                       </div>
                     </details>
                     <p>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -82,19 +82,7 @@ const CustomLessonGenerator = ({
     mainHeading.current?.focus();
   }, []);
 
-  const onChangeOutlineRule: React.ChangeEventHandler<HTMLSelectElement> = (
-    event
-  ) => {
-    dispatchRulesWithData({
-      type: rulesWithDataActions.setRuleWithDataStatus,
-      payload: {
-        ruleName: event.target.name,
-        ruleStatus: event.target.value,
-      },
-    });
-  };
-
-  const onChangeTranslationRule: React.ChangeEventHandler<HTMLSelectElement> = (
+  const onChangeEntryRegexRule: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
     dispatchRulesWithData({
@@ -282,7 +270,7 @@ const CustomLessonGenerator = ({
                               id={"outlineRule"}
                               name={"outlineRule"}
                               value={rulesWithDataState.outlineRule}
-                              onChange={onChangeOutlineRule}
+                              onChange={onChangeEntryRegexRule}
                               data-rule-status={rulesWithDataState.outlineRule}
                               className="rule-select text-small form-control w-80 mr1"
                             >
@@ -321,7 +309,7 @@ const CustomLessonGenerator = ({
                               id={"translationRule"}
                               name={"translationRule"}
                               value={rulesWithDataState.translationRule}
-                              onChange={onChangeTranslationRule}
+                              onChange={onChangeEntryRegexRule}
                               data-rule-status={
                                 rulesWithDataState.translationRule
                               }

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -53,7 +53,9 @@ const CustomLessonGenerator = ({
   const [hideHelp, setHideHelp] = useState(true);
 
   const [outlineRule, setOutlineRule] = useState<RuleStatus>("ignored");
+  const [translationRule, setTranslationRule] = useState<RuleStatus>("ignored");
   const [outlineRegexText, setOutlineRegexText] = useState("");
+  const [translationRegexText, setTranslationRegexText] = useState("");
 
   const toggleHideHelp = () => {
     setHideHelp(!hideHelp);
@@ -102,6 +104,28 @@ const CustomLessonGenerator = ({
     setOutlineRegexText(event.target.value);
   };
 
+  const onChangeTranslationRule: React.ChangeEventHandler<HTMLSelectElement> = (
+    event
+  ) => {
+    switch (event.target.value) {
+      case "on":
+        setTranslationRule("on");
+        break;
+      case "off":
+        setTranslationRule("off");
+        break;
+      case "ignored":
+        setTranslationRule("ignored");
+        break;
+    }
+  };
+
+  const onChangeTranslationRegex: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setTranslationRegexText(event.target.value);
+  };
+
   const [rulesSettings, setRulesSettings] = useLocalStorage(
     "rules",
     defaultRules
@@ -120,6 +144,8 @@ const CustomLessonGenerator = ({
   const regexRules: RegexRules = {
     outlineRule,
     outlineRegexText,
+    translationRule,
+    translationRegexText,
   };
 
   const buildLesson = () => {
@@ -244,7 +270,8 @@ const CustomLessonGenerator = ({
                               />
                             ))}
                         </div>
-                        <div className="pb3 flex flex-wrap gap-4">
+                        <p className="mb1 flex items-center">Advanced:</p>
+                        <div className="flex flex-wrap gap-4">
                           <p className="mb1 flex items-center">
                             <select
                               id={"outlineRule"}
@@ -276,9 +303,49 @@ const CustomLessonGenerator = ({
                               autoComplete="off"
                               autoCorrect="off"
                               onChange={onChangeOutlineRegex}
+                              placeholder=".*[DZ]$"
                               spellCheck={false}
                               type="text"
                               value={outlineRegexText}
+                            ></input>
+                          </p>
+                        </div>
+                        <div className="pb3 flex flex-wrap gap-4">
+                          <p className="mb1 flex items-center">
+                            <select
+                              id={"translationRule"}
+                              name={"translationRule"}
+                              value={translationRule}
+                              onChange={onChangeTranslationRule}
+                              data-rule-status={translationRule}
+                              className="rule-select text-small form-control w-80 mr1"
+                            >
+                              <option value="on">On</option>
+                              <option value="off">Off</option>
+                              <option value="ignored">Ignored</option>
+                            </select>
+                            <label
+                              className="dib lh-single"
+                              htmlFor={"translationRule"}
+                            >
+                              has translation matching
+                            </label>
+                          </p>
+                          <p className="flex flex-wrap items-center gap-4 mb1">
+                            <label htmlFor="translation-regex">
+                              translation regex:
+                            </label>
+                            <input
+                              id="translation-regex"
+                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+                              autoCapitalize="off"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              onChange={onChangeTranslationRegex}
+                              placeholder=".*(ation|cean)$"
+                              spellCheck={false}
+                              type="text"
+                              value={translationRegexText}
                             ></input>
                           </p>
                         </div>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -264,85 +264,89 @@ const CustomLessonGenerator = ({
                             ))}
                         </div>
                         <p className="mb1 flex items-center">Advanced:</p>
-                        <div className="flex flex-wrap gap-4">
-                          <p className="mb1 flex items-center">
-                            <select
-                              id={"translationMatching"}
-                              name={"translationMatching"}
-                              value={rulesWithDataState.translationMatching}
-                              onChange={onChangeEntryRegexRule}
-                              data-rule-status={
-                                rulesWithDataState.translationMatching
-                              }
-                              className="rule-select text-small form-control w-80 mr1"
-                            >
-                              <option value="on">On</option>
-                              <option value="off">Off</option>
-                              <option value="ignored">Ignored</option>
-                            </select>
-                            <label
-                              className="dib lh-single"
-                              htmlFor={"translationMatching"}
-                            >
-                              has translation matching
-                            </label>
-                          </p>
-                          <p className="flex flex-wrap items-center gap-4 mb1">
-                            <label htmlFor="translation-regex">
-                              translation regex:
-                            </label>
-                            <input
-                              id="translation-regex"
-                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
-                              autoCapitalize="off"
-                              autoComplete="off"
-                              autoCorrect="off"
-                              onChange={onChangeEntryRegex}
-                              placeholder=".*(ation|cean)$"
-                              spellCheck={false}
-                              type="text"
-                              value={rulesWithDataState.translationRegexText}
-                            ></input>
-                          </p>
-                        </div>
-                        <div className="pb3 flex flex-wrap gap-4">
-                          <p className="mb1 flex items-center">
-                            <select
-                              id={"outlineMatching"}
-                              name={"outlineMatching"}
-                              value={rulesWithDataState.outlineMatching}
-                              onChange={onChangeEntryRegexRule}
-                              data-rule-status={rulesWithDataState.outlineMatching}
-                              className="rule-select text-small form-control w-80 mr1"
-                            >
-                              <option value="on">On</option>
-                              <option value="off">Off</option>
-                              <option value="ignored">Ignored</option>
-                            </select>
-                            <label
-                              className="dib lh-single"
-                              htmlFor={"outlineMatching"}
-                            >
-                              has outline matching
-                            </label>
-                          </p>
-                          <p className="flex flex-wrap items-center gap-4 mb1">
-                            <label htmlFor="outline-regex">
-                              outline regex:
-                            </label>
-                            <input
-                              id="outline-regex"
-                              className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
-                              autoCapitalize="off"
-                              autoComplete="off"
-                              autoCorrect="off"
-                              onChange={onChangeEntryRegex}
-                              placeholder=".*[DZ]$"
-                              spellCheck={false}
-                              type="text"
-                              value={rulesWithDataState.outlineRegexText}
-                            ></input>
-                          </p>
+                        <div className="pb3">
+                          <div className="flex flex-wrap gap-4">
+                            <p className="mb1 flex items-center">
+                              <select
+                                id={"translationMatching"}
+                                name={"translationMatching"}
+                                value={rulesWithDataState.translationMatching}
+                                onChange={onChangeEntryRegexRule}
+                                data-rule-status={
+                                  rulesWithDataState.translationMatching
+                                }
+                                className="rule-select text-small form-control w-80 mr1"
+                              >
+                                <option value="on">On</option>
+                                <option value="off">Off</option>
+                                <option value="ignored">Ignored</option>
+                              </select>
+                              <label
+                                className="dib lh-single"
+                                htmlFor={"translationMatching"}
+                              >
+                                has translation matching
+                              </label>
+                            </p>
+                            <p className="flex flex-wrap items-center gap-4 mb1">
+                              <label htmlFor="translation-regex">
+                                translation regex:
+                              </label>
+                              <input
+                                id="translation-regex"
+                                className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+                                autoCapitalize="off"
+                                autoComplete="off"
+                                autoCorrect="off"
+                                onChange={onChangeEntryRegex}
+                                placeholder=".*(ation|cean)$"
+                                spellCheck={false}
+                                type="text"
+                                value={rulesWithDataState.translationRegexText}
+                              ></input>
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap gap-4">
+                            <p className="mb1 flex items-center">
+                              <select
+                                id={"outlineMatching"}
+                                name={"outlineMatching"}
+                                value={rulesWithDataState.outlineMatching}
+                                onChange={onChangeEntryRegexRule}
+                                data-rule-status={
+                                  rulesWithDataState.outlineMatching
+                                }
+                                className="rule-select text-small form-control w-80 mr1"
+                              >
+                                <option value="on">On</option>
+                                <option value="off">Off</option>
+                                <option value="ignored">Ignored</option>
+                              </select>
+                              <label
+                                className="dib lh-single"
+                                htmlFor={"outlineMatching"}
+                              >
+                                has outline matching
+                              </label>
+                            </p>
+                            <p className="flex flex-wrap items-center gap-4 mb1">
+                              <label htmlFor="outline-regex">
+                                outline regex:
+                              </label>
+                              <input
+                                id="outline-regex"
+                                className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+                                autoCapitalize="off"
+                                autoComplete="off"
+                                autoCorrect="off"
+                                onChange={onChangeEntryRegex}
+                                placeholder=".*[DZ]$"
+                                spellCheck={false}
+                                type="text"
+                                value={rulesWithDataState.outlineRegexText}
+                              ></input>
+                            </p>
+                          </div>
                         </div>
                       </div>
                     </details>

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -58,6 +58,8 @@ const CustomLessonGenerator = ({
   const mainHeading = useRef<HTMLHeadingElement>(null);
 
   const [hideHelp, setHideHelp] = useState(true);
+  const [regexRuleIgnoredButHasText, setRegexRuleIgnoredButHasText] =
+    useState(false);
 
   const toggleHideHelp = () => {
     setHideHelp(!hideHelp);
@@ -87,6 +89,7 @@ const CustomLessonGenerator = ({
   const onChangeEntryRegexRule: React.ChangeEventHandler<HTMLSelectElement> = (
     event
   ) => {
+    setRegexRuleIgnoredButHasText(false);
     dispatchRulesWithData({
       type: rulesWithDataActions.setRuleWithDataStatus,
       payload: {
@@ -99,6 +102,7 @@ const CustomLessonGenerator = ({
   const onChangeEntryRegex: React.ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
+    setRegexRuleIgnoredButHasText(false);
     dispatchRulesWithData({
       type: rulesWithDataActions.setRegexRuleData,
       payload: {
@@ -143,6 +147,14 @@ const CustomLessonGenerator = ({
 
   const buildLesson = () => {
     generateCustomLesson(globalLookupDictionary, onRules, regexRules);
+    if (
+      (rulesWithDataState.translationRegexText.length > 0 &&
+        rulesWithDataState.translationMatching === "ignored") ||
+      (rulesWithDataState.outlineRegexText.length > 0 &&
+        rulesWithDataState.outlineMatching === "ignored")
+    ) {
+      setRegexRuleIgnoredButHasText(true);
+    }
     setRulesSettings(rulesState);
     setRulesWithDataSettings(rulesWithDataState);
   };
@@ -311,6 +323,13 @@ const CustomLessonGenerator = ({
                         Start generated lesson
                       </Link>
                     </p>
+                    {regexRuleIgnoredButHasText && (
+                      <p>
+                        Note: an advanced setting is set to “ignored” but has
+                        text. You can change the setting to “on” or “off” or
+                        delete the text to hide this message.
+                      </p>
+                    )}
                     <p>
                       {customLessonMaterialValidationState === "fail" && (
                         <>

--- a/src/pages/lessons/custom/GeneratorHelp.tsx
+++ b/src/pages/lessons/custom/GeneratorHelp.tsx
@@ -589,6 +589,38 @@ const GeneratorHelp = ({ hideHelp, containerId }: Props) => (
           <code>&#123;MODE:SNAKE&#125;</code>.
         </p>
       </RuleBlurb>
+
+      <RuleHeading>“has outline matching”</RuleHeading>
+      <RuleBlurb>
+        <p className="mb0">
+          This rule looks for entries where the outline or strokes match the
+          regular expression provided. This{" "}
+          <a
+            href="https://www.sitepoint.com/learn-regex/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            external link to learn more regular expressions opens in a new tab
+          </a>
+          .
+        </p>
+      </RuleBlurb>
+
+      <RuleHeading>“has translation matching”</RuleHeading>
+      <RuleBlurb>
+        <p className="mb0">
+          This rule looks for entries where the translation or words match the
+          regular expression provided. This{" "}
+          <a
+            href="https://www.sitepoint.com/learn-regex/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            external link to learn more regular expressions opens in a new tab
+          </a>
+          .
+        </p>
+      </RuleBlurb>
     </div>
   </div>
 );

--- a/src/pages/lessons/custom/generator/components/RegexRuleSetting.tsx
+++ b/src/pages/lessons/custom/generator/components/RegexRuleSetting.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import type { RuleStatus } from "../types";
+
+type Props = {
+  regexRuleName: "outlineMatching" | "translationMatching";
+  regexRuleStatus: RuleStatus;
+  regexRuleDataValue: string;
+  entryPart: "outline" | "translation";
+  onChangeEntryRegexStatus: any;
+  onChangeEntryRegexData: any;
+  placeholder: string;
+};
+
+const RegexRuleSettings = ({
+  regexRuleName,
+  regexRuleStatus,
+  regexRuleDataValue,
+  entryPart,
+  onChangeEntryRegexStatus,
+  onChangeEntryRegexData,
+  placeholder,
+}: Props) => (
+  <div className="flex flex-wrap gap-4">
+    <p className="mb1 flex items-center">
+      <select
+        id={regexRuleName}
+        name={regexRuleName} // translationMatching
+        value={regexRuleStatus} // "on"
+        onChange={onChangeEntryRegexStatus}
+        data-rule-status={regexRuleStatus}
+        className="rule-select text-small form-control w-80 mr1"
+      >
+        <option value="on">On</option>
+        <option value="off">Off</option>
+        <option value="ignored">Ignored</option>
+      </select>
+      <label className="dib lh-single" htmlFor={regexRuleName}>
+        has {entryPart} matching
+      </label>
+    </p>
+    <p className="flex flex-wrap items-center gap-4 mb1">
+      <label htmlFor={`${entryPart}-regex`}>{entryPart} regex:</label>
+      <input
+        id={`${entryPart}-regex`}
+        className="caret-color bg-white dark:bg-coolgrey-1000 input-textarea underline overflow-hidden w-336"
+        autoCapitalize="off"
+        autoComplete="off"
+        autoCorrect="off"
+        onChange={onChangeEntryRegexData}
+        placeholder={placeholder}
+        spellCheck={false}
+        type="text"
+        value={regexRuleDataValue} // "(tion|cean)"
+      ></input>
+    </p>
+  </div>
+);
+
+export default RegexRuleSettings;

--- a/src/pages/lessons/custom/generator/rulesWithDataActions.ts
+++ b/src/pages/lessons/custom/generator/rulesWithDataActions.ts
@@ -1,0 +1,4 @@
+export const actions = {
+  setRuleWithDataStatus: "setRuleWithDataStatus",
+  setRegexRuleData: "setRegexRuleData",
+};

--- a/src/pages/lessons/custom/generator/rulesWithDataReducer.ts
+++ b/src/pages/lessons/custom/generator/rulesWithDataReducer.ts
@@ -3,16 +3,16 @@ import type { RuleStatus } from "./types";
 
 export type RulesWithData = {
   outlineRegexText: string;
-  outlineRule: RuleStatus;
+  outlineMatching: RuleStatus;
   translationRegexText: string;
-  translationRule: RuleStatus;
+  translationMatching: RuleStatus;
 };
 
 export const defaultState: RulesWithData = {
   outlineRegexText: "",
-  outlineRule: "ignored",
+  outlineMatching: "ignored",
   translationRegexText: "",
-  translationRule: "ignored",
+  translationMatching: "ignored",
 };
 
 export const initConfig = (state: any) => ({
@@ -23,7 +23,7 @@ export const initConfig = (state: any) => ({
 const setRuleWithDataStatus = (
   state: RulesWithData,
   payload: {
-    ruleName: "outlineRule" | "translationRule";
+    ruleName: "outlineMatching" | "translationMatching";
     ruleStatus: RuleStatus;
   }
 ) => {

--- a/src/pages/lessons/custom/generator/rulesWithDataReducer.ts
+++ b/src/pages/lessons/custom/generator/rulesWithDataReducer.ts
@@ -1,0 +1,60 @@
+import { actions } from "./rulesWithDataActions";
+import type { RuleStatus } from "./types";
+
+export type RulesWithData = {
+  outlineRegexText: string;
+  outlineRule: RuleStatus;
+  translationRegexText: string;
+  translationRule: RuleStatus;
+};
+
+export const defaultState: RulesWithData = {
+  outlineRegexText: "",
+  outlineRule: "ignored",
+  translationRegexText: "",
+  translationRule: "ignored",
+};
+
+export const initConfig = (state: any) => ({
+  ...defaultState,
+  ...state,
+});
+
+const setRuleWithDataStatus = (
+  state: RulesWithData,
+  payload: {
+    ruleName: "outlineRule" | "translationRule";
+    ruleStatus: RuleStatus;
+  }
+) => {
+  return {
+    ...state,
+    [payload.ruleName]: payload.ruleStatus,
+  };
+};
+
+const setRegexRuleData = (
+  state: RulesWithData,
+  payload: {
+    entryPart: "outline" | "translation";
+    regexText: string;
+  }
+) => {
+  return {
+    ...state,
+    [`${payload.entryPart}RegexText`]: payload.regexText,
+  };
+};
+
+export const rulesWithDataReducer = (state: RulesWithData, action: any) => {
+  switch (action?.type) {
+    case actions.setRuleWithDataStatus:
+      return setRuleWithDataStatus(state, action.payload);
+
+    case actions.setRegexRuleData:
+      return setRegexRuleData(state, action.payload);
+
+    default:
+      return state;
+  }
+};

--- a/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
+++ b/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
@@ -70,7 +70,7 @@ function generateCustomLesson(
     }
   }
 
-  const rulesFilteredVocab = [...entriesList.slice(0, maxItems)]
+  const rulesFilteredVocab = [...entriesList]
     .filter((materialItem) => ruleFilters(materialItem))
     .filter((materialItem) => {
       if (
@@ -111,7 +111,8 @@ function generateCustomLesson(
       }
 
       return true;
-    });
+    })
+    .slice(0, maxItems);
 
   const rulesFilteredMaterial = rulesFilteredVocab.map(
     ([outline, translation]) => ({ phrase: translation, stroke: outline })

--- a/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
+++ b/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
@@ -20,6 +20,8 @@ import type {
 export type RegexRules = {
   outlineRule: RuleStatus;
   outlineRegexText: string;
+  translationRule: RuleStatus;
+  translationRegexText: string;
 };
 
 const translationExclusions = ["pos", "sol", "spas", "pros"];
@@ -86,6 +88,26 @@ function generateCustomLesson(
 
       if (regexRules?.outlineRule === "off") {
         return !materialItem[0].match(regexp);
+      }
+
+      return true;
+    })
+    .filter((materialItem) => {
+      if (
+        regexRules?.translationRule === "ignored" ||
+        !regexRules?.translationRegexText
+      ) {
+        return true;
+      }
+
+      const regexp = new RegExp(regexRules.translationRegexText, "g");
+
+      if (regexRules?.translationRule === "on") {
+        return materialItem[1].match(regexp);
+      }
+
+      if (regexRules?.translationRule === "off") {
+        return !materialItem[1].match(regexp);
       }
 
       return true;

--- a/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
+++ b/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
@@ -10,13 +10,24 @@ import type {
   Translation,
 } from "../../../../../types";
 
-import type { FilterAndExpectation, Rules, RuleFunctionsTypes } from "../types";
+import type {
+  FilterAndExpectation,
+  Rules,
+  RuleStatus,
+  RuleFunctionsTypes,
+} from "../types";
+
+export type RegexRules = {
+  outlineRule: RuleStatus;
+  outlineRegexText: string;
+};
 
 const translationExclusions = ["pos", "sol", "spas", "pros"];
 
 function generateCustomLesson(
   globalLookupDictionary: LookupDictWithNamespacedDicts,
-  rules: Rules
+  rules: Rules,
+  regexRules: RegexRules
 ) {
   const filters: FilterAndExpectation[] = [];
 
@@ -57,9 +68,28 @@ function generateCustomLesson(
     }
   }
 
-  const rulesFilteredVocab = [...entriesList.slice(0, maxItems)].filter(
-    (materialItem) => ruleFilters(materialItem)
-  );
+  const rulesFilteredVocab = [...entriesList.slice(0, maxItems)]
+    .filter((materialItem) => ruleFilters(materialItem))
+    .filter((materialItem) => {
+      if (
+        regexRules?.outlineRule === "ignored" ||
+        !regexRules?.outlineRegexText
+      ) {
+        return true;
+      }
+
+      const regexp = new RegExp(regexRules.outlineRegexText, "g");
+
+      if (regexRules?.outlineRule === "on") {
+        return materialItem[0].match(regexp);
+      }
+
+      if (regexRules?.outlineRule === "off") {
+        return !materialItem[0].match(regexp);
+      }
+
+      return true;
+    });
 
   const rulesFilteredMaterial = rulesFilteredVocab.map(
     ([outline, translation]) => ({ phrase: translation, stroke: outline })

--- a/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
+++ b/src/pages/lessons/custom/generator/utilities/generateCustomLesson.ts
@@ -18,9 +18,9 @@ import type {
 } from "../types";
 
 export type RegexRules = {
-  outlineRule: RuleStatus;
+  outlineMatching: RuleStatus;
   outlineRegexText: string;
-  translationRule: RuleStatus;
+  translationMatching: RuleStatus;
   translationRegexText: string;
 };
 
@@ -74,7 +74,7 @@ function generateCustomLesson(
     .filter((materialItem) => ruleFilters(materialItem))
     .filter((materialItem) => {
       if (
-        regexRules?.outlineRule === "ignored" ||
+        regexRules?.outlineMatching === "ignored" ||
         !regexRules?.outlineRegexText
       ) {
         return true;
@@ -82,11 +82,11 @@ function generateCustomLesson(
 
       const regexp = new RegExp(regexRules.outlineRegexText, "g");
 
-      if (regexRules?.outlineRule === "on") {
+      if (regexRules?.outlineMatching === "on") {
         return materialItem[0].match(regexp);
       }
 
-      if (regexRules?.outlineRule === "off") {
+      if (regexRules?.outlineMatching === "off") {
         return !materialItem[0].match(regexp);
       }
 
@@ -94,7 +94,7 @@ function generateCustomLesson(
     })
     .filter((materialItem) => {
       if (
-        regexRules?.translationRule === "ignored" ||
+        regexRules?.translationMatching === "ignored" ||
         !regexRules?.translationRegexText
       ) {
         return true;
@@ -102,11 +102,11 @@ function generateCustomLesson(
 
       const regexp = new RegExp(regexRules.translationRegexText, "g");
 
-      if (regexRules?.translationRule === "on") {
+      if (regexRules?.translationMatching === "on") {
         return materialItem[1].match(regexp);
       }
 
-      if (regexRules?.translationRule === "off") {
+      if (regexRules?.translationMatching === "off") {
         return !materialItem[1].match(regexp);
       }
 

--- a/src/pages/lessons/utilities/customiseLesson.ts
+++ b/src/pages/lessons/utilities/customiseLesson.ts
@@ -2,7 +2,7 @@ import Zipper from "../../../utils/zipper";
 
 import type { CustomLesson } from "../../../types";
 
-function generateCustomLesson() {
+function customiseLesson() {
   // @ts-ignore 'this' implicitly has type 'any' because it does not have a type annotation.
   const existingLesson = this.state.lesson;
 
@@ -33,4 +33,4 @@ function generateCustomLesson() {
   });
 }
 
-export default generateCustomLesson;
+export default customiseLesson;


### PR DESCRIPTION
This PR adds regex rules to the lesson generator so you can generate material with particular outlines or translations that match your provided regular expressions:

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/2476974/235619577-e1a26000-c8fe-448a-8249-49a6b1575a51.png">

This PR also:

- adds a story for the lesson generator and its help panel
- renames a misleading function name in a module