### PR TITLE
Add voice setting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -279,6 +279,7 @@ class App extends Component {
           { limitNumberOfWords: 0, repetitions: 1, },
         ],
         voiceName: '',
+        voiceURI: '',
       },
       lesson: fallbackLesson,
       lessonIndex: [{
@@ -1270,19 +1271,22 @@ class App extends Component {
 
   /**
    * @param {string} voiceName
+   * @param {string} voiceURI
    */
-  changeVoiceUserSetting(voiceName) {
+  changeVoiceUserSetting(voiceName, voiceURI) {
     let currentState = this.state.userSettings;
     let newState = Object.assign({}, currentState);
 
     newState['voiceName'] = voiceName;
+    newState['voiceURI'] = voiceURI;
 
     this.setState({userSettings: newState}, () => {
       writePersonalPreferences('userSettings', this.state.userSettings);
     });
 
-    let labelString = voiceName;
-    if (!voiceName) { labelString = "BAD_INPUT"; }
+    // Let's not bother with tracking voice name. URI is enough.
+    let labelString = voiceURI;
+    if (!voiceURI) { labelString = "BAD_INPUT"; }
 
     GoogleAnalytics.event({
       category: 'UserSettings',
@@ -2146,10 +2150,12 @@ class App extends Component {
         //   console.warn(`${event.error}: ${this.text}`);
         // };
 
+        const preferredVoiceURI = this.state.userSettings.voiceURI;
         const preferredVoiceName = this.state.userSettings.voiceName;
-        const voiceInVoices = voices.find(
-          (voice) => voice.name === preferredVoiceName
-        );
+        const voiceInVoices =
+          voices.find((voice) => voice.voiceURI === preferredVoiceURI) ??
+          voices.find((voice) => voice.name === preferredVoiceName);
+
         if (voiceInVoices) {
           utterThis.lang = voiceInVoices.lang;
           utterThis.voice = voiceInVoices;

--- a/src/index.scss
+++ b/src/index.scss
@@ -349,6 +349,22 @@ details summary > * {
   display: inline;
 }
 
+details summary.absolute-marker::-webkit-details-marker,
+details summary.absolute-marker::marker {
+ display: none;
+ content: "";
+}
+summary.absolute-marker::before {
+  content: " ▶︎";
+  color: var(--violet-700);
+  position: absolute;
+  transform: translate(-1rem, -0.1rem);
+}
+details[open] summary.absolute-marker:before {
+  content: " ▼";
+  position: absolute;
+}
+
 p {
   line-height: 2;
   margin-bottom: 1em;
@@ -1684,6 +1700,12 @@ $textarea-padding-x: 8px;
   }
 }
 
+.text-small-test-say-word-button.text-small-test-say-word-button {
+  font-size: $h6-size; // 12.8px
+  line-height: 1.6;
+  height: 2rem;
+}
+
 @media (prefers-color-scheme: dark) {
   .steno-diagram-svg {
     fill-opacity: 0.8;
@@ -1815,6 +1837,9 @@ $textarea-padding-x: 8px;
   }
 }
 
+.gap-1 {
+  gap: 0.25rem; /* 4px */
+}
 .gap-4 {
   gap: 1rem; /* 16px */
 }

--- a/src/pages/lessons/Lesson.jsx
+++ b/src/pages/lessons/Lesson.jsx
@@ -200,6 +200,7 @@ class Lesson extends Component {
                 changeShowStrokesOnMisstroke={this.props.changeShowStrokesOnMisstroke}
                 changeStenoLayout={this.props.changeStenoLayout}
                 changeUserSetting={this.props.changeUserSetting}
+                changeVoiceUserSetting={this.props.changeVoiceUserSetting}
                 chooseStudy={this.props.chooseStudy}
                 currentLessonStrokes={this.props.currentLessonStrokes}
                 disableUserSettings={this.props.disableUserSettings}
@@ -305,6 +306,7 @@ class Lesson extends Component {
                 changeSpacePlacementUserSetting={this.props.changeSpacePlacementUserSetting}
                 changeStenoLayout={this.props.changeStenoLayout}
                 changeUserSetting={this.props.changeUserSetting}
+                changeVoiceUserSetting={this.props.changeVoiceUserSetting}
                 chooseStudy={this.props.chooseStudy}
                 completedPhrases={this.props.completedPhrases}
                 currentLessonStrokes={this.props.currentLessonStrokes}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -44,6 +44,7 @@ type Props = {
   changeSpacePlacementUserSetting: () => void;
   changeStenoLayout: () => void;
   changeUserSetting: () => void;
+  changeVoiceUserSetting: () => void;
   chooseStudy: () => void;
   completedPhrases: MaterialText[];
   currentLessonStrokes: CurrentLessonStrokes;
@@ -103,6 +104,7 @@ const MainLessonView = ({
   changeSpacePlacementUserSetting,
   changeStenoLayout,
   changeUserSetting,
+  changeVoiceUserSetting,
   chooseStudy,
   completedPhrases,
   currentLessonStrokes,
@@ -330,6 +332,7 @@ const MainLessonView = ({
               changeShowStrokesAsList={changeShowStrokesAsList}
               changeShowStrokesOnMisstroke={changeShowStrokesOnMisstroke}
               changeUserSetting={changeUserSetting}
+              changeVoiceUserSetting={changeVoiceUserSetting}
               disableUserSettings={disableUserSettings}
               handleDiagramSize={handleDiagramSize}
               handleBeatsPerMinute={handleBeatsPerMinute}

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -38,6 +38,7 @@ const Finished = ({
   changeSpacePlacementUserSetting,
   changeStenoLayout,
   changeUserSetting,
+  changeVoiceUserSetting,
   chooseStudy,
   currentLessonStrokes,
   disableUserSettings,
@@ -248,6 +249,7 @@ const Finished = ({
         <div>
           <UserSettings
             changeUserSetting={changeUserSetting}
+            changeVoiceUserSetting={changeVoiceUserSetting}
             changeSortOrderUserSetting={changeSortOrderUserSetting}
             changeShowScoresWhileTyping={changeShowScoresWhileTyping}
             changeSpacePlacementUserSetting={changeSpacePlacementUserSetting}

--- a/src/pages/lessons/components/SpeakWordsHelp.tsx
+++ b/src/pages/lessons/components/SpeakWordsHelp.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from "react";
+import ReactModal from "react-modal";
+
+type Props = {
+  disabled: boolean;
+};
+
+const SpeakWordsHelp = ({ disabled }: Props) => {
+  const [hasSpeechSupport, setHasSpeechSupport] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    ReactModal.setAppElement("#js-app");
+  }, []);
+
+  function handleOpenModal(event: any) {
+    event.preventDefault();
+    setHasSpeechSupport("speechSynthesis" in window);
+    setShowModal(true);
+  }
+
+  function handleCloseModal(event: any) {
+    event.preventDefault();
+    setShowModal(false);
+  }
+
+  return (
+    <>
+      {" "}
+      (
+      <button
+        className="de-emphasized-button text-small"
+        onClick={handleOpenModal}
+        aria-label="Help with speak words setting"
+        disabled={disabled}
+      >
+        help
+      </button>
+      <ReactModal
+        isOpen={showModal}
+        aria={{
+          labelledby: "aria-modal-heading",
+          describedby: "aria-modal-description",
+        }}
+        ariaHideApp={true}
+        closeTimeoutMS={300}
+        role="dialog"
+        onRequestClose={handleCloseModal}
+        className={{
+          "base": "modal",
+          "afterOpen": "modal--after-open",
+          "beforeClose": "modal--before-close",
+        }}
+        overlayClassName={{
+          "base": "modal__overlay",
+          "afterOpen": "modal__overlay--after-open",
+          "beforeClose": "modal__overlay--before-close",
+        }}
+      >
+        <div className="fr">
+          <button
+            className="de-emphasized-button hide-md"
+            onClick={handleCloseModal}
+          >
+            Close
+          </button>
+        </div>
+        <h3 id="aria-modal-heading">Speak words setting</h3>
+        <div id="aria-modal-description">
+          <p>
+            Typey Type’s setting to “speak words” will speak words aloud when
+            you have the sound turned on. It’s great with story lessons and real
+            sentences where the context can help you distinguish homophones.
+          </p>
+          <p>
+            This setting uses fancy browser technology called the “Web Speech
+            API”.
+          </p>
+          <p
+            className={
+              hasSpeechSupport
+                ? "quote mt1 mb3 bg-slat dark:bg-coolgrey-900"
+                : "quote mt1 mb3 bg-danger dark:text-coolgrey-900"
+            }
+          >
+            Web Speech is {hasSpeechSupport ? " available" : " unavailable"} on
+            your system.
+          </p>
+          {hasSpeechSupport ? (
+            <p>
+              If you have working sound but hear no words, your system might be
+              missing a language pack or “voice”.
+            </p>
+          ) : (
+            <p>
+              <span className="bg-warning">
+                You may need to update your browser or check that your device
+                has a speech engine and language pack.
+              </span>
+            </p>
+          )}
+          <p>For Windows, you can download a “language pack” from Microsoft.</p>
+          <p>
+            For Linux systems, you may need to install a speech engine with
+            voices, such as <code>speech-dispatcher</code> and{" "}
+            <code>espeak-ng</code>.
+          </p>
+          <p>
+            Double-click the “Say word” button or type ⇧Enter (e.g.{" "}
+            <code>{`"STP*R": "{#Shift_L(Return)}",`}</code>) from the text area
+            to hear the word again and keep focus on the text area.
+          </p>
+        </div>
+        <div className="text-right">
+          <button className="button" onClick={handleCloseModal}>
+            OK
+          </button>
+        </div>
+      </ReactModal>
+      )
+    </>
+  );
+};
+
+export default SpeakWordsHelp;

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Tooltip } from "react-tippy";
+import ErrorBoundary from "../../../components/ErrorBoundary";
 import NumericInput from "react-numeric-input";
 import SettingCheckbox from "../../../components/SettingCheckbox";
 import SettingListItem from "../../../components/SettingListItem";
 import SpeakWordsHelp from "./SpeakWordsHelp";
+import VoiceSetting from "./VoiceSetting";
 
 import type { UserSettings as UserSettingsObjectType } from "../../../types";
 
@@ -20,6 +22,7 @@ type Props = {
   changeSpacePlacementUserSetting: (event: any) => void;
   changeStenoLayout: (event: any) => void;
   changeUserSetting: (event: any) => void;
+  changeVoiceUserSetting: (voiceName: string) => void;
   disableUserSettings: boolean;
   handleBeatsPerMinute: (event: any) => void;
   handleDiagramSize: (event: any) => void;
@@ -44,6 +47,7 @@ const UserSettings = ({
   changeSpacePlacementUserSetting,
   changeStenoLayout,
   changeUserSetting,
+  changeVoiceUserSetting,
   disableUserSettings,
   handleBeatsPerMinute,
   handleDiagramSize,
@@ -672,6 +676,17 @@ const UserSettings = ({
                     <SpeakWordsHelp disabled={disableUserSettings} />
                   }
                 />
+                <ErrorBoundary relative={true} vanish={true}>
+                  <details style={{ maxWidth: "300px" }}>
+                    <summary>Voice settings</summary>
+                    <VoiceSetting
+                      disableUserSettings={disableUserSettings}
+                      setAnnouncementMessage={setAnnouncementMessage}
+                      changeVoiceUserSetting={changeVoiceUserSetting}
+                      speakMaterial={userSettings.speakMaterial}
+                    />
+                  </details>
+                </ErrorBoundary>
               </SettingListItem>
               <SettingListItem sectionHierachy="major">
                 <SettingCheckbox

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -677,19 +677,21 @@ const UserSettings = ({
                   }
                 />
                 <ErrorBoundary relative={true} vanish={true}>
-                  <details style={{ maxWidth: "300px", paddingLeft: "22px" }}>
-                    <summary className="ml1 absolute-marker">
-                      Voice settings
-                    </summary>
-                    <VoiceSetting
-                      changeVoiceUserSetting={changeVoiceUserSetting}
-                      disableUserSettings={disableUserSettings}
-                      setAnnouncementMessage={setAnnouncementMessage}
-                      speakMaterial={userSettings.speakMaterial}
-                      voiceName={userSettings.voiceName}
-                      voiceURI={userSettings.voiceURI}
-                    />
-                  </details>
+                  {userSettings.speakMaterial ? (
+                    <details style={{ maxWidth: "300px", paddingLeft: "22px" }}>
+                      <summary className="ml1 absolute-marker">
+                        Voice settings
+                      </summary>
+                      <VoiceSetting
+                        changeVoiceUserSetting={changeVoiceUserSetting}
+                        disableUserSettings={disableUserSettings}
+                        setAnnouncementMessage={setAnnouncementMessage}
+                        speakMaterial={userSettings.speakMaterial}
+                        voiceName={userSettings.voiceName}
+                        voiceURI={userSettings.voiceURI}
+                      />
+                    </details>
+                  ) : null}
                 </ErrorBoundary>
               </SettingListItem>
               <SettingListItem sectionHierachy="major">

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -686,6 +686,7 @@ const UserSettings = ({
                       disableUserSettings={disableUserSettings}
                       setAnnouncementMessage={setAnnouncementMessage}
                       speakMaterial={userSettings.speakMaterial}
+                      voiceName={userSettings.voiceName}
                       voiceURI={userSettings.voiceURI}
                     />
                   </details>

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -22,7 +22,7 @@ type Props = {
   changeSpacePlacementUserSetting: (event: any) => void;
   changeStenoLayout: (event: any) => void;
   changeUserSetting: (event: any) => void;
-  changeVoiceUserSetting: (voiceName: string) => void;
+  changeVoiceUserSetting: (voiceName: string, voiceURI: string) => void;
   disableUserSettings: boolean;
   handleBeatsPerMinute: (event: any) => void;
   handleDiagramSize: (event: any) => void;
@@ -686,7 +686,7 @@ const UserSettings = ({
                       disableUserSettings={disableUserSettings}
                       setAnnouncementMessage={setAnnouncementMessage}
                       speakMaterial={userSettings.speakMaterial}
-                      voiceName={userSettings.voiceName}
+                      voiceURI={userSettings.voiceURI}
                     />
                   </details>
                 </ErrorBoundary>

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -680,10 +680,11 @@ const UserSettings = ({
                   <details style={{ maxWidth: "300px" }}>
                     <summary>Voice settings</summary>
                     <VoiceSetting
+                      changeVoiceUserSetting={changeVoiceUserSetting}
                       disableUserSettings={disableUserSettings}
                       setAnnouncementMessage={setAnnouncementMessage}
-                      changeVoiceUserSetting={changeVoiceUserSetting}
                       speakMaterial={userSettings.speakMaterial}
+                      voiceName={userSettings.voiceName}
                     />
                   </details>
                 </ErrorBoundary>

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
-import ReactModal from "react-modal";
+import React from "react";
 import { Tooltip } from "react-tippy";
 import NumericInput from "react-numeric-input";
 import SettingCheckbox from "../../../components/SettingCheckbox";
 import SettingListItem from "../../../components/SettingListItem";
+import SpeakWordsHelp from "./SpeakWordsHelp";
 
 import type { UserSettings as UserSettingsObjectType } from "../../../types";
 
@@ -58,121 +58,6 @@ const UserSettings = ({
   totalWordCount,
   userSettings,
 }: Props) => {
-  const [hasSpeechSupport, setHasSpeechSupport] = useState(false);
-  const [showModal, setShowModal] = useState(false);
-
-  useEffect(() => {
-    ReactModal.setAppElement("#js-app");
-  }, []);
-
-  function handleOpenModal(event: any) {
-    event.preventDefault();
-    setHasSpeechSupport("speechSynthesis" in window);
-    setShowModal(true);
-  }
-
-  function handleCloseModal(event: any) {
-    event.preventDefault();
-    setShowModal(false);
-  }
-
-  const speakWordsHelpButtonAndModal = (
-    <>
-      {" "}
-      (
-      <button
-        className="de-emphasized-button text-small"
-        onClick={handleOpenModal}
-        aria-label="Help with speak words setting"
-        disabled={disableUserSettings}
-      >
-        help
-      </button>
-      <ReactModal
-        isOpen={showModal}
-        aria={{
-          labelledby: "aria-modal-heading",
-          describedby: "aria-modal-description",
-        }}
-        ariaHideApp={true}
-        closeTimeoutMS={300}
-        role="dialog"
-        onRequestClose={handleCloseModal}
-        className={{
-          "base": "modal",
-          "afterOpen": "modal--after-open",
-          "beforeClose": "modal--before-close",
-        }}
-        overlayClassName={{
-          "base": "modal__overlay",
-          "afterOpen": "modal__overlay--after-open",
-          "beforeClose": "modal__overlay--before-close",
-        }}
-      >
-        <div className="fr">
-          <button
-            className="de-emphasized-button hide-md"
-            onClick={handleCloseModal}
-          >
-            Close
-          </button>
-        </div>
-        <h3 id="aria-modal-heading">Speak words setting</h3>
-        <div id="aria-modal-description">
-          <p>
-            Typey Type’s setting to “speak words” will speak words aloud when
-            you have the sound turned on. It’s great with story lessons and real
-            sentences where the context can help you distinguish homophones.
-          </p>
-          <p>
-            This setting uses fancy browser technology called the “Web Speech
-            API”.
-          </p>
-          <p
-            className={
-              hasSpeechSupport
-                ? "quote mt1 mb3 bg-slat dark:bg-coolgrey-900"
-                : "quote mt1 mb3 bg-danger dark:text-coolgrey-900"
-            }
-          >
-            Web Speech is {hasSpeechSupport ? " available" : " unavailable"} on
-            your system.
-          </p>
-          {hasSpeechSupport ? (
-            <p>
-              If you have working sound but hear no words, your system might be
-              missing a language pack or “voice”.
-            </p>
-          ) : (
-            <p>
-              <span className="bg-warning">
-                You may need to update your browser or check that your device
-                has a speech engine and language pack.
-              </span>
-            </p>
-          )}
-          <p>For Windows, you can download a “language pack” from Microsoft.</p>
-          <p>
-            For Linux systems, you may need to install a speech engine with
-            voices, such as <code>speech-dispatcher</code> and{" "}
-            <code>espeak-ng</code>.
-          </p>
-          <p>
-            Double-click the “Say word” button or type ⇧Enter (e.g.{" "}
-            <code>{`"STP*R": "{#Shift_L(Return)}",`}</code>) from the text area
-            to hear the word again and keep focus on the text area.
-          </p>
-        </div>
-        <div className="text-right">
-          <button className="button" onClick={handleCloseModal}>
-            OK
-          </button>
-        </div>
-      </ReactModal>
-      )
-    </>
-  );
-
   return (
     <div className="user-settings">
       <form>
@@ -435,7 +320,9 @@ const UserSettings = ({
                   nameAndId={"showStrokesOnMisstroke"}
                   onChange={changeShowStrokesOnMisstroke}
                   onShow={setAnnouncementMessage}
-                  tooltipTitle={"Show stroke hints for words when you misstroke them"}
+                  tooltipTitle={
+                    "Show stroke hints for words when you misstroke them"
+                  }
                 />
               </SettingListItem>
               <SettingListItem sectionHierachy="minor">
@@ -505,7 +392,9 @@ const UserSettings = ({
                   nameAndId={"showStrokesAsList"}
                   onChange={changeShowStrokesAsList}
                   onShow={setAnnouncementMessage}
-                  tooltipTitle={"Show alternative stroke hints from personal and Plover dictionaries"}
+                  tooltipTitle={
+                    "Show alternative stroke hints from personal and Plover dictionaries"
+                  }
                 />
               </SettingListItem>
               <SettingListItem sectionHierachy="major">
@@ -779,7 +668,9 @@ const UserSettings = ({
                   onChange={changeUserSetting}
                   onShow={setAnnouncementMessage}
                   tooltipTitle={"Speak words with sound"}
-                  modalAndButton={speakWordsHelpButtonAndModal}
+                  modalAndButton={
+                    <SpeakWordsHelp disabled={disableUserSettings} />
+                  }
                 />
               </SettingListItem>
               <SettingListItem sectionHierachy="major">
@@ -829,9 +720,7 @@ const UserSettings = ({
                   nameAndId={"showScoresWhileTyping"}
                   onChange={changeShowScoresWhileTyping}
                   onShow={setAnnouncementMessage}
-                  tooltipTitle={
-                    "Show scores while typing"
-                  }
+                  tooltipTitle={"Show scores while typing"}
                 />
               </SettingListItem>
               <SettingListItem sectionHierachy="minor">

--- a/src/pages/lessons/components/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings.tsx
@@ -677,8 +677,10 @@ const UserSettings = ({
                   }
                 />
                 <ErrorBoundary relative={true} vanish={true}>
-                  <details style={{ maxWidth: "300px" }}>
-                    <summary>Voice settings</summary>
+                  <details style={{ maxWidth: "300px", paddingLeft: "22px" }}>
+                    <summary className="ml1 absolute-marker">
+                      Voice settings
+                    </summary>
                     <VoiceSetting
                       changeVoiceUserSetting={changeVoiceUserSetting}
                       disableUserSettings={disableUserSettings}

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -44,6 +44,32 @@ const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
   return a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name);
 };
 
+const testSay = (voiceName: SpeechSynthesisVoice["name"]) => {
+  try {
+    const synth = window.speechSynthesis;
+    if (window.SpeechSynthesisUtterance) {
+      if (synth && synth.speaking) {
+        synth.cancel();
+      }
+      const utterThis = new SpeechSynthesisUtterance(
+        "The rain in Spain stays mainly in the plain"
+      );
+
+      const voices = speechSynthesis.getVoices();
+      const voiceInVoices = voices.find((voice) => voice.name === voiceName);
+
+      if (voiceInVoices) {
+        utterThis.lang = voiceInVoices.lang;
+        utterThis.voice = voiceInVoices;
+      }
+
+      synth?.speak(utterThis);
+    }
+  } catch (e) {
+    console.log("Unable to speak test material", e);
+  }
+};
+
 const VoiceSetting = ({
   changeVoiceUserSetting,
   disableUserSettings,
@@ -71,9 +97,15 @@ const VoiceSetting = ({
     }
   }, [loadVoices, speakMaterial]);
 
+  const handleTestVoice = () => {
+    if (!disableUserSettings && speakMaterial) {
+      testSay(voiceName);
+    }
+  };
+
   return (
-    <div>
-      <div className="mt1 mb1 pl1 pr2 flex flex-wrap items-center justify-between">
+    <div style={{ marginTop: "-0.5em" }}>
+      <div className="mt1 mb1 pl1 pr2 flex flex-column">
         {/* @ts-ignore */}
         <Tooltip
           title="Set your voice"
@@ -91,23 +123,32 @@ const VoiceSetting = ({
             Speak words: voice
           </label>
         </Tooltip>
-        <select
-          name="speak-words-voice"
-          id="speak-words-voice"
-          value={voiceName}
-          onChange={(event) => {
-            const voiceName = event.target.value;
-            changeVoiceUserSetting(voiceName);
-          }}
-          disabled={disableUserSettings}
-          className="text-small form-control w-144"
-        >
-          {voices.map((voice) => (
-            <option value={voice.name} key={voice.name}>
-              {voice.name} - {voice.lang}
-            </option>
-          ))}
-        </select>
+        <div className="flex flex-wrap items-center gap-1">
+          <select
+            name="speak-words-voice"
+            id="speak-words-voice"
+            value={voiceName}
+            onChange={(event) => {
+              const voiceName = event.target.value;
+              changeVoiceUserSetting(voiceName);
+            }}
+            disabled={disableUserSettings && !speakMaterial}
+            className="form-control w-144 mr-1"
+          >
+            {voices.map((voice) => (
+              <option value={voice.name} key={voice.name}>
+                {voice.name} - {voice.lang}
+              </option>
+            ))}
+          </select>
+          <button
+            className="button button--secondary text-small-test-say-word-button mr1"
+            onClick={handleTestVoice}
+            type="button"
+          >
+            Test
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Tooltip } from "react-tippy";
 
 type Props = {
-  changeVoiceUserSetting: (voiceName: string) => void;
+  changeVoiceUserSetting: (voiceName: string, voiceURI: string) => void;
   disableUserSettings: boolean;
   setAnnouncementMessage: () => void;
   speakMaterial: boolean;
-  voiceName: SpeechSynthesisVoice["name"];
+  voiceURI: SpeechSynthesisVoice["voiceURI"];
 };
 
 const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
@@ -44,7 +44,7 @@ const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
   return a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name);
 };
 
-const testSay = (voiceName: SpeechSynthesisVoice["name"]) => {
+const testSay = (voiceURI: SpeechSynthesisVoice["voiceURI"]) => {
   try {
     const synth = window.speechSynthesis;
     if (window.SpeechSynthesisUtterance) {
@@ -56,7 +56,7 @@ const testSay = (voiceName: SpeechSynthesisVoice["name"]) => {
       );
 
       const voices = speechSynthesis.getVoices();
-      const voiceInVoices = voices.find((voice) => voice.name === voiceName);
+      const voiceInVoices = voices.find((voice) => voice.name === voiceURI);
 
       if (voiceInVoices) {
         utterThis.lang = voiceInVoices.lang;
@@ -75,7 +75,7 @@ const VoiceSetting = ({
   disableUserSettings,
   setAnnouncementMessage,
   speakMaterial,
-  voiceName,
+  voiceURI,
 }: Props) => {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const synth = speakMaterial ? window.speechSynthesis : null;
@@ -99,7 +99,7 @@ const VoiceSetting = ({
 
   const handleTestVoice = () => {
     if (!disableUserSettings && speakMaterial) {
-      testSay(voiceName);
+      testSay(voiceURI);
     }
   };
 
@@ -127,17 +127,29 @@ const VoiceSetting = ({
           <select
             name="speak-words-voice"
             id="speak-words-voice"
-            value={voiceName}
+            value={voiceURI}
             onChange={(event) => {
               const voiceName = event.target.value;
-              changeVoiceUserSetting(voiceName);
+              const voiceURI =
+                event.target[event.target.selectedIndex].getAttribute(
+                  "data-uri"
+                ) ?? "";
+              changeVoiceUserSetting(voiceName, voiceURI);
             }}
             disabled={disableUserSettings && !speakMaterial}
             className="form-control w-144 mr-1"
           >
             {voices.map((voice) => (
-              <option value={voice.name} key={voice.name}>
+              <option
+                value={voice.voiceURI}
+                data-name={voice.name}
+                data-uri={voice.voiceURI}
+                key={voice.voiceURI}
+              >
                 {voice.name} - {voice.lang}
+                {voice.voiceURI.includes("super-compact")
+                  ? " - super compact"
+                  : ""}
               </option>
             ))}
           </select>

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -4,8 +4,9 @@ import { Tooltip } from "react-tippy";
 type Props = {
   changeVoiceUserSetting: (voiceName: string) => void;
   disableUserSettings: boolean;
-  speakMaterial: boolean;
   setAnnouncementMessage: () => void;
+  speakMaterial: boolean;
+  voiceName: SpeechSynthesisVoice["name"];
 };
 
 const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
@@ -46,8 +47,9 @@ const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
 const VoiceSetting = ({
   changeVoiceUserSetting,
   disableUserSettings,
-  speakMaterial,
   setAnnouncementMessage,
+  speakMaterial,
+  voiceName,
 }: Props) => {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const synth = speakMaterial ? window.speechSynthesis : null;
@@ -92,7 +94,7 @@ const VoiceSetting = ({
         <select
           name="speak-words-voice"
           id="speak-words-voice"
-          // value={"en"} /*{userSettings.voiceName}*/
+          value={voiceName}
           onChange={(event) => {
             const voiceName = event.target.value;
             changeVoiceUserSetting(voiceName);

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -63,7 +63,12 @@ const testSay = (voiceURI: SpeechSynthesisVoice["voiceURI"]) => {
         utterThis.voice = voiceInVoices;
       }
 
-      synth?.speak(utterThis);
+      // @ts-ignore 'chrome' isn't on Window because it is browser specific and that's why we are using it to check for chromium browsers
+      const isChromium = !!window.chrome;
+      const timeoutDelay = isChromium ? 50 : 0;
+      setTimeout(function () {
+        synth?.speak(utterThis);
+      }, timeoutDelay);
     }
   } catch (e) {
     console.log("Unable to speak test material", e);

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -6,6 +6,7 @@ type Props = {
   disableUserSettings: boolean;
   setAnnouncementMessage: () => void;
   speakMaterial: boolean;
+  voiceName: SpeechSynthesisVoice["name"];
   voiceURI: SpeechSynthesisVoice["voiceURI"];
 };
 
@@ -44,7 +45,10 @@ const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
   return a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name);
 };
 
-const testSay = (voiceURI: SpeechSynthesisVoice["voiceURI"]) => {
+const testSay = (
+  voiceName: SpeechSynthesisVoice["name"],
+  voiceURI: SpeechSynthesisVoice["voiceURI"]
+) => {
   try {
     const synth = window.speechSynthesis;
     if (window.SpeechSynthesisUtterance) {
@@ -56,7 +60,9 @@ const testSay = (voiceURI: SpeechSynthesisVoice["voiceURI"]) => {
       );
 
       const voices = speechSynthesis.getVoices();
-      const voiceInVoices = voices.find((voice) => voice.name === voiceURI);
+      const voiceInVoices =
+        voices.find((voice) => voice.voiceURI === voiceURI) ??
+        voices.find((voice) => voice.name === voiceName);
 
       if (voiceInVoices) {
         utterThis.lang = voiceInVoices.lang;
@@ -80,6 +86,7 @@ const VoiceSetting = ({
   disableUserSettings,
   setAnnouncementMessage,
   speakMaterial,
+  voiceName,
   voiceURI,
 }: Props) => {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
@@ -104,7 +111,7 @@ const VoiceSetting = ({
 
   const handleTestVoice = () => {
     if (!disableUserSettings && speakMaterial) {
-      testSay(voiceURI);
+      testSay(voiceName, voiceURI);
     }
   };
 

--- a/src/pages/lessons/components/VoiceSetting.tsx
+++ b/src/pages/lessons/components/VoiceSetting.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Tooltip } from "react-tippy";
+
+type Props = {
+  changeVoiceUserSetting: (voiceName: string) => void;
+  disableUserSettings: boolean;
+  speakMaterial: boolean;
+  setAnnouncementMessage: () => void;
+};
+
+const voiceSort = (a: SpeechSynthesisVoice, b: SpeechSynthesisVoice) => {
+  /** e.g. "en" */
+  const lang = navigator.language;
+
+  if (a.lang === "en-AU" && b.lang !== "en-AU") return -1;
+  if (b.lang === "en-AU" && a.lang !== "en-AU") return 1;
+
+  if (a.lang === lang && b.lang !== lang) return -1;
+  if (b.lang === lang && a.lang !== lang) return 1;
+
+  /**
+   * e.g. ['en', 'de', 'ja', 'ru']
+   * e.g. ["en-GB", "en"]
+   */
+  const langs = navigator.languages;
+
+  // Prioritise language:
+  for (let i = 0; i < langs.length; i++) {
+    if (a.lang === langs[i] && b.lang !== langs[i]) return -1;
+    if (b.lang === langs[i] && a.lang !== langs[i]) return 1;
+  }
+
+  // Prioritise "en-GB" or "en" if langs includes ["en", "en-US"]:
+  for (let i = 0; i < langs.length; i++) {
+    /** e.g. "en" */
+    const twoLetterLang = langs[i].slice(0, 2);
+    if (a.lang.startsWith(twoLetterLang) && !b.lang.startsWith(twoLetterLang))
+      return -1;
+    if (b.lang.startsWith(twoLetterLang) && !a.lang.startsWith(twoLetterLang))
+      return 1;
+  }
+
+  return a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name);
+};
+
+const VoiceSetting = ({
+  changeVoiceUserSetting,
+  disableUserSettings,
+  speakMaterial,
+  setAnnouncementMessage,
+}: Props) => {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const synth = speakMaterial ? window.speechSynthesis : null;
+
+  const loadVoices = useCallback(() => {
+    if (synth) {
+      const sortedVoices = synth.getVoices().sort(voiceSort);
+      setVoices(sortedVoices);
+    }
+  }, [synth]);
+
+  if (synth && "onvoiceschanged" in synth && speakMaterial) {
+    synth.onvoiceschanged = loadVoices;
+  }
+
+  useEffect(() => {
+    if (speakMaterial) {
+      loadVoices();
+    }
+  }, [loadVoices, speakMaterial]);
+
+  return (
+    <div>
+      <div className="mt1 mb1 pl1 pr2 flex flex-wrap items-center justify-between">
+        {/* @ts-ignore */}
+        <Tooltip
+          title="Set your voice"
+          className="mw-240"
+          animation="shift"
+          arrow="true"
+          duration="200"
+          tabIndex="0"
+          tag="span"
+          theme="didoesdigital didoesdigital-sm"
+          trigger="mouseenter focus click"
+          onShow={setAnnouncementMessage}
+        >
+          <label className="mr1 db" htmlFor="speak-words-voice">
+            Speak words: voice
+          </label>
+        </Tooltip>
+        <select
+          name="speak-words-voice"
+          id="speak-words-voice"
+          // value={"en"} /*{userSettings.voiceName}*/
+          onChange={(event) => {
+            const voiceName = event.target.value;
+            changeVoiceUserSetting(voiceName);
+          }}
+          disabled={disableUserSettings}
+          className="text-small form-control w-144"
+        >
+          {voices.map((voice) => (
+            <option value={voice.name} key={voice.name}>
+              {voice.name} - {voice.lang}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default VoiceSetting;

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -30,6 +30,7 @@ export type FinishedProps = {
   changeSpacePlacementUserSetting: (event: any) => void;
   changeStenoLayout: (event: any) => void;
   changeUserSetting: (event: any) => void;
+  changeVoiceUserSetting: (voiceName: string) => void;
   chooseStudy: () => void;
   currentLessonStrokes: any; // CurrentLessonStrokes;
   disableUserSettings: boolean;

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -30,7 +30,7 @@ export type FinishedProps = {
   changeSpacePlacementUserSetting: (event: any) => void;
   changeStenoLayout: (event: any) => void;
   changeUserSetting: (event: any) => void;
-  changeVoiceUserSetting: (voiceName: string) => void;
+  changeVoiceUserSetting: (voiceName: string, voiceURI: string) => void;
   chooseStudy: () => void;
   currentLessonStrokes: any; // CurrentLessonStrokes;
   disableUserSettings: boolean;

--- a/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
+++ b/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
@@ -39,6 +39,7 @@ const userSettings: UserSettings = {
     { limitNumberOfWords: 100, repetitions: 3 },
     { limitNumberOfWords: 0, repetitions: 1 },
   ],
+  voiceName: ""
 };
 
 describe("progress summary and links", () => {

--- a/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
+++ b/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
@@ -39,7 +39,8 @@ const userSettings: UserSettings = {
     { limitNumberOfWords: 100, repetitions: 3 },
     { limitNumberOfWords: 0, repetitions: 1 },
   ],
-  voiceName: ""
+  voiceName: "",
+  voiceURI: ""
 };
 
 describe("progress summary and links", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,6 +368,7 @@ export type UserSettings = {
   studyPresets: StudyPresets;
   stenoLayout: StenoLayout;
   upcomingWordsLayout: UpcomingWordsLayout;
+  voiceName: SpeechSynthesisVoice["name"]
 };
 
 export type GlobalUserSettings = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,7 @@ export type UserSettings = {
   stenoLayout: StenoLayout;
   upcomingWordsLayout: UpcomingWordsLayout;
   voiceName: SpeechSynthesisVoice["name"]
+  voiceURI: SpeechSynthesisVoice["voiceURI"]
 };
 
 export type GlobalUserSettings = {

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -676,7 +676,8 @@ function loadPersonalPreferences() {
       { limitNumberOfWords: 100, repetitions: 3, },
       { limitNumberOfWords: 0, repetitions: 1, },
     ],
-    voiceName: ''
+    voiceName: '',
+    voiceURI: ''
   };
   try {
     if (window.localStorage) {

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -675,7 +675,8 @@ function loadPersonalPreferences() {
       { limitNumberOfWords: 50, repetitions: 3, },
       { limitNumberOfWords: 100, repetitions: 3, },
       { limitNumberOfWords: 0, repetitions: 1, },
-    ]
+    ],
+    voiceName: ''
   };
   try {
     if (window.localStorage) {

--- a/src/utils/typey-type.test.js
+++ b/src/utils/typey-type.test.js
@@ -441,69 +441,6 @@ testWithNoTab
   });
 });
 
-describe('loadPersonalPreferences', () => {
-  describe('without localStorage', () => {
-    it('should return previously met words and user settings', () => {
-      let metWords = {};
-      let flashcardsMetWords = {
-        "the": {
-          "phrase": "the",
-          "stroke": "-T",
-          "rung": 0
-        }
-      };
-      let flashcardsProgress = {};
-      let globalUserSettings = {
-        experiments: {},
-        flashcardsCourseLevel: "noviceCourse",
-        showMisstrokesInLookup: false,
-        writerInput: "qwerty"
-      };
-      let lessonsProgress = {};
-      let recentLessons = {history: []};
-      let topSpeedPersonalBest = 0;
-      let userGoals = {
-        newWords: 15,
-        oldWords: 50
-      }
-      let userSettings = {
-        beatsPerMinute: 10,
-        blurMaterial: false,
-        caseSensitive: false,
-        diagramSize: 1.0,
-        simpleTypography: true,
-        punctuationDescriptions: false,
-        retainedWords: true,
-        limitNumberOfWords: 45,
-        startFromWord: 1,
-        newWords: true,
-        repetitions: 3,
-        showScoresWhileTyping: true,
-        showStrokes: true,
-        showStrokesAsDiagrams: true,
-        showStrokesAsList: false,
-        showStrokesOnMisstroke: true,
-        stenoLayout: 'stenoLayoutAmericanSteno',
-        hideStrokesOnLastRepetition: true,
-        spacePlacement: 'spaceOff',
-        speakMaterial: false,
-        textInputAccessibility: true,
-        upcomingWordsLayout: "singleLine",
-        sortOrder: 'sortOff',
-        seenWords: true,
-        study: 'discover',
-        studyPresets: [
-          { limitNumberOfWords: 15, repetitions: 5, },
-          { limitNumberOfWords: 50, repetitions: 3, },
-          { limitNumberOfWords: 100, repetitions: 3, },
-          { limitNumberOfWords: 0, repetitions: 1, },
-        ]
-      };
-      expect(loadPersonalPreferences()).toEqual([metWords, userSettings, flashcardsMetWords, flashcardsProgress, globalUserSettings, lessonsProgress, recentLessons, topSpeedPersonalBest, userGoals]);
-    });
-  });
-});
-
 // describe('writePersonalPreferences', () => {
 //   describe('without localStorage', () => {
 //     it('should log error', () => {


### PR DESCRIPTION
This PR fixes https://github.com/didoesdigital/typey-type/issues/141

- This approach lets the person pick a voice from the available voices, sets the voice of the speech synthesis to the person's chosen voice, and sets the language of the speech synthesis to the language of the chosen voice. If there are no voices available, no voice and no language is specifically set.
- This approach stores the "[voiceURI](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisVoice/voiceURI)" of the person's preferred voice as well as the voice [name](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisVoice/name), and try to use the voiceURI to exactly identify the intended voice or fall back to the name to loosely identify the intended voice.
- This PR attempts to work around the [Chrome issue](https://stackoverflow.com/questions/39391502/js-speechsynthesis-problems-with-the-cancel-method) where every second "speak" method call after a "cancel" call fails by adding a timeout after "cancel" for chromium browsers.
- This PR adds a "Test" button to test each voice using the phrase "[The rain in Spain stays mainly in the plain](https://en.wikipedia.org/wiki/The_Rain_in_Spain)". It'd be nice to have a better phrase for comparing dialects with a mix of vowel sounds.

The new setting in the UI:
<img width="327" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/089ca477-551a-404a-b9ca-bd912296b42c">

macOS Firefox:
<img width="298" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/32e561f4-1c3b-48eb-9efe-cf3a664b2586">

macOS Chrome:
<img width="421" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/34760df8-3b0b-41d7-8e33-8b6728701a59">

macOS Safari:
<img width="302" alt="image" src="https://github.com/didoesdigital/typey-type/assets/2476974/5e5f1b82-a7f8-4ba9-8fb9-12809fd01dcf">

The list of voices could use improvements, such as:

- grouping by language e.g. using an [`optgroup`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)
- explaining or hiding "compact" vs "super compact" versions of duplicate voice names
- filtering/reducing the list somehow because there are sooo many options