### PR TITLE
fix styling of raw steno keys

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1718,10 +1718,6 @@ $textarea-padding-x: 8px;
     background-color: darken(desaturate(add-tint($brand-warning, 5%), 40%), 15%);
   }
 
-  .raw-steno-key {
-    padding: 4px 0;
-  }
-
   &.steno-stroke--subtle {
     background-color: var(--coolgrey-700);
     color: var(--violet-100);
@@ -1729,16 +1725,6 @@ $textarea-padding-x: 8px;
     &::selection {
       background-color: var(--gold-500);
     }
-  }
-}
-.raw-steno-key {
-  background-color: desaturate(add-tint($brand-primary, 5%), 40%);
-  color: var(--coolgrey-300);
-  padding-left: 4px;
-  padding-right: 4px;
-  &.raw-steno-key--subtle {
-    background-color: desaturate(add-tint($brand-primary, 30%), 40%);
-    color: var(--coolgrey-300);
   }
 }
 

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -320,12 +320,12 @@ export default function Game() {
                         diagram, you can turn off all of your steno dictionaries
                         to produce raw steno output. That way, when you press
                         the{" "}
-                        <kbd className="raw-steno-key raw-steno-key--subtle">
+                        <kbd className="steno-stroke steno-stroke--subtle">
                           S
                         </kbd>{" "}
                         key, the steno engine will output “S” instead of “is”.
                         Likewise, pressing the{" "}
-                        <kbd className="raw-steno-key raw-steno-key--subtle">
+                        <kbd className="steno-stroke steno-stroke--subtle">
                           -T
                         </kbd>{" "}
                         key will output “-T” instead of “the”. The dash is

--- a/src/pages/lessons/components/FinishedPossibleStrokeImprovements.tsx
+++ b/src/pages/lessons/components/FinishedPossibleStrokeImprovements.tsx
@@ -90,7 +90,7 @@ const FinishedPossibleStrokeImprovements = ({
               <span className="steno-stroke steno-stroke--subtle text-small px1 py05">
                 {phrase.stroke.split("").map((item: any, i: any) => (
                   <kbd
-                    className="raw-steno-key raw-steno-key--subtle text-small"
+                    className="steno-stroke steno-stroke--subtle text-small"
                     key={i}
                   >
                     {item}

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -377,7 +377,7 @@ const CustomLessonGenerator = ({
                                   className="wrap"
                                 >
                                   {materialItem.phrase}{" "}
-                                  <kbd className="raw-steno-key raw-steno-key--subtle">
+                                  <kbd className="steno-stroke steno-stroke--subtle">
                                     {materialItem.stroke}
                                   </kbd>
                                 </li>


### PR DESCRIPTION
fix #13 
Successfully remove the raw-steno-key and raw-steno-key--subtle from CSS file and replace with steno-stroke and steno-stroke--subtle in JSX files
