### PR TITLE
Add obvious way to hide scores while typing

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -2288,6 +2288,14 @@ small .svg-icon-wrapper.svg-baseline svg {
   opacity: 1;
   transition: filter .2s linear,
               opacity .2s linear !important;
+  &:hover {
+    color:  var(--blue-700);
+    cursor: pointer;
+  }
+  &:active, &:focus {
+    color:  var(--blue-800);
+    cursor: pointer;
+  }
 }
 
 .scores--hidden {

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -194,6 +194,7 @@ class Lesson extends Component {
                 actualText={this.props.actualText}
                 changeSortOrderUserSetting={this.props.changeSortOrderUserSetting}
                 changeSpacePlacementUserSetting={this.props.changeSpacePlacementUserSetting}
+                changeShowScoresWhileTyping={this.props.changeShowScoresWhileTyping}
                 changeShowStrokesAs={this.props.changeShowStrokesAs}
                 changeShowStrokesAsList={this.props.changeShowStrokesAsList}
                 changeShowStrokesOnMisstroke={this.props.changeShowStrokesOnMisstroke}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -321,6 +321,7 @@ const MainLessonView = ({
               changeSortOrderUserSetting={changeSortOrderUserSetting}
               changeSpacePlacementUserSetting={changeSpacePlacementUserSetting}
               changeStenoLayout={changeStenoLayout}
+              changeShowScoresWhileTyping={changeShowScoresWhileTyping}
               changeShowStrokesAs={changeShowStrokesAs}
               changeShowStrokesAsList={changeShowStrokesAsList}
               changeShowStrokesOnMisstroke={changeShowStrokesOnMisstroke}

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -29,6 +29,7 @@ const getNextLessonPath = (metadata: any) => {
 let topSpeedToday = 0;
 
 const Finished = ({
+  changeShowScoresWhileTyping,
   changeShowStrokesAs,
   changeShowStrokesAsList,
   changeShowStrokesOnMisstroke,
@@ -241,6 +242,7 @@ const Finished = ({
           <UserSettings
             changeUserSetting={changeUserSetting}
             changeSortOrderUserSetting={changeSortOrderUserSetting}
+            changeShowScoresWhileTyping={changeShowScoresWhileTyping}
             changeSpacePlacementUserSetting={changeSpacePlacementUserSetting}
             changeShowStrokesAs={changeShowStrokesAs}
             changeShowStrokesAsList={changeShowStrokesAsList}

--- a/src/pages/lessons/components/UserSettings.stories.jsx
+++ b/src/pages/lessons/components/UserSettings.stories.jsx
@@ -12,6 +12,7 @@ const defaultArgs = {
   changeSortOrderUserSetting: () => undefined,
   changeSpacePlacementUserSetting: () => undefined,
   changeStenoLayout: () => undefined,
+  changeShowScoresWhileTyping: () => undefined,
   changeShowStrokesAs: () => undefined,
   changeShowStrokesAsList: () => undefined,
   changeShowStrokesOnMisstroke: () => undefined,

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -12,6 +12,7 @@ const grabStyle = function () {
 };
 
 type Props = {
+  changeShowScoresWhileTyping: (event: any) => void;
   changeShowStrokesAs: (event: any) => void;
   changeShowStrokesAsList: (event: any) => void;
   changeShowStrokesOnMisstroke: (event: any) => void;
@@ -35,6 +36,7 @@ type Props = {
 };
 
 const UserSettings = ({
+  changeShowScoresWhileTyping,
   changeShowStrokesAs,
   changeShowStrokesAsList,
   changeShowStrokesOnMisstroke,
@@ -816,6 +818,19 @@ const UserSettings = ({
                   onShow={setAnnouncementMessage}
                   tooltipTitle={
                     "Show text descriptions for punctuation symbols"
+                  }
+                />
+              </SettingListItem>
+              <SettingListItem sectionHierachy="minor">
+                <SettingCheckbox
+                  checked={userSettings.showScoresWhileTyping}
+                  disabled={disableUserSettings}
+                  label={"Show scores"}
+                  nameAndId={"showScoresWhileTyping"}
+                  onChange={changeShowScoresWhileTyping}
+                  onShow={setAnnouncementMessage}
+                  tooltipTitle={
+                    "Show scores while typing"
                   }
                 />
               </SettingListItem>

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -21,6 +21,7 @@ export type TransformedData = {
 } | null;
 
 export type FinishedProps = {
+  changeShowScoresWhileTyping: (event: any) => void;
   changeShowStrokesAs: (event: any) => void;
   changeShowStrokesAsList: (event: any) => void;
   changeShowStrokesOnMisstroke: (event: any) => void;


### PR DESCRIPTION
Lots of people find the changing text of the time, WPM, and other scores distracting. There is a hidden way to hide the scores by clicking on them, but it is not obvious. So this PR adds 2 ways to make it more obvious:

- Hovering over the scores now highlights the text and changes the cursor to encourage interaction
- There is a dedicated checkbox in the settings on the right near the bottom

<img width="1341" alt="typey-type-cursor-blue-scores-hover" src="https://github.com/didoesdigital/typey-type/assets/2476974/65588681-ba48-4dd3-9a7a-e6eece5b320d">

<img width="495" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/0a0a8151-f6f9-4b2e-a748-8dc79b76e77b">
