### PR TITLE
Add some related words to Lookup page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2326,8 +2326,6 @@ class App extends Component {
                     <DocumentTitle title={'Typey Type | Lookup'}>
                       <ErrorBoundary>
                         <AsyncLookup
-                          setAnnouncementMessage={function () { setAnnouncementMessage(app, this) }}
-                          setAnnouncementMessageString={setAnnouncementMessageString.bind(this)}
                           fetchAndSetupGlobalDict={this.fetchAndSetupGlobalDict.bind(this)}
                           globalLookupDictionary={this.state.globalLookupDictionary}
                           globalLookupDictionaryLoaded={this.state.globalLookupDictionaryLoaded}

--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,7 @@ import sortLesson from './utils/lessons/sortLesson';
 import Zipper from './utils/zipper';
 import generateCustomLesson from './pages/lessons/custom/generator/utilities/generateCustomLesson';
 import customiseLesson from './pages/lessons/utilities/customiseLesson';
+import setCustomLessonContent from './pages/lessons/utilities/setCustomLessonContent';
 
 const AsyncBreak = Loadable({
   loader: () => import("./pages/break/Break"),
@@ -2333,6 +2334,7 @@ class App extends Component {
                           globalUserSettings={this.state.globalUserSettings}
                           lookupTerm={this.state.lookupTerm}
                           personalDictionaries={this.state.personalDictionaries}
+                          setCustomLessonContent={setCustomLessonContent.bind(this)}
                           stenoHintsOnTheFly={stenohintsonthefly}
                           updateGlobalLookupDictionary={this.updateGlobalLookupDictionary.bind(this)}
                           updatePersonalDictionaries={this.updatePersonalDictionaries.bind(this)}

--- a/src/components/StrokesForWords.js
+++ b/src/components/StrokesForWords.js
@@ -79,6 +79,10 @@ class StrokesForWords extends Component {
         .filter(row => row[2] === SOURCE_NAMESPACES.get("user") || !(misstrokesJSON[row[0]] && modifiedWordOrPhrase === misstrokesJSON[row[0]]))
     }
 
+    if (this.props.trackPhrase) {
+      this.props.trackPhrase(phrase);
+    }
+
     this.setState({
       modifiedWordOrPhrase: modifiedWordOrPhrase,
       phrase: phrase,
@@ -137,16 +141,6 @@ class StrokesForWords extends Component {
             showMisstrokesInLookup={this.props.globalUserSettings?.showMisstrokesInLookup}
           />
 
-            </div>
-            <div className="mt18 mw-336 flex-grow">
-              {!!this.state.wordFamilyGroup ? (
-                <div>
-                  <p className="mb1">Some related words:</p>
-                  <pre id="js-word-family-group" className="fw4">
-                    {this.state.wordFamilyGroup}
-                  </pre>
-                </div>
-              ) : <div id="js-word-family-group" className="avoid-clipboard-error-on-missing-target"></div>}
             </div>
           </div>
         </React.Fragment>

--- a/src/components/StrokesForWords.js
+++ b/src/components/StrokesForWords.js
@@ -13,6 +13,7 @@ import LookupResultsOutlinesAndDicts from './LookupResultsOutlinesAndDicts';
 class StrokesForWords extends Component {
   state = {
     modifiedWordOrPhrase: "",
+    wordFamilyGroup: "",
     phrase: "",
     listOfStrokesAndDicts: []
   }
@@ -42,6 +43,30 @@ class StrokesForWords extends Component {
     this.updateWordsForStrokes(phrase);
   }
 
+  getWordFamilyGroup(phrase, globalLookupDictionary) {
+    const commonFamilyGroupEndings = [
+      "ing",
+      "ed",
+      "ment",
+      "'s",
+      "ly",
+      "ion",
+      "s",
+      "er"
+    ];
+
+    const familyGroup = [];
+    commonFamilyGroupEndings.forEach((ending => {
+      const phrasePlusEnding = phrase + ending;
+      if (globalLookupDictionary.get(phrasePlusEnding)) {
+        familyGroup.push(phrasePlusEnding);
+      }
+    }))
+
+    const result = familyGroup.join("\n");
+    return result;
+  }
+
   updateWordsForStrokes(phrase) {
     if (this.props.onChange) {
       this.props.onChange(phrase);
@@ -57,9 +82,11 @@ class StrokesForWords extends Component {
     this.setState({
       modifiedWordOrPhrase: modifiedWordOrPhrase,
       phrase: phrase,
-      listOfStrokesAndDicts: listOfStrokesAndDicts
+      listOfStrokesAndDicts: listOfStrokesAndDicts,
+      wordFamilyGroup: this.getWordFamilyGroup(phrase, this.props.globalLookupDictionary),
     })
   }
+
 
   render () {
     const stenoLayout = (this.props.userSettings && this.props.userSettings.stenoLayout) ? this.props.userSettings.stenoLayout : 'stenoLayoutAmericanSteno';
@@ -71,6 +98,9 @@ class StrokesForWords extends Component {
     return (
       this.props.globalLookupDictionaryLoaded ?
         <React.Fragment>
+          <div className="flex flex-wrap justify-between">
+            <div className="mw-584 w-100 flex-grow mr3 min-h-384">
+
           <label htmlFor="words-for-strokes" className="input-textarea-label input-textarea-label--large mb1 overflow-hidden">Enter words to look up</label>
           <textarea
             autoCapitalize="off"
@@ -106,6 +136,19 @@ class StrokesForWords extends Component {
           <PloverMisstrokesDetail
             showMisstrokesInLookup={this.props.globalUserSettings?.showMisstrokesInLookup}
           />
+
+            </div>
+            <div className="mt18 mw-336 flex-grow">
+              {!!this.state.wordFamilyGroup && (
+                <div>
+                  <p className="mb1">Some related words:</p>
+                  <pre id="js-word-family-group" className="fw4">
+                    {this.state.wordFamilyGroup}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </div>
         </React.Fragment>
       : (
         <>Loading…</>

--- a/src/components/StrokesForWords.js
+++ b/src/components/StrokesForWords.js
@@ -139,14 +139,14 @@ class StrokesForWords extends Component {
 
             </div>
             <div className="mt18 mw-336 flex-grow">
-              {!!this.state.wordFamilyGroup && (
+              {!!this.state.wordFamilyGroup ? (
                 <div>
                   <p className="mb1">Some related words:</p>
                   <pre id="js-word-family-group" className="fw4">
                     {this.state.wordFamilyGroup}
                   </pre>
                 </div>
-              )}
+              ) : <div id="js-word-family-group" className="avoid-clipboard-error-on-missing-target"></div>}
             </div>
           </div>
         </React.Fragment>

--- a/src/components/StrokesForWords.js
+++ b/src/components/StrokesForWords.js
@@ -13,7 +13,6 @@ import LookupResultsOutlinesAndDicts from './LookupResultsOutlinesAndDicts';
 class StrokesForWords extends Component {
   state = {
     modifiedWordOrPhrase: "",
-    wordFamilyGroup: "",
     phrase: "",
     listOfStrokesAndDicts: []
   }
@@ -43,30 +42,6 @@ class StrokesForWords extends Component {
     this.updateWordsForStrokes(phrase);
   }
 
-  getWordFamilyGroup(phrase, globalLookupDictionary) {
-    const commonFamilyGroupEndings = [
-      "ing",
-      "ed",
-      "ment",
-      "'s",
-      "ly",
-      "ion",
-      "s",
-      "er"
-    ];
-
-    const familyGroup = [];
-    commonFamilyGroupEndings.forEach((ending => {
-      const phrasePlusEnding = phrase + ending;
-      if (globalLookupDictionary.get(phrasePlusEnding)) {
-        familyGroup.push(phrasePlusEnding);
-      }
-    }))
-
-    const result = familyGroup.join("\n");
-    return result;
-  }
-
   updateWordsForStrokes(phrase) {
     if (this.props.onChange) {
       this.props.onChange(phrase);
@@ -86,11 +61,9 @@ class StrokesForWords extends Component {
     this.setState({
       modifiedWordOrPhrase: modifiedWordOrPhrase,
       phrase: phrase,
-      listOfStrokesAndDicts: listOfStrokesAndDicts,
-      wordFamilyGroup: this.getWordFamilyGroup(phrase, this.props.globalLookupDictionary),
+      listOfStrokesAndDicts: listOfStrokesAndDicts
     })
   }
-
 
   render () {
     const stenoLayout = (this.props.userSettings && this.props.userSettings.stenoLayout) ? this.props.userSettings.stenoLayout : 'stenoLayoutAmericanSteno';
@@ -102,9 +75,6 @@ class StrokesForWords extends Component {
     return (
       this.props.globalLookupDictionaryLoaded ?
         <React.Fragment>
-          <div className="flex flex-wrap justify-between">
-            <div className="mw-584 w-100 flex-grow mr3 min-h-384">
-
           <label htmlFor="words-for-strokes" className="input-textarea-label input-textarea-label--large mb1 overflow-hidden">Enter words to look up</label>
           <textarea
             autoCapitalize="off"
@@ -140,9 +110,6 @@ class StrokesForWords extends Component {
           <PloverMisstrokesDetail
             showMisstrokesInLookup={this.props.globalUserSettings?.showMisstrokesInLookup}
           />
-
-            </div>
-          </div>
         </React.Fragment>
       : (
         <>Loading…</>

--- a/src/index.scss
+++ b/src/index.scss
@@ -837,6 +837,7 @@ input:focus::placeholder {
 // .mt8     { margin-top: 64px; }
 .mt10    { margin-top: 80px; }
 // .mt11    { margin-top: 88px; }
+.mt18    { margin-top: 144px; }
 
 .my05 {
   padding-top: 4px;

--- a/src/pages/lessons/utilities/setCustomLessonContent.ts
+++ b/src/pages/lessons/utilities/setCustomLessonContent.ts
@@ -1,0 +1,33 @@
+import Zipper from "../../../utils/zipper";
+
+import type { CustomLesson, MaterialItem } from "../../../types";
+
+function setCustomLessonContent(material: MaterialItem[]) {
+  const customisedLesson: CustomLesson = {
+    sourceMaterial: material.slice(),
+    presentedMaterial: material.slice(),
+    settings: { ignoredChars: "" },
+    title: "Custom", // "Start custom lesson" overrides this anyway
+    subtitle: "",
+    // @ts-ignore FIXME: might be a Zipper typing issue
+    newPresentedMaterial: new Zipper(material.slice()),
+    path: process.env.PUBLIC_URL + "/lessons/custom",
+  };
+
+  const validationState = "success";
+
+  const newCustomLessonMaterial = customisedLesson.presentedMaterial
+    .map((materialItem) => `${materialItem.phrase}	${materialItem.stroke}`)
+    .join("\n");
+
+  // @ts-ignore 'this' implicitly has type 'any' because it does not have a type annotation.
+  this.setState({
+    lesson: customisedLesson,
+    currentPhraseID: 0,
+    customLesson: customisedLesson,
+    customLessonMaterial: newCustomLessonMaterial,
+    customLessonMaterialValidationState: validationState,
+  });
+}
+
+export default setCustomLessonContent;

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -86,6 +86,8 @@ const Lookup = ({
     setCustomLessonContent(material);
   };
 
+  const enabledCustomLessonLink = trackedPhrase.length > 0;
+
   return (
     <main id="main">
       <Subheader>
@@ -98,10 +100,11 @@ const Lookup = ({
         </div>
         <div className="flex mxn2">
           <Link
-            to="/lessons/custom/setup"
-            onClick={setUpCustomLesson}
-            className="link-button link-button-ghost table-cell mr1"
-            role="button"
+            to={enabledCustomLessonLink ? "/lessons/custom/setup" : "#"}
+            onClick={enabledCustomLessonLink ? setUpCustomLesson : undefined}
+            className={`link-button link-button-ghost table-cell mr1${
+              enabledCustomLessonLink ? "" : " o-30"
+            }`}
           >
             Set up custom lesson
           </Link>

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -97,13 +97,6 @@ const Lookup = ({
           </header>
         </div>
         <div className="flex mxn2">
-          <PseudoContentButton
-            className="js-clipboard-button button button--secondary table-cell mr2 copy-to-clipboard"
-            style={{ lineHeight: 2 }}
-            dataClipboardTarget="#js-word-family-group"
-          >
-            Copy words to clipboard
-          </PseudoContentButton>
           <Link
             to="/lessons/custom/setup"
             onClick={setUpCustomLesson}
@@ -156,16 +149,9 @@ const Lookup = ({
           </div>
           <div className="mt18 mw-336 flex-grow">
             <div>
-              <p className="mb1">Some related words:</p>
-              {wordFamilyGroup.length > 0 ? (
-                <pre id="js-word-family-group" className="fw4">
-                  {wordFamilyGroup.join("\n")}
-                </pre>
-              ) : (
-                <div
-                  id="js-word-family-group"
-                  className="avoid-clipboard-error-on-missing-target"
-                ></div>
+              <p className="mb1 de-emphasized">Some related words:</p>
+              {wordFamilyGroup.length > 0 && (
+                <pre className="fw4">{wordFamilyGroup.join("\n")}</pre>
               )}
             </div>
           </div>

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
 import StrokesForWords from "../../components/StrokesForWords";
 import PseudoContentButton from "../../components/PseudoContentButton";
 import Subheader from "../../components/Subheader";
@@ -54,9 +54,11 @@ const Lookup = ({
 
   useEffect(() => {
     if (trackedPhrase.length > 0) {
-      setWordFamilyGroup(getWordFamilyGroup(trackedPhrase, globalLookupDictionary))
+      setWordFamilyGroup(
+        getWordFamilyGroup(trackedPhrase, globalLookupDictionary)
+      );
     } else {
-      setWordFamilyGroup([])
+      setWordFamilyGroup([]);
     }
   }, [trackedPhrase, globalLookupDictionary]);
 
@@ -69,18 +71,20 @@ const Lookup = ({
     const words = wordFamilyGroup.slice();
     words.unshift(trackedPhrase);
 
-    const material = words.map(word => {
-      if (globalLookupDictionary.get(word)) {
-        return ({
-          phrase: word,
-          stroke: globalLookupDictionary.get(word)[0][0]
-        })
-      } else {
-        return undefined
-      }
-    }).filter(notUndefined => !!notUndefined);
+    const material = words
+      .map((word) => {
+        if (globalLookupDictionary.get(word)) {
+          return {
+            phrase: word,
+            stroke: globalLookupDictionary.get(word)[0][0],
+          };
+        } else {
+          return undefined;
+        }
+      })
+      .filter((notUndefined) => !!notUndefined);
     setCustomLessonContent(material);
-  }
+  };
 
   return (
     <main id="main">
@@ -116,39 +120,39 @@ const Lookup = ({
       >
         <div className="flex flex-wrap justify-between">
           <div className="mw-584 w-100 flex-grow mr3 min-h-384">
-          <div>
-          <StrokesForWords
-            fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
-            globalLookupDictionary={globalLookupDictionary}
-            globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-            globalUserSettings={globalUserSettings}
-            lookupTerm={lookupTerm}
-            onChange={strokesForWordsChange}
-            personalDictionaries={personalDictionaries}
-            stenoHintsOnTheFly={stenohintsonthefly}
-            trackPhrase={setTrackPhrase}
-            updateGlobalLookupDictionary={updateGlobalLookupDictionary}
-            updatePersonalDictionaries={updatePersonalDictionaries}
-            userSettings={userSettings}
-          />
-        </div>
-        <div className="">
-          <div className="mt0">
-            <h3 className="h4">Share link</h3>
-            <p className="mb0 truncate">
-              <span className="py05 dib" id="js-bookmark-url">
-                https://didoesdigital.com{bookmarkURL}
-              </span>
-            </p>
-          </div>
-          <PseudoContentButton
-            className="js-clipboard-button button button--secondary table-cell mr2 copy-to-clipboard"
-            style={{ lineHeight: 2 }}
-            dataClipboardTarget="#js-bookmark-url"
-          >
-            Copy link to clipboard
-          </PseudoContentButton>
-        </div>
+            <div>
+              <StrokesForWords
+                fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
+                globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                globalUserSettings={globalUserSettings}
+                lookupTerm={lookupTerm}
+                onChange={strokesForWordsChange}
+                personalDictionaries={personalDictionaries}
+                stenoHintsOnTheFly={stenohintsonthefly}
+                trackPhrase={setTrackPhrase}
+                updateGlobalLookupDictionary={updateGlobalLookupDictionary}
+                updatePersonalDictionaries={updatePersonalDictionaries}
+                userSettings={userSettings}
+              />
+            </div>
+            <div className="">
+              <div className="mt0">
+                <h3 className="h4">Share link</h3>
+                <p className="mb0 truncate">
+                  <span className="py05 dib" id="js-bookmark-url">
+                    https://didoesdigital.com{bookmarkURL}
+                  </span>
+                </p>
+              </div>
+              <PseudoContentButton
+                className="js-clipboard-button button button--secondary table-cell mr2 copy-to-clipboard"
+                style={{ lineHeight: 2 }}
+                dataClipboardTarget="#js-bookmark-url"
+              >
+                Copy link to clipboard
+              </PseudoContentButton>
+            </div>
           </div>
           <div className="mt18 mw-336 flex-grow">
             <div>
@@ -157,9 +161,12 @@ const Lookup = ({
                 <pre id="js-word-family-group" className="fw4">
                   {wordFamilyGroup.join("\n")}
                 </pre>
-              )
-              : <div id="js-word-family-group" className="avoid-clipboard-error-on-missing-target"></div>
-              }
+              ) : (
+                <div
+                  id="js-word-family-group"
+                  className="avoid-clipboard-error-on-missing-target"
+                ></div>
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -70,9 +70,9 @@ const Lookup = ({
           <PseudoContentButton
             className="js-clipboard-button button button--secondary table-cell mr2 copy-to-clipboard"
             style={{ lineHeight: 2 }}
-            dataClipboardTarget="#js-bookmark-url"
+            dataClipboardTarget="#js-word-family-group"
           >
-            Copy to clipboard
+            Copy words to clipboard
           </PseudoContentButton>
         </div>
       </Subheader>
@@ -80,16 +80,6 @@ const Lookup = ({
         className="p3 mx-auto mw-1024 mh-page"
         data-testid="lookup-page-contents"
       >
-        <div className="">
-          <div className="mt0">
-            <h3 className="h4">Share link</h3>
-            <p className="mb0 truncate">
-              <span className="py05 dib" id="js-bookmark-url">
-                https://didoesdigital.com{bookmarkURL}
-              </span>
-            </p>
-          </div>
-        </div>
         <div className="w-100 flex-grow mr3 min-h-384">
           <StrokesForWords
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
@@ -146,6 +136,23 @@ const Lookup = ({
             </OutboundLink>
             .
           </p>
+        </div>
+        <div className="">
+          <div className="mt0">
+            <h3 className="h4">Share link</h3>
+            <p className="mb0 truncate">
+              <span className="py05 dib" id="js-bookmark-url">
+                https://didoesdigital.com{bookmarkURL}
+              </span>
+            </p>
+          </div>
+          <PseudoContentButton
+            className="js-clipboard-button button button--secondary table-cell mr2 copy-to-clipboard"
+            style={{ lineHeight: 2 }}
+            dataClipboardTarget="#js-bookmark-url"
+          >
+            Copy link to clipboard
+          </PseudoContentButton>
         </div>
       </div>
     </main>

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -26,7 +26,6 @@ type Props = {
   updateGlobalLookupDictionary: any;
   updatePersonalDictionaries: any;
   userSettings: UserSettings;
-  setAnnouncementMessage: () => void;
 };
 
 const Lookup = ({
@@ -41,7 +40,6 @@ const Lookup = ({
   updatePersonalDictionaries,
   userSettings,
   setCustomLessonContent,
-  setAnnouncementMessage,
 }: Props) => {
   const [bookmarkURL, setBookmarkURL] = useState(
     process.env.PUBLIC_URL + "/lookup"

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link } from 'react-router-dom';
-import OutboundLink from "../../components/OutboundLink";
 import StrokesForWords from "../../components/StrokesForWords";
 import PseudoContentButton from "../../components/PseudoContentButton";
-import { IconExternal } from "../../components/Icon";
-import { Tooltip } from "react-tippy";
 import Subheader from "../../components/Subheader";
 import getWordFamilyGroup from "./utilities/getWordFamilyGroup";
 
@@ -73,6 +70,7 @@ const Lookup = ({
   const setUpCustomLesson = () => {
     const words = wordFamilyGroup.slice();
     words.unshift(trackedPhrase);
+
     const material = words.map(word => {
       if (globalLookupDictionary.get(word)) {
         return ({
@@ -135,48 +133,6 @@ const Lookup = ({
             updatePersonalDictionaries={updatePersonalDictionaries}
             userSettings={userSettings}
           />
-        </div>
-        <div className="panel bg-white dark:bg-coolgrey-1000 p3 mt3">
-          <p>
-            This lookup uses Plover’s latest dictionary and Typey&nbsp;Type’s
-            suggestions.
-          </p>
-          <p className="mb0">
-            If you notice any odd strokes,{" "}
-            <OutboundLink
-              eventLabel="post to the feedback form"
-              aria-label="post to the feedback form (external link opens in new tab)"
-              to="https://docs.google.com/forms/d/e/1FAIpQLSeevsX2oYEvnDHd3y8weg5_7-T8QZsF93ElAo28JO9Tmog-7Q/viewform?usp=sf_link"
-            >
-              use the{" "}
-              <span className="whitespace-nowrap">
-                feedback form
-                {/* @ts-ignore */}
-                <Tooltip
-                  title="Opens in new tab"
-                  className=""
-                  animation="shift"
-                  arrow="true"
-                  duration="200"
-                  tabIndex="0"
-                  tag="span"
-                  theme="didoesdigital"
-                  trigger="mouseenter focus click"
-                  onShow={setAnnouncementMessage}
-                >
-                  <IconExternal
-                    ariaHidden="true"
-                    role="presentation"
-                    iconWidth="24"
-                    iconHeight="24"
-                    className="ml1 svg-icon-wrapper svg-baseline"
-                    iconTitle=""
-                  />
-                </Tooltip>
-              </span>
-            </OutboundLink>
-            .
-          </p>
         </div>
         <div className="">
           <div className="mt0">

--- a/src/pages/lookup/utilities/getWordFamilyGroup.ts
+++ b/src/pages/lookup/utilities/getWordFamilyGroup.ts
@@ -23,6 +23,12 @@ const getWordFamilyGroup = (
     }
   });
 
+  if (trimmedWord.endsWith("e")) {
+    if (globalLookupDictionary.get(trimmedWord.slice(0, -1) + "ing")) {
+      familyGroup.push(trimmedWord.slice(0, -1) + "ing");
+    }
+  }
+
   return familyGroup;
 };
 

--- a/src/pages/lookup/utilities/getWordFamilyGroup.ts
+++ b/src/pages/lookup/utilities/getWordFamilyGroup.ts
@@ -1,0 +1,29 @@
+import type { LookupDictWithNamespacedDicts } from "../../../types";
+
+const getWordFamilyGroup = (
+  trimmedWord: string,
+  globalLookupDictionary: LookupDictWithNamespacedDicts
+) => {
+  const commonFamilyGroupEndings = [
+    "ing",
+    "ed",
+    "ment",
+    "'s",
+    "ly",
+    "ion",
+    "s",
+    "er",
+  ];
+
+  const familyGroup: string[] = [];
+  commonFamilyGroupEndings.forEach((ending) => {
+    const trimmedWordPlusEnding = trimmedWord + ending;
+    if (globalLookupDictionary.get(trimmedWordPlusEnding)) {
+      familyGroup.push(trimmedWordPlusEnding);
+    }
+  });
+
+  return familyGroup;
+};
+
+export default getWordFamilyGroup;


### PR DESCRIPTION
This PR adds some related words to the Lookup page when looking up words:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2476974/236452103-7614562f-5b33-4f54-bb56-18d040b09592.png">

This PR also makes it possible to set up a custom lesson using the looked up word and related words:

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/2476974/236452266-32326080-75c0-4b41-b40a-8bf6f3b46db6.png">

The word family group is made by trying to append these word parts:

```
  [
    "ing",
    "ed",
    "ment",
    "'s",
    "ly",
    "ion",
    "s",
    "er",
  ]
```

… and replacing "e" with "ing".

This PR also re-arranges the share link to the bottom of the Lookup page and removes the mostly unused panel:

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/2476974/236452845-2dacc1fb-0119-4411-9005-92b2707da3ea.png">
