### PR TITLE
Remember settings for each study type preset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -259,7 +259,13 @@ class App extends Component {
         startFromWord: 1,
         study: 'discover',
         stenoLayout: 'stenoLayoutAmericanSteno', // 'stenoLayoutAmericanSteno' || 'stenoLayoutNoNumberBarInnerThumbNumber' || 'stenoLayoutNoNumberBarOuterThumbNumbers' || 'stenoLayoutPalantype' || 'stenoLayoutBrazilianPortugueseSteno' || 'stenoLayoutDanishSteno' || 'stenoLayoutItalianMichelaSteno' || 'stenoLayoutJapanese' || 'stenoLayoutKoreanModernC' || 'stenoLayoutKoreanModernS'
-        upcomingWordsLayout: 'singleLine'
+        upcomingWordsLayout: 'singleLine',
+        studyPresets: [
+          { limitNumberOfWords: 15, repetitions: 5, },
+          { limitNumberOfWords: 50, repetitions: 3, },
+          { limitNumberOfWords: 100, repetitions: 3, },
+          { limitNumberOfWords: 0, repetitions: 1, },
+        ]
       },
       lesson: fallbackLesson,
       lessonIndex: [{
@@ -1257,8 +1263,8 @@ class App extends Component {
         newState.newWords = PARAMS.discover.newWords;
         newState.seenWords = PARAMS.discover.seenWords;
         newState.retainedWords = PARAMS.discover.retainedWords;
-        newState.repetitions = PARAMS.discover.repetitions;
-        newState.limitNumberOfWords = PARAMS.discover.limitNumberOfWords;
+        newState.repetitions = this.state.userSettings.studyPresets[0].repetitions || PARAMS.discover.repetitions;
+        newState.limitNumberOfWords = this.state.userSettings.studyPresets[0].limitNumberOfWords || PARAMS.discover.limitNumberOfWords;
         newState.sortOrder = PARAMS.discover.sortOrder;
         break;
       case "revise":
@@ -1267,8 +1273,8 @@ class App extends Component {
         newState.newWords = PARAMS.revise.newWords;
         newState.seenWords = PARAMS.revise.seenWords;
         newState.retainedWords = PARAMS.revise.retainedWords;
-        newState.repetitions = PARAMS.revise.repetitions;
-        newState.limitNumberOfWords = PARAMS.revise.limitNumberOfWords;
+        newState.repetitions = this.state.userSettings.studyPresets[1].repetitions || PARAMS.revise.repetitions;
+        newState.limitNumberOfWords = this.state.userSettings.studyPresets[1].limitNumberOfWords || PARAMS.revise.limitNumberOfWords;
         newState.sortOrder = PARAMS.revise.sortOrder;
         break;
       case "drill":
@@ -1277,8 +1283,8 @@ class App extends Component {
         newState.newWords = PARAMS.drill.newWords;
         newState.seenWords = PARAMS.drill.seenWords;
         newState.retainedWords = PARAMS.drill.retainedWords;
-        newState.repetitions = PARAMS.drill.repetitions;
-        newState.limitNumberOfWords = PARAMS.drill.limitNumberOfWords;
+        newState.repetitions = this.state.userSettings.studyPresets[2].repetitions || PARAMS.drill.repetitions;
+        newState.limitNumberOfWords = this.state.userSettings.studyPresets[2].limitNumberOfWords || PARAMS.drill.limitNumberOfWords;
         newState.sortOrder = PARAMS.drill.sortOrder;
         break;
       case "practice":
@@ -1287,8 +1293,8 @@ class App extends Component {
         newState.newWords = PARAMS.practice.newWords;
         newState.seenWords = PARAMS.practice.seenWords;
         newState.retainedWords = PARAMS.practice.retainedWords;
-        newState.repetitions = PARAMS.practice.repetitions;
-        newState.limitNumberOfWords = PARAMS.practice.limitNumberOfWords;
+        newState.repetitions = this.state.userSettings.studyPresets[3].repetitions || PARAMS.practice.repetitions;
+        newState.limitNumberOfWords = this.state.userSettings.studyPresets[3].limitNumberOfWords || PARAMS.practice.limitNumberOfWords;
         newState.sortOrder = PARAMS.practice.sortOrder;
         break;
       default:
@@ -1818,6 +1824,38 @@ class App extends Component {
 
   updateGlobalLookupDictionary(combinedLookupDictionary) {
     this.setState({globalLookupDictionary: combinedLookupDictionary});
+  }
+
+  // updatePreset(studyType: Study) {
+  updatePreset(studyType) {
+    const newUserSettings = Object.assign({}, this.state.userSettings);
+    const presetSettings = {
+      limitNumberOfWords: this.state.userSettings.limitNumberOfWords,
+      repetitions: this.state.userSettings.repetitions
+    }
+
+    switch (studyType) {
+      case "discover":
+        newUserSettings.studyPresets[0] = presetSettings;
+        break;
+
+      case "revise":
+        newUserSettings.studyPresets[1] = presetSettings;
+        break;
+
+      case "drill":
+        newUserSettings.studyPresets[2] = presetSettings;
+        break;
+
+      case "practice":
+        newUserSettings.studyPresets[3] = presetSettings;
+        break;
+
+      default:
+        break;
+    }
+
+    this.setState({userSettings: newUserSettings});
   }
 
   updateRecommendationHistory(prevRecommendationHistory, lessonIndex = this.state.lessonIndex) {
@@ -2468,6 +2506,7 @@ class App extends Component {
                           totalNumberOfHintedWords={this.state.totalNumberOfHintedWords}
                           totalWordCount={stateLesson.presentedMaterial.length}
                           upcomingPhrases={upcomingMaterial}
+                          updatePreset={this.updatePreset.bind(this)}
                           updateRecommendationHistory={this.updateRecommendationHistory.bind(this)}
                           updateMarkup={this.updateMarkup.bind(this)}
                           updateTopSpeedPersonalBest={this.updateTopSpeedPersonalBest.bind(this)}

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -230,6 +230,7 @@ class Lesson extends Component {
                 charsPerWord={this.props.charsPerWord}
                 revisionMaterial={this.props.revisionMaterial}
                 revisionMode={this.props.revisionMode}
+                updatePreset={this.props.updatePreset}
                 updateRecommendationHistory={this.props.updateRecommendationHistory}
                 updateRevisionMaterial={this.props.updateRevisionMaterial}
                 updateTopSpeedPersonalBest={this.props.updateTopSpeedPersonalBest}
@@ -341,6 +342,7 @@ class Lesson extends Component {
                 totalNumberOfRetainedWords={this.props.totalNumberOfRetainedWords}
                 totalWordCount={this.props.totalWordCount}
                 upcomingPhrases={this.props.upcomingPhrases}
+                updatePreset={this.props.updatePreset}
                 updateMarkup={this.props.updateMarkup.bind(this)}
                 userSettings={this.props.userSettings}
                 hideOtherSettings={this.state.hideOtherSettings}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -47,6 +47,7 @@ const Lessons = ({
   stopLesson,
   updateFlashcardsMetWords,
   updateFlashcardsProgress,
+  updatePreset,
   changeFullscreen,
   flashcardsMetWords,
   ...lessonProps
@@ -141,6 +142,7 @@ const Lessons = ({
             lessonIndex={lessonIndex}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -162,6 +164,7 @@ const Lessons = ({
             lessonIndex={lessonIndex}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -183,6 +186,7 @@ const Lessons = ({
             lessonIndex={lessonIndex}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -205,6 +209,7 @@ const Lessons = ({
             personalDictionaries={personalDictionaries}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -227,6 +232,7 @@ const Lessons = ({
             personalDictionaries={personalDictionaries}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -249,6 +255,7 @@ const Lessons = ({
             personalDictionaries={personalDictionaries}
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
+            updatePreset={updatePreset}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
             {...lessonProps}
             {...props}
@@ -315,6 +322,7 @@ const Lessons = ({
             setAnnouncementMessage={setAnnouncementMessage}
             stopLesson={stopLesson}
             updateFlashcardsMetWords={updateFlashcardsMetWords}
+            updatePreset={updatePreset}
             {...lessonProps}
             {...props}
           />

--- a/src/pages/lessons/MainLessonView.stories.jsx
+++ b/src/pages/lessons/MainLessonView.stories.jsx
@@ -189,6 +189,7 @@ const Template = (args) => {
             charsPerWord={() => undefined}
             totalWordCount={1}
             upcomingPhrases={["and the"]}
+            updatePreset={() => undefined}
             updateRecommendationHistory={() => undefined}
             updateMarkup={() => undefined}
             updateTopSpeedPersonalBest={() => undefined}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -25,6 +25,7 @@ import type {
   LessonSettings,
   LookupDictWithNamespacedDictsAndConfig,
   Outline,
+  Study,
   UserSettings as UserSettingsType,
 } from "../../types";
 
@@ -81,6 +82,7 @@ type Props = {
   totalWordCount: number;
   upcomingPhrases: MaterialText[];
   updateMarkup: () => void;
+  updatePreset: (studyType: Study) => void;
   userSettings: UserSettingsType;
   hideOtherSettings: boolean;
   toggleHideOtherSettings: () => void;
@@ -139,6 +141,7 @@ const MainLessonView = ({
   totalWordCount,
   upcomingPhrases,
   updateMarkup,
+  updatePreset,
   userSettings,
   hideOtherSettings,
   toggleHideOtherSettings,
@@ -307,6 +310,7 @@ const MainLessonView = ({
                   setAnnouncementMessage={setAnnouncementMessage}
                   toggleHideOtherSettings={toggleHideOtherSettings}
                   userSettings={userSettings}
+                  updatePreset={updatePreset}
                 />
               </div>
               <LessonFinePrintFooter

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -71,6 +71,7 @@ const Finished = ({
   totalNumberOfNewWordsMet,
   totalNumberOfRetainedWords,
   totalWordCount,
+  updatePreset,
   updateRevisionMaterial,
   updateTopSpeedPersonalBest,
   userSettings,
@@ -230,6 +231,7 @@ const Finished = ({
               setAnnouncementMessage={setAnnouncementMessage}
               toggleHideOtherSettings={toggleHideOtherSettings}
               userSettings={userSettings}
+              updatePreset={updatePreset}
             />
           </div>
           <LessonFinePrintFooter

--- a/src/pages/lessons/components/LessonCanvasFooter.tsx
+++ b/src/pages/lessons/components/LessonCanvasFooter.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import ReactModal from "react-modal";
 import Metronome from "./Metronome";
 import { Tooltip } from "react-tippy";
+import type { Study } from "../../../types";
 
 type LessonCanvasFooterProps = {
   chooseStudy: () => void;
@@ -9,6 +11,7 @@ type LessonCanvasFooterProps = {
   setAnnouncementMessage: () => void;
   toggleHideOtherSettings: () => void;
   userSettings: any;
+  updatePreset: (studyType: Study) => void;
 };
 
 const LessonCanvasFooter = ({
@@ -18,7 +21,38 @@ const LessonCanvasFooter = ({
   setAnnouncementMessage,
   toggleHideOtherSettings,
   userSettings,
+  updatePreset,
 }: LessonCanvasFooterProps) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const studyBlurb =
+    userSettings.study === "practice"
+      ? "The “Practice” study type lets you mimic real usage as closely as possible by showing new, seen, and memorised words."
+      : userSettings.study === "drill"
+      ? "The “Drill” study type helps you build up your muscle memory and test your skills by showing you words you’ve memorised."
+      : userSettings.study === "revise"
+      ? "The “Revise” study type helps you revise recently learned outlines by showing only words you’ve seen."
+      : "The “Discover” study type lets you discover new outlines by showing only a limited number of new words while revealing their strokes.";
+
+  useEffect(() => {
+    ReactModal.setAppElement("#js-app");
+  }, []);
+
+  function handleOpenStudyPresetsModal(event: any) {
+    event.preventDefault();
+    setShowModal(true);
+  }
+
+  function handleCloseStudyPresetsModal(event: any) {
+    event.preventDefault();
+    setShowModal(false);
+  }
+
+  function savePreset() {
+    updatePreset(userSettings.study);
+    setShowModal(false);
+  }
+
   return (
     <div className="flex flex-wrap mx-auto mw-1440 justify-between text-small">
       <Metronome
@@ -74,6 +108,18 @@ const LessonCanvasFooter = ({
                     Discover
                   </Tooltip>
                 </label>
+                <button
+                  className="de-emphasized-button text-small"
+                  style={{
+                    "marginLeft": "22px",
+                    "display":
+                      userSettings.study === "discover" ? "block" : "none",
+                  }}
+                  onClick={handleOpenStudyPresetsModal}
+                  disabled={disableUserSettings}
+                >
+                  Save…
+                </button>
               </p>
               <p className="block relative mr3 mb0">
                 <label className="radio-label mb0">
@@ -104,6 +150,18 @@ const LessonCanvasFooter = ({
                     Revise
                   </Tooltip>
                 </label>
+                <button
+                  className="de-emphasized-button text-small"
+                  style={{
+                    "marginLeft": "22px",
+                    "display":
+                      userSettings.study === "revise" ? "block" : "none",
+                  }}
+                  onClick={handleOpenStudyPresetsModal}
+                  disabled={disableUserSettings}
+                >
+                  Save…
+                </button>
               </p>
             </div>
             <div className="flex flex-wrap justify-between">
@@ -136,6 +194,18 @@ const LessonCanvasFooter = ({
                     Drill
                   </Tooltip>
                 </label>
+                <button
+                  className="de-emphasized-button text-small"
+                  style={{
+                    "marginLeft": "22px",
+                    "display":
+                      userSettings.study === "drill" ? "block" : "none",
+                  }}
+                  onClick={handleOpenStudyPresetsModal}
+                  disabled={disableUserSettings}
+                >
+                  Save…
+                </button>
               </p>
               <p className="block relative mr3 mb0">
                 <label className="radio-label mb0">
@@ -166,10 +236,85 @@ const LessonCanvasFooter = ({
                     Practice
                   </Tooltip>
                 </label>
+                <button
+                  className="de-emphasized-button text-small"
+                  style={{
+                    "marginLeft": "22px",
+                    "display":
+                      userSettings.study === "practice" ? "block" : "none",
+                  }}
+                  onClick={handleOpenStudyPresetsModal}
+                  disabled={disableUserSettings}
+                >
+                  Save…
+                </button>
               </p>
             </div>
           </div>
         </fieldset>
+        <ReactModal
+          isOpen={showModal}
+          aria={{
+            labelledby: "aria-study-presets-modal-heading",
+            describedby: "aria-study-presets-modal-description",
+          }}
+          ariaHideApp={true}
+          closeTimeoutMS={300}
+          role="dialog"
+          onRequestClose={handleCloseStudyPresetsModal}
+          className={{
+            "base": "modal",
+            "afterOpen": "modal--after-open",
+            "beforeClose": "modal--before-close",
+          }}
+          overlayClassName={{
+            "base": "modal__overlay",
+            "afterOpen": "modal__overlay--after-open",
+            "beforeClose": "modal__overlay--before-close",
+          }}
+        >
+          <div className="fr">
+            <button
+              className="de-emphasized-button hide-md"
+              onClick={handleCloseStudyPresetsModal}
+            >
+              Close
+            </button>
+          </div>
+          <h3 id="aria-study-presets-modal-heading">
+            {getPrettyStudy(userSettings.study)} study type preset
+          </h3>
+          <div id="aria-study-presets-modal-description">
+            <p>
+              {studyBlurb} Selecting this study type preset will update the
+              settings accordingly.
+            </p>
+            <p>
+              You can save your current word count and repetitions settings so
+              that the next time you select “
+              {getPrettyStudy(userSettings.study)}”, Typey&nbsp;Type will
+              remember to use them:
+            </p>
+            <ul>
+              <li>
+                Limit number of words:{" "}
+                {userSettings.limitNumberOfWords || "0 (show all)"}
+              </li>
+              <li>Repetitions: {userSettings.repetitions}</li>
+            </ul>
+            <button
+              className="button button--secondary"
+              onClick={() => savePreset()}
+            >
+              Save {getPrettyStudy(userSettings.study)} preset
+            </button>
+          </div>
+          <div className="text-right">
+            <button className="button" onClick={handleCloseStudyPresetsModal}>
+              Cancel
+            </button>
+          </div>
+        </ReactModal>
       </div>
       <p>
         <button
@@ -187,5 +332,24 @@ const LessonCanvasFooter = ({
     </div>
   );
 };
+
+function getPrettyStudy(studyType: Study) {
+  switch (studyType) {
+    case "discover":
+      return "Discover";
+
+    case "revise":
+      return "Revise";
+
+    case "drill":
+      return "Drill";
+
+    case "practice":
+      return "Practice";
+
+    default:
+      return studyType;
+  }
+}
 
 export default LessonCanvasFooter;

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -5,6 +5,7 @@ import type {
   MetWords,
   PrettyLessonTitle,
   UserSettings,
+  Study,
 } from "../../types";
 
 export type LessonData = {
@@ -63,6 +64,7 @@ export type FinishedProps = {
   totalNumberOfNewWordsMet: any;
   totalNumberOfRetainedWords: any;
   totalWordCount: any;
+  updatePreset: (studyType: Study) => void;
   updateRevisionMaterial: any;
   updateTopSpeedPersonalBest: any;
   userSettings: UserSettings;

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -664,6 +664,12 @@ function loadPersonalPreferences() {
     study: 'discover',
     stenoLayout: 'stenoLayoutAmericanSteno',
     upcomingWordsLayout: 'singleLine',
+    studyPresets: [
+      { limitNumberOfWords: 15, repetitions: 5, },
+      { limitNumberOfWords: 50, repetitions: 3, },
+      { limitNumberOfWords: 100, repetitions: 3, },
+      { limitNumberOfWords: 0, repetitions: 1, },
+    ]
   };
   try {
     if (window.localStorage) {


### PR DESCRIPTION
Closes https://github.com/didoesdigital/typey-type/issues/131

This PR adds the ability to save personal "preset" settings for study types.

First, it adds a "Save…" button:

<img width="521" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/fa0f7c32-00cf-4e51-a808-407f6bb752e0">

… which opens a modal:

<img width="1438" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/d05a9533-b425-413d-ae2e-1be43796dc27">

If the student clicks "Cancel", then nothing happens. If they click "Save [study type] preset", then their current reps and word count become the new settings for that preset and the modal closes.

Switching to another study type moves the "Save…" button:

<img width="1434" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/28263471-6ede-4759-a802-28f4d4d564ff">

Returning to the previous study type where the preset was saved shows the newly saved settings:

<img width="1439" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/051564b1-a0c4-4663-a323-562eaf5d7df4">
