### PR TITLE
Refactor: cleans up `setupLesson`, extracts `App.js` functions, `shouldUsePersonalDictionaries`, `StrokesForWords`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,6 +47,7 @@ import {
   changeShowStrokesAsList,
   changeShowStrokesOnMisstroke,
   changeSortOrderUserSetting,
+  changeSpacePlacementUserSetting,
   changeVoiceUserSetting,
   handleBeatsPerMinute,
   handleDiagramSize,
@@ -863,34 +864,6 @@ class App extends Component {
     GoogleAnalytics.event({
       category: 'UserSettings',
       action: 'Choose Study Type',
-      label: labelString
-    });
-
-    return value;
-  }
-
-  changeSpacePlacementUserSetting(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = 'spacePlacement'
-    const value = event.target.value;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change spacePlacement',
       label: labelString
     });
 
@@ -1751,7 +1724,7 @@ class App extends Component {
               changeShowStrokesInLesson: this.changeShowStrokesInLesson.bind(this),
               changeShowStrokesOnMisstroke: changeShowStrokesOnMisstroke.bind(this),
               changeSortOrderUserSetting: changeSortOrderUserSetting.bind(this),
-              changeSpacePlacementUserSetting: this.changeSpacePlacementUserSetting.bind(this),
+              changeSpacePlacementUserSetting: changeSpacePlacementUserSetting.bind(this),
               changeStenoLayout: this.changeStenoLayout.bind(this),
               changeUserSetting: this.changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting,

--- a/src/App.js
+++ b/src/App.js
@@ -840,13 +840,9 @@ class App extends Component {
     // let stenoLayout = "stenoLayoutAmericanSteno";
     // if (this.state.userSettings) { stenoLayout = this.state.userSettings.stenoLayout; }
 
-    const shouldUsePersonalDictionaries = this.state.personalDictionaries
-      && Object.entries(this.state.personalDictionaries).length > 0
-      && !!this.state.personalDictionaries.dictionariesNamesAndContents;
-
     const loadPlover = this.state.userSettings.showStrokesAsList ? true : false;
 
-    this.appFetchAndSetupGlobalDict(loadPlover, shouldUsePersonalDictionaries ? this.props.personalDictionaries : null).then(() => {
+    this.appFetchAndSetupGlobalDict(loadPlover, null).then(() => {
       // grab metWords, trim spaces, and sort by times seen
       let myWords = createWordListFromMetWords(metWords).join("\n");
       // parseWordList appears to remove empty lines and other garbage, we might not need it here
@@ -1006,17 +1002,11 @@ class App extends Component {
     const name = "showStrokesAsList";
     const value = event.target.checked;
 
-    const shouldUsePersonalDictionaries =
-      this.state.personalDictionaries &&
-      Object.entries(this.state.personalDictionaries).length > 0 &&
-      !!this.state.personalDictionaries.dictionariesNamesAndContents;
-
     if (value) {
       newState[name] = true;
-      this.appFetchAndSetupGlobalDict(
-        true,
-        shouldUsePersonalDictionaries ? this.state.personalDictionaries : null
-      ).catch((error) => console.error(error));
+
+      this.appFetchAndSetupGlobalDict(true, null)
+        .catch((error) => console.error(error));
     } else {
       newState[name] = false;
     }
@@ -1483,13 +1473,9 @@ class App extends Component {
           !path.includes("collections/tech")
         ) {
 
-          const shouldUsePersonalDictionaries = this.state.personalDictionaries
-            && Object.entries(this.state.personalDictionaries).length > 0
-            && !!this.state.personalDictionaries.dictionariesNamesAndContents;
-
           const loadPlover = this.state.userSettings.showStrokesAsList ? true : false;
 
-          this.appFetchAndSetupGlobalDict(loadPlover, shouldUsePersonalDictionaries ? this.state.personalDictionaries : null).then(() => {
+          this.appFetchAndSetupGlobalDict(loadPlover, null).then(() => {
             let lessonWordsAndStrokes = generateListOfWordsAndStrokes(lesson['sourceMaterial'].map(i => i.phrase), this.state.globalLookupDictionary);
               lesson.sourceMaterial = lessonWordsAndStrokes;
               lesson.presentedMaterial = lessonWordsAndStrokes;

--- a/src/App.js
+++ b/src/App.js
@@ -64,6 +64,9 @@ import {
 import {
   changeWriterInput
 } from './pages/lessons/components/UserSettings/updateGlobalUserSetting';
+import {
+  changeFullscreen
+} from './pages/lessons/components/UserSettings/updateFlashcardSetting';
 import AppRoutes from './AppRoutes';
 import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings';
 
@@ -403,13 +406,6 @@ class App extends Component {
       action: 'Start from word 1',
       label: 'true'
     });
-  }
-
-  changeFullscreen(event) {
-    const target = event.target;
-    const value = target.type === 'checkbox' ? target.checked : target.value;
-    this.setState({fullscreen: value});
-    return value;
   }
 
   updateLessonsProgress(lessonpath, lesson, userSettings, prevlessonsProgress) {
@@ -1487,7 +1483,7 @@ class App extends Component {
               generateCustomLesson: generateCustomLesson.bind(this),
               updateMultipleMetWords: updateMultipleMetWords.bind(this),
               changeFlashcardCourseLevel: this.changeFlashcardCourseLevel.bind(this),
-              changeFullscreen: this.changeFullscreen.bind(this),
+              changeFullscreen: changeFullscreen.bind(this),
               changeShowScoresWhileTyping: changeShowScoresWhileTyping.bind(this),
               changeShowStrokesAs: changeShowStrokesAs.bind(this),
               changeShowStrokesAsList: changeShowStrokesAsList.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import {
   repetitionsRemaining,
   shouldShowStroke,
   strokeAccuracy,
-  targetStrokeCount,
+  getTargetStrokeCount,
   updateCapitalisationStrokesInNextItem,
   writePersonalPreferences
 } from './utils/typey-type';
@@ -981,7 +981,7 @@ class App extends Component {
     newLesson.newPresentedMaterial = new Zipper(repeatedLesson);
 
     // Get target stroke count:
-    const target = targetStrokeCount(newLesson.presentedMaterial[0] || { phrase: '', stroke: 'TK-LS' });
+    const target = getTargetStrokeCount(newLesson.presentedMaterial[0] || { phrase: '', stroke: 'TK-LS' });
 
     // Update lesson progress and recent lesson history:
     if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
@@ -1450,7 +1450,7 @@ class App extends Component {
         nextItem = updateCapitalisationStrokesInNextItem(nextItem, lastWord);
       }
 
-      let target = targetStrokeCount(nextItem || { phrase: '', stroke: 'TK-LS' });
+      let target = getTargetStrokeCount(nextItem || { phrase: '', stroke: 'TK-LS' });
       newState.targetStrokeCount = target;
       this.state.lesson.newPresentedMaterial.visitNext();
 

--- a/src/App.js
+++ b/src/App.js
@@ -915,6 +915,11 @@ class App extends Component {
 
     // Copy userSettings before mutating:
     const newSettings = Object.assign({}, userSettings);
+    const limitNumberOfWords = newSettings.limitNumberOfWords;
+    const startFromWord = newSettings.startFromWord;
+    const simpleTypography = newSettings.simpleTypography;
+    const reps = newSettings.repetitions;
+    const study = newSettings.study
     
     // Get lookupTerm from URL:
     const lookupTerm = parsedParams['q'];
@@ -926,12 +931,6 @@ class App extends Component {
       lookupTerm: lookupTerm,
       userSettings: newSettings
     }, () => {
-      const limitNumberOfWords = newSettings.limitNumberOfWords;
-      const startFromWord = newSettings.startFromWord;
-      const simpleTypography = newSettings.simpleTypography;
-      const reps = newSettings.repetitions;
-      const study = newSettings.study
-      
       // Write updated user settings to local storage:
       writePersonalPreferences('userSettings', newSettings);
 

--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,6 @@ import fetchAndSetupGlobalDict from './utils/app/fetchAndSetupGlobalDict';
 import calculateMemorisedWordCount from './utils/calculateMemorisedWordCount';
 import calculateSeenWordCount from './utils/calculateSeenWordCount';
 import increaseMetWords from './utils/increaseMetWords';
-import isNormalInteger from './utils/isNormalInteger';
 import filterByFamiliarity from './utils/lessons/filterByFamiliarity';
 import replaceSmartTypographyInPresentedMaterial from './utils/lessons/replaceSmartTypographyInPresentedMaterial';
 import sortLesson from './utils/lessons/sortLesson';
@@ -59,6 +58,7 @@ import {
   handleUpcomingWordsLayout,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
+import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js';
 
 /** @type {SpeechSynthesis | null} */
 let synth = null;
@@ -918,89 +918,7 @@ class App extends Component {
     const lookupTerm = parsedParams['q'];
 
     // Update newSettings using URL search query parameters:
-    for (const [param, paramVal] of Object.entries(parsedParams)) {
-      if (param in userSettings) {
-        const booleanParams = [
-          'blurMaterial',
-          'caseSensitive',
-          'simpleTypography',
-          'punctuationDescriptions',
-          'retainedWords',
-          'newWords',
-          'showScoresWhileTyping',
-          'showStrokes',
-          'showStrokesAsDiagrams',
-          'showStrokesAsList',
-          'hideStrokesOnLastRepetition',
-          'speakMaterial',
-          'textInputAccessibility',
-          'seenWords'
-        ];
-
-        if (booleanParams.includes(param)) {
-          if (paramVal === "1") { newSettings[param] = true; }
-          if (paramVal === "0") { newSettings[param] = false; }
-        }
-
-        const spacePlacementValidValues = [
-          'spaceOff',
-          'spaceBeforeOutput',
-          'spaceAfterOutput',
-          'spaceExact'
-        ];
-
-        if (param === 'spacePlacement' && spacePlacementValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const sortOrderValidValues = [
-          'sortOff',
-          'sortNew',
-          'sortOld',
-          'sortRandom',
-          'sortLongest',
-          'sortShortest'
-        ];
-
-        if (param === 'sortOrder' && sortOrderValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const studyValidValues = [
-          'discover',
-          'revise',
-          'drill',
-          'practice'
-        ];
-
-        if (param === 'study' && studyValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const stenoLayoutValidValues = [
-          'stenoLayoutAmericanSteno',
-          'stenoLayoutNoNumberBarInnerThumbNumbers',
-          'stenoLayoutNoNumberBarOuterThumbNumbers',
-          'stenoLayoutPalantype',
-          'stenoLayoutBrazilianPortugueseSteno',
-          'stenoLayoutDanishSteno',
-          'stenoLayoutItalianMichelaSteno',
-          'stenoLayoutItalianMelaniSteno',
-          'stenoLayoutJapanese',
-          'stenoLayoutKoreanModernC',
-          // 'stenoLayoutKoreanModernS'
-        ];
-
-        if (param === 'stenoLayout' && stenoLayoutValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        if ((param === 'repetitions' || param === 'limitNumberOfWords' || param === 'startFromWord') && isNormalInteger(paramVal)) {
-          let paramValNumber = Number(paramVal);
-          newSettings[param] = paramValNumber;
-        }
-      }
-    }
+    applyQueryParamsToUserSettings(newSettings, parsedParams, userSettings);
 
     this.setState({
       lookupTerm: lookupTerm,

--- a/src/App.js
+++ b/src/App.js
@@ -833,8 +833,6 @@ class App extends Component {
         totalNumberOfHintedWords: 0,
         lesson: newLesson,
         currentPhraseID: 0,
-        lookupTerm,
-        userSettings: newSettings
       });
     });
   }

--- a/src/App.js
+++ b/src/App.js
@@ -270,8 +270,6 @@ class App extends Component {
       totalNumberOfMatchedChars: 0,
       yourSeenWordCount: calculateSeenWordCount(this.state.metWords),
       yourMemorisedWordCount: calculateMemorisedWordCount(this.state.metWords)
-    }, () => {
-      this.stopTimer();
     });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -246,7 +246,7 @@ class App extends Component {
     writePersonalPreferences('flashcardsProgress', this.state.flashcardsProgress);
 
     if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom")) {
-      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path, this.state.lesson, this.state.userSettings);
+      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path, this.state.lesson, this.state.userSettings, this.state.lessonsProgress);
       let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study, this.state.recentLessons);
       writePersonalPreferences('lessonsProgress', lessonsProgress);
       writePersonalPreferences('recentLessons', recentLessons);
@@ -437,8 +437,7 @@ class App extends Component {
     return value;
   }
 
-  updateLessonsProgress(lessonpath, lesson, userSettings) {
-    const prevlessonsProgress = this.state.lessonsProgress;
+  updateLessonsProgress(lessonpath, lesson, userSettings, prevlessonsProgress) {
     const metWords = this.state.metWords;
     const lessonsProgress = Object.assign({}, prevlessonsProgress);
 
@@ -893,6 +892,7 @@ class App extends Component {
     const lessonPath = this.state.lesson.path;
     let newLesson = Object.assign({}, this.state.lesson);
     const prevRecentLessons = this.state.recentLessons;
+    const prevLessonsProgress = this.state.lessonsProgress;
 
     // Copy userSettings before mutating:
     const newSettings = Object.assign({}, userSettings);
@@ -984,7 +984,7 @@ class App extends Component {
 
     // Update lesson progress and recent lesson history:
     if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
-      const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
+      const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings, prevLessonsProgress);
       const recentLessons = this.updateRecentLessons(lessonPath, study, prevRecentLessons);
       writePersonalPreferences('lessonsProgress', lessonsProgress);
       writePersonalPreferences('recentLessons', recentLessons);

--- a/src/App.js
+++ b/src/App.js
@@ -247,7 +247,7 @@ class App extends Component {
 
     if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom")) {
       let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path, this.state.lesson, this.state.userSettings);
-      let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
+      let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study, this.state.recentLessons);
       writePersonalPreferences('lessonsProgress', lessonsProgress);
       writePersonalPreferences('recentLessons', recentLessons);
     }
@@ -531,9 +531,9 @@ class App extends Component {
     return lessonsProgress;
   }
 
-  updateRecentLessons(recentLessonPath, studyType) {
+  updateRecentLessons(recentLessonPath, studyType, prevRecentLessons) {
     let trimmedRecentLessonPath = recentLessonPath.replace(process.env.PUBLIC_URL,'').replace('lesson.txt','');
-    let recentLessons = Object.assign({}, this.state.recentLessons);
+    const recentLessons = Object.assign({}, prevRecentLessons);
 
     if (!trimmedRecentLessonPath.includes("/lessons/custom") && recentLessons.history) {
       let existingLessonIndex = recentLessons.history.findIndex(historyRecentLesson => historyRecentLesson.path === trimmedRecentLessonPath);
@@ -1010,7 +1010,7 @@ class App extends Component {
         // Update lesson progress and recent lesson history:
         if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
           const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
-          const recentLessons = this.updateRecentLessons(lessonPath, study);
+          const recentLessons = this.updateRecentLessons(lessonPath, study, this.state.recentLessons);
           writePersonalPreferences('lessonsProgress', lessonsProgress);
           writePersonalPreferences('recentLessons', recentLessons);
         }

--- a/src/App.js
+++ b/src/App.js
@@ -983,6 +983,14 @@ class App extends Component {
       // Get target stroke count:
       const target = targetStrokeCount(newLesson.presentedMaterial[0] || { phrase: '', stroke: 'TK-LS' });
 
+      // Update lesson progress and recent lesson history:
+      if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
+        const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
+        const recentLessons = this.updateRecentLessons(lessonPath, study, this.state.recentLessons);
+        writePersonalPreferences('lessonsProgress', lessonsProgress);
+        writePersonalPreferences('recentLessons', recentLessons);
+      }
+
       // Reset lesson state for starting lesson:
       this.setState({
         actualText: ``,
@@ -1006,14 +1014,6 @@ class App extends Component {
         currentPhraseID: 0,
         lookupTerm,
         userSettings: newSettings
-      }, () => {
-        // Update lesson progress and recent lesson history:
-        if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
-          const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
-          const recentLessons = this.updateRecentLessons(lessonPath, study, this.state.recentLessons);
-          writePersonalPreferences('lessonsProgress', lessonsProgress);
-          writePersonalPreferences('recentLessons', recentLessons);
-        }
       });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,9 @@ import {
   handleStartFromWordChange,
   handleUpcomingWordsLayout,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
+import {
+  changeWriterInput
+} from './pages/lessons/components/UserSettings/updateGlobalUserSetting';
 import AppRoutes from './AppRoutes';
 import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings';
 
@@ -786,30 +789,6 @@ class App extends Component {
     });
 
     return value;
-  }
-
-  // changeWriterInput(event: SyntheticInputEvent<HTMLInputElement>) {
-  changeWriterInput(event) {
-    let globalUserSettings = Object.assign({}, this.state.globalUserSettings);
-    let name = 'BAD_INPUT';
-
-    if (event && event.target && event.target.name) {
-      globalUserSettings['writerInput'] = event.target.name;
-      name = event.target.name;
-    }
-
-    this.setState({globalUserSettings: globalUserSettings}, () => {
-      writePersonalPreferences('globalUserSettings', globalUserSettings);
-    });
-
-    let labelString = name;
-    if (!name) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'Global user settings',
-      action: 'Change writer input',
-      label: labelString
-    });
   }
 
   setupLesson() {
@@ -1549,7 +1528,7 @@ class App extends Component {
               changeStenoLayout: changeStenoLayout.bind(this),
               changeUserSetting: changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting,
-              changeWriterInput: this.changeWriterInput.bind(this),
+              changeWriterInput: changeWriterInput.bind(this),
               chooseStudy: chooseStudy.bind(this),
               createCustomLesson: this.createCustomLesson.bind(this),
               handleBeatsPerMinute: handleBeatsPerMinute.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,8 @@ import {
   toggleExperiment,
 } from './pages/lessons/components/UserSettings/updateGlobalUserSetting';
 import {
-  changeFullscreen
+  changeFlashcardCourseLevel,
+  changeFullscreen,
 } from './pages/lessons/components/UserSettings/updateFlashcardSetting';
 import AppRoutes from './AppRoutes';
 import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings';
@@ -697,28 +698,6 @@ class App extends Component {
       console.error(error);
       // this.showDictionaryErrorNotification();
     });
-  }
-
-  changeFlashcardCourseLevel(event) {
-    const value = event.target.value;
-    let globalUserSettings = Object.assign({}, this.state.globalUserSettings);
-    globalUserSettings['flashcardsCourseLevel'] = value;
-
-    this.setState({globalUserSettings: globalUserSettings}, () => {
-      this.updateFlashcardsRecommendation();
-      writePersonalPreferences('globalUserSettings', globalUserSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'Flashcards',
-      action: 'Change course level',
-      label: labelString
-    });
-
-    return value;
   }
 
   setupLesson() {
@@ -1449,7 +1428,7 @@ class App extends Component {
               customiseLesson: customiseLesson.bind(this),
               generateCustomLesson: generateCustomLesson.bind(this),
               updateMultipleMetWords: updateMultipleMetWords.bind(this),
-              changeFlashcardCourseLevel: this.changeFlashcardCourseLevel.bind(this),
+              changeFlashcardCourseLevel: changeFlashcardCourseLevel.bind(this),
               changeFullscreen: changeFullscreen.bind(this),
               changeShowScoresWhileTyping: changeShowScoresWhileTyping.bind(this),
               changeShowStrokesAs: changeShowStrokesAs.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,7 @@ import {
   handleLimitWordsChange,
   handleRepetitionsChange,
   handleStartFromWordChange,
+  handleUpcomingWordsLayout,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
 
@@ -392,32 +393,6 @@ class App extends Component {
       action: 'Start from word 1',
       label: 'true'
     });
-  }
-
-  handleUpcomingWordsLayout(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = event.target.name;
-    const value = event.target.value;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      this.setupLesson();
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change upcoming words layout',
-      label: labelString
-    });
-
-    return value;
   }
 
   changeShowStrokesInLesson(event) {
@@ -1817,7 +1792,7 @@ class App extends Component {
               handleRepetitionsChange: handleRepetitionsChange.bind(this),
               handleStartFromWordChange: handleStartFromWordChange.bind(this),
               handleStopLesson: this.handleStopLesson.bind(this),
-              handleUpcomingWordsLayout: this.handleUpcomingWordsLayout.bind(this),
+              handleUpcomingWordsLayout: handleUpcomingWordsLayout.bind(this),
               restartLesson: this.restartLesson.bind(this),
               reviseLesson: this.reviseLesson.bind(this),
               sayCurrentPhraseAgain: this.sayCurrentPhraseAgain.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -246,7 +246,7 @@ class App extends Component {
     writePersonalPreferences('flashcardsProgress', this.state.flashcardsProgress);
 
     if (this.state.lesson.path && !this.state.lesson.path.endsWith("/lessons/custom")) {
-      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path);
+      let lessonsProgress = this.updateLessonsProgress(this.state.lesson.path, this.state.lesson, this.state.userSettings);
       let recentLessons = this.updateRecentLessons(this.state.lesson.path, this.state.userSettings.study);
       writePersonalPreferences('lessonsProgress', lessonsProgress);
       writePersonalPreferences('recentLessons', recentLessons);
@@ -439,12 +439,10 @@ class App extends Component {
     return value;
   }
 
-  updateLessonsProgress(lessonpath) {
+  updateLessonsProgress(lessonpath, lesson, userSettings) {
     const prevlessonsProgress = this.state.lessonsProgress;
-    const userSettings = this.state.userSettings;
     const metWords = this.state.metWords;
     const lessonsProgress = Object.assign({}, prevlessonsProgress);
-    const lesson = this.state.lesson;
 
     // This is actually UNIQUE numberOfWordsSeen.
     // It seems low value to update localStorage data to rename it only for readability.
@@ -1011,7 +1009,7 @@ class App extends Component {
       }, () => {
         // Update lesson progress and recent lesson history:
         if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
-          const lessonsProgress = this.updateLessonsProgress(lessonPath);
+          const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
           const recentLessons = this.updateRecentLessons(lessonPath, study);
           writePersonalPreferences('lessonsProgress', lessonsProgress);
           writePersonalPreferences('recentLessons', recentLessons);

--- a/src/App.js
+++ b/src/App.js
@@ -890,6 +890,8 @@ class App extends Component {
     const revisionMaterial = this.state.revisionMaterial;
     const search = this.props.location.search;
     const userSettings = this.state.userSettings;
+    const metWords = this.state.metWords;
+    const lessonPath = this.state.lesson.path;
     let newLesson = Object.assign({}, this.state.lesson);
 
     // If there's no lesson data, use fallback lesson:
@@ -924,18 +926,14 @@ class App extends Component {
       lookupTerm: lookupTerm,
       userSettings: newSettings
     }, () => {
-      const metWords = this.state.metWords;
-      const revisionMode = this.state.revisionMode;
-      const updatedUserSettings = this.state.userSettings;
-      const limitNumberOfWords = this.state.userSettings.limitNumberOfWords;
-      const startFromWord = this.state.userSettings.startFromWord;
-      const simpleTypography = this.state.userSettings.simpleTypography;
-      const reps = this.state.userSettings.repetitions;
-      const lessonPath = this.state.lesson.path;
-      const study = this.state.userSettings.study
+      const limitNumberOfWords = newSettings.limitNumberOfWords;
+      const startFromWord = newSettings.startFromWord;
+      const simpleTypography = newSettings.simpleTypography;
+      const reps = newSettings.repetitions;
+      const study = newSettings.study
       
       // Write updated user settings to local storage:
-      writePersonalPreferences('userSettings', updatedUserSettings);
+      writePersonalPreferences('userSettings', newSettings);
 
       // Clean up URL, remove parameters:
       const newHistory = Object.assign({}, this.props.location)
@@ -945,14 +943,14 @@ class App extends Component {
 
       // Replace smart typography in presented material:
       if (simpleTypography) {
-        newLesson.presentedMaterial = replaceSmartTypographyInPresentedMaterial.call(this, newLesson.presentedMaterial, updatedUserSettings);
+        newLesson.presentedMaterial = replaceSmartTypographyInPresentedMaterial.call(this, newLesson.presentedMaterial, newSettings);
       }
 
       // Filter lesson by familiarity:
-      newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, metWords, updatedUserSettings, revisionMode);
+      newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, metWords, newSettings, revisionMode);
 
       // Sort lesson:
-      newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, metWords, updatedUserSettings);
+      newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, metWords, newSettings);
 
       // Apply range (start from & limit) to lesson:
       if (revisionMode && limitNumberOfWords > 0) {

--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ import {
   changeShowStrokesOnMisstroke,
   changeSortOrderUserSetting,
   changeSpacePlacementUserSetting,
+  changeStenoLayout,
   changeVoiceUserSetting,
   handleBeatsPerMinute,
   handleDiagramSize,
@@ -916,34 +917,6 @@ class App extends Component {
     });
   }
 
-  changeStenoLayout(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = event.target.name;
-    const value = event.target.value;
-
-    newState['stenoLayout'] = value;
-
-    this.setState({userSettings: newState}, () => {
-      this.setupLesson();
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    let actionString = 'Change steno layout';
-    if (name === 'writerStenoLayout') { actionString = 'Change writer steno layout'; }
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: actionString,
-      label: labelString
-    });
-
-    return value;
-  }
-
   setupLesson() {
     let newLesson = Object.assign({}, this.state.lesson);
 
@@ -1725,7 +1698,7 @@ class App extends Component {
               changeShowStrokesOnMisstroke: changeShowStrokesOnMisstroke.bind(this),
               changeSortOrderUserSetting: changeSortOrderUserSetting.bind(this),
               changeSpacePlacementUserSetting: changeSpacePlacementUserSetting.bind(this),
-              changeStenoLayout: this.changeStenoLayout.bind(this),
+              changeStenoLayout: changeStenoLayout.bind(this),
               changeUserSetting: this.changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting,
               changeWriterInput: this.changeWriterInput.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -41,6 +41,15 @@ import generateCustomLesson from './pages/lessons/custom/generator/utilities/gen
 import customiseLesson from './pages/lessons/utilities/customiseLesson';
 import setCustomLessonContent from './pages/lessons/utilities/setCustomLessonContent';
 import updateMultipleMetWords from './pages/games/KPOES/updateMultipleMetWords';
+import {
+  changeShowScoresWhileTyping,
+  changeShowStrokesAs,
+  changeShowStrokesAsList,
+  changeShowStrokesOnMisstroke,
+  changeVoiceUserSetting,
+  handleBeatsPerMinute,
+  handleDiagramSize,
+} from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
 
 /** @type {SpeechSynthesis | null} */
@@ -343,58 +352,6 @@ class App extends Component {
     return [metWords, userSettings, flashcardsMetWords, flashcardsProgress, globalUserSettings, lessonsProgress, recentLessons, topSpeedPersonalBest['wpm'], userGoals];
   }
 
-  handleDiagramSize(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = "diagramSize"
-    let value = typeof event === 'number' ? event.toFixed(1) : 1.0;
-    if (value > 2) { value = 2.0; }
-    if (value < 1) { value = 1.0; }
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change diagram size',
-      label: labelString
-    });
-
-    return value;
-  }
-
-  handleBeatsPerMinute(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = "beatsPerMinute"
-    const value = event;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change beats per minute',
-      label: labelString
-    });
-
-    return value;
-  }
-
   handleLimitWordsChange(event) {
     let currentState = this.state.userSettings;
     let newState = Object.assign({}, currentState);
@@ -573,30 +530,6 @@ class App extends Component {
         label: labelShowStrokesInLesson
       });
     }
-
-    return value;
-  }
-
-  changeShowStrokesOnMisstroke(event) {
-    let newState = Object.assign({}, this.state.userSettings);
-
-    const name = 'showStrokesOnMisstroke'
-    const value = event.target.value;
-
-    newState[name] = !newState[name];
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; } else { labelString = value.toString(); }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change show strokes on misstroke',
-      label: labelString
-    });
 
     return value;
   }
@@ -994,110 +927,6 @@ class App extends Component {
     });
 
     return value;
-  }
-
-  changeShowStrokesAsList(event) {
-    let newState = Object.assign({}, this.state.userSettings);
-
-    const name = "showStrokesAsList";
-    const value = event.target.checked;
-
-    if (value) {
-      newState[name] = true;
-
-      this.appFetchAndSetupGlobalDict(true, null)
-        .catch((error) => console.error(error));
-    } else {
-      newState[name] = false;
-    }
-
-    this.setState({ userSettings: newState }, () => {
-      writePersonalPreferences("userSettings", this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) {
-      labelString = "BAD_INPUT";
-    }
-
-    GoogleAnalytics.event({
-      category: "UserSettings",
-      action: "Change show strokes as list",
-      label: labelString,
-    });
-
-    return value;
-  }
-
-  changeShowStrokesAs(event) {
-    let newState = Object.assign({}, this.state.userSettings);
-
-    const name = 'showStrokesAsDiagrams'
-    const value = event.target.value;
-
-    if (value === 'strokesAsText') {
-      newState[name] = false;
-    } else {
-      newState[name] = true;
-    }
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change show strokes as',
-      label: labelString
-    });
-
-    return value;
-  }
-
-  changeShowScoresWhileTyping(event) {
-    let newState = Object.assign({}, this.state.userSettings);
-
-    newState['showScoresWhileTyping'] = !newState['showScoresWhileTyping'];
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change show scores while typing',
-      label: newState['showScoresWhileTyping'].toString()
-    });
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-    return newState['showScoresWhileTyping'];
-  }
-
-  /**
-   * @param {string} voiceName
-   * @param {string} voiceURI
-   */
-  changeVoiceUserSetting(voiceName, voiceURI) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    newState['voiceName'] = voiceName;
-    newState['voiceURI'] = voiceURI;
-
-    this.setState({userSettings: newState}, () => {
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    // Let's not bother with tracking voice name. URI is enough.
-    let labelString = voiceURI;
-    if (!voiceURI) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change voice',
-      label: labelString
-    });
   }
 
   chooseStudy(event) {
@@ -2049,21 +1878,21 @@ class App extends Component {
               updateMultipleMetWords: updateMultipleMetWords.bind(this),
               changeFlashcardCourseLevel: this.changeFlashcardCourseLevel.bind(this),
               changeFullscreen: this.changeFullscreen.bind(this),
-              changeShowScoresWhileTyping: this.changeShowScoresWhileTyping.bind(this),
-              changeShowStrokesAs: this.changeShowStrokesAs.bind(this),
-              changeShowStrokesAsList: this.changeShowStrokesAsList.bind(this),
+              changeShowScoresWhileTyping: changeShowScoresWhileTyping.bind(this),
+              changeShowStrokesAs: changeShowStrokesAs.bind(this),
+              changeShowStrokesAsList: changeShowStrokesAsList.bind(this),
               changeShowStrokesInLesson: this.changeShowStrokesInLesson.bind(this),
-              changeShowStrokesOnMisstroke: this.changeShowStrokesOnMisstroke.bind(this),
+              changeShowStrokesOnMisstroke: changeShowStrokesOnMisstroke.bind(this),
               changeSortOrderUserSetting: this.changeSortOrderUserSetting.bind(this),
               changeSpacePlacementUserSetting: this.changeSpacePlacementUserSetting.bind(this),
               changeStenoLayout: this.changeStenoLayout.bind(this),
               changeUserSetting: this.changeUserSetting.bind(this),
-              changeVoiceUserSetting: this.changeVoiceUserSetting.bind(this),
+              changeVoiceUserSetting: changeVoiceUserSetting,
               changeWriterInput: this.changeWriterInput.bind(this),
               chooseStudy: this.chooseStudy.bind(this),
               createCustomLesson: this.createCustomLesson.bind(this),
-              handleBeatsPerMinute: this.handleBeatsPerMinute.bind(this),
-              handleDiagramSize: this.handleDiagramSize.bind(this),
+              handleBeatsPerMinute: handleBeatsPerMinute.bind(this),
+              handleDiagramSize: handleDiagramSize.bind(this),
               handleLesson: this.handleLesson.bind(this),
               handleLimitWordsChange: this.handleLimitWordsChange.bind(this),
               handleRepetitionsChange: this.handleRepetitionsChange.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ import {
   changeShowStrokesAs,
   changeShowStrokesAsList,
   changeShowStrokesOnMisstroke,
+  changeSortOrderUserSetting,
   changeVoiceUserSetting,
   handleBeatsPerMinute,
   handleDiagramSize,
@@ -789,34 +790,6 @@ class App extends Component {
     GoogleAnalytics.event({
       category: 'UserSettings',
       action: 'Change ' + name,
-      label: labelString
-    });
-
-    return value;
-  }
-
-  changeSortOrderUserSetting(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = 'sortOrder'
-    const value = event.target.value;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change sort order',
       label: labelString
     });
 
@@ -1777,7 +1750,7 @@ class App extends Component {
               changeShowStrokesAsList: changeShowStrokesAsList.bind(this),
               changeShowStrokesInLesson: this.changeShowStrokesInLesson.bind(this),
               changeShowStrokesOnMisstroke: changeShowStrokesOnMisstroke.bind(this),
-              changeSortOrderUserSetting: this.changeSortOrderUserSetting.bind(this),
+              changeSortOrderUserSetting: changeSortOrderUserSetting.bind(this),
               changeSpacePlacementUserSetting: this.changeSpacePlacementUserSetting.bind(this),
               changeStenoLayout: this.changeStenoLayout.bind(this),
               changeUserSetting: this.changeUserSetting.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -918,7 +918,7 @@ class App extends Component {
     const lookupTerm = parsedParams['q'];
 
     // Update newSettings using URL search query parameters:
-    applyQueryParamsToUserSettings(newSettings, parsedParams, userSettings);
+    applyQueryParamsToUserSettings(newSettings, parsedParams);
 
     this.setState({
       lookupTerm: lookupTerm,

--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ import {
   handleUpcomingWordsLayout,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
-import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js';
+import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings';
 
 /** @type {SpeechSynthesis | null} */
 let synth = null;

--- a/src/App.js
+++ b/src/App.js
@@ -553,7 +553,7 @@ class App extends Component {
     this.setState({
       recentLessons: recentLessons,
     }, () => {
-      writePersonalPreferences('recentLessons', this.state.recentLessons);
+      writePersonalPreferences('recentLessons', recentLessons);
     });
     return recentLessons;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -57,6 +57,7 @@ import {
   handleRepetitionsChange,
   handleStartFromWordChange,
   handleUpcomingWordsLayout,
+  updatePreset,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import {
   changeShowStrokesInLesson,
@@ -1044,41 +1045,6 @@ class App extends Component {
     this.setState({globalLookupDictionary: combinedLookupDictionary});
   }
 
-  /**
-   * 
-   * @param {"discover" | "revise" | "drill" | "practice"} studyType should have type Study
-   */
-  updatePreset(studyType) {
-    const newUserSettings = Object.assign({}, this.state.userSettings);
-    const presetSettings = {
-      limitNumberOfWords: this.state.userSettings.limitNumberOfWords,
-      repetitions: this.state.userSettings.repetitions
-    }
-
-    switch (studyType) {
-      case "discover":
-        newUserSettings.studyPresets[0] = presetSettings;
-        break;
-
-      case "revise":
-        newUserSettings.studyPresets[1] = presetSettings;
-        break;
-
-      case "drill":
-        newUserSettings.studyPresets[2] = presetSettings;
-        break;
-
-      case "practice":
-        newUserSettings.studyPresets[3] = presetSettings;
-        break;
-
-      default:
-        break;
-    }
-
-    this.setState({userSettings: newUserSettings});
-  }
-
   updateRecommendationHistory(prevRecommendationHistory, lessonIndex = this.state.lessonIndex) {
     let newRecommendationHistory = Object.assign({}, prevRecommendationHistory);
 
@@ -1469,7 +1435,7 @@ class App extends Component {
               updateMarkup: this.updateMarkup.bind(this),
               updateMetWords: this.updateMetWords.bind(this),
               updatePersonalDictionaries: this.updatePersonalDictionaries.bind(this),
-              updatePreset: this.updatePreset.bind(this),
+              updatePreset: updatePreset.bind(this),
               updateRecommendationHistory: this.updateRecommendationHistory.bind(this),
               updateRevisionMaterial: updateRevisionMaterial.bind(this),
               updateStartingMetWordsAndCounts: this.updateStartingMetWordsAndCounts.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -49,6 +49,7 @@ import {
   changeVoiceUserSetting,
   handleBeatsPerMinute,
   handleDiagramSize,
+  handleLimitWordsChange,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
 
@@ -350,34 +351,6 @@ class App extends Component {
     });
 
     return [metWords, userSettings, flashcardsMetWords, flashcardsProgress, globalUserSettings, lessonsProgress, recentLessons, topSpeedPersonalBest['wpm'], userGoals];
-  }
-
-  handleLimitWordsChange(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = "limitNumberOfWords"
-    const value = event;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change limit word count',
-      label: labelString
-    });
-
-    return value;
   }
 
   startFromWordOne() {
@@ -1894,7 +1867,7 @@ class App extends Component {
               handleBeatsPerMinute: handleBeatsPerMinute.bind(this),
               handleDiagramSize: handleDiagramSize.bind(this),
               handleLesson: this.handleLesson.bind(this),
-              handleLimitWordsChange: this.handleLimitWordsChange.bind(this),
+              handleLimitWordsChange: handleLimitWordsChange.bind(this),
               handleRepetitionsChange: this.handleRepetitionsChange.bind(this),
               handleStartFromWordChange: this.handleStartFromWordChange.bind(this),
               handleStopLesson: this.handleStopLesson.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,7 @@ import {
   handleBeatsPerMinute,
   handleDiagramSize,
   handleLimitWordsChange,
+  handleRepetitionsChange,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
 
@@ -414,34 +415,6 @@ class App extends Component {
     GoogleAnalytics.event({
       category: 'UserSettings',
       action: 'Change start from word',
-      label: labelString
-    });
-
-    return value;
-  }
-
-  handleRepetitionsChange(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = "repetitions"
-    const value = event;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change repetitions',
       label: labelString
     });
 
@@ -1868,7 +1841,7 @@ class App extends Component {
               handleDiagramSize: handleDiagramSize.bind(this),
               handleLesson: this.handleLesson.bind(this),
               handleLimitWordsChange: handleLimitWordsChange.bind(this),
-              handleRepetitionsChange: this.handleRepetitionsChange.bind(this),
+              handleRepetitionsChange: handleRepetitionsChange.bind(this),
               handleStartFromWordChange: this.handleStartFromWordChange.bind(this),
               handleStopLesson: this.handleStopLesson.bind(this),
               handleUpcomingWordsLayout: this.handleUpcomingWordsLayout.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -59,6 +59,9 @@ import {
   handleUpcomingWordsLayout,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import {
+  changeShowStrokesInLesson,
+} from './pages/lessons/components/UserSettings/updateLessonSetting';
+import {
   changeWriterInput
 } from './pages/lessons/components/UserSettings/updateGlobalUserSetting';
 import AppRoutes from './AppRoutes';
@@ -400,39 +403,6 @@ class App extends Component {
       action: 'Start from word 1',
       label: 'true'
     });
-  }
-
-  changeShowStrokesInLesson(event) {
-    const target = event.target;
-    const value = target.type === 'checkbox' ? target.checked : target.value;
-
-    this.setState({showStrokesInLesson: value});
-    const yourTypedText = document.getElementById('your-typed-text');
-    if (yourTypedText) {
-      yourTypedText.focus();
-    }
-
-    if (this.props.location.pathname.includes('custom')) {
-      GoogleAnalytics.event({
-        category: 'Stroke hint',
-        action: 'Reveal',
-        label: 'CUSTOM_LESSON'
-      });
-    }
-    else {
-      let labelShowStrokesInLesson = 'true';
-      try {
-        labelShowStrokesInLesson = this.state.lesson.newPresentedMaterial.current.phrase + ": " + this.state.lesson.newPresentedMaterial.current.stroke;
-      } catch { }
-
-      GoogleAnalytics.event({
-        category: 'Stroke hint',
-        action: 'Reveal',
-        label: labelShowStrokesInLesson
-      });
-    }
-
-    return value;
   }
 
   changeFullscreen(event) {
@@ -1521,7 +1491,7 @@ class App extends Component {
               changeShowScoresWhileTyping: changeShowScoresWhileTyping.bind(this),
               changeShowStrokesAs: changeShowStrokesAs.bind(this),
               changeShowStrokesAsList: changeShowStrokesAsList.bind(this),
-              changeShowStrokesInLesson: this.changeShowStrokesInLesson.bind(this),
+              changeShowStrokesInLesson: changeShowStrokesInLesson.bind(this),
               changeShowStrokesOnMisstroke: changeShowStrokesOnMisstroke.bind(this),
               changeSortOrderUserSetting: changeSortOrderUserSetting.bind(this),
               changeSpacePlacementUserSetting: changeSpacePlacementUserSetting.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -49,6 +49,7 @@ import {
   changeSortOrderUserSetting,
   changeSpacePlacementUserSetting,
   changeStenoLayout,
+  changeUserSetting,
   changeVoiceUserSetting,
   handleBeatsPerMinute,
   handleDiagramSize,
@@ -758,39 +759,6 @@ class App extends Component {
 
     GoogleAnalytics.event({
       category: 'Global user settings',
-      action: 'Change ' + name,
-      label: labelString
-    });
-
-    return value;
-  }
-
-  changeUserSetting(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const target = event.target;
-    const value = target.type === 'checkbox' ? target.checked : target.value;
-    const name = target.name;
-
-    newState[name] = value;
-
-    if (!newState.speakMaterial && synth) {
-      synth.cancel();
-    }
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; } else { labelString.toString(); }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
       action: 'Change ' + name,
       label: labelString
     });
@@ -1699,7 +1667,7 @@ class App extends Component {
               changeSortOrderUserSetting: changeSortOrderUserSetting.bind(this),
               changeSpacePlacementUserSetting: changeSpacePlacementUserSetting.bind(this),
               changeStenoLayout: changeStenoLayout.bind(this),
-              changeUserSetting: this.changeUserSetting.bind(this),
+              changeUserSetting: changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting,
               changeWriterInput: this.changeWriterInput.bind(this),
               chooseStudy: this.chooseStudy.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -927,10 +927,6 @@ class App extends Component {
     // Update newSettings using URL search query parameters:
     applyQueryParamsToUserSettings(newSettings, parsedParams);
 
-    this.setState({
-      lookupTerm: lookupTerm,
-      userSettings: newSettings
-    }, () => {
       // Write updated user settings to local storage:
       writePersonalPreferences('userSettings', newSettings);
 
@@ -1006,7 +1002,9 @@ class App extends Component {
         totalNumberOfMistypedWords: 0,
         totalNumberOfHintedWords: 0,
         lesson: newLesson,
-        currentPhraseID: 0
+        currentPhraseID: 0,
+        lookupTerm,
+        userSettings: newSettings
       }, () => {
         // Update lesson progress and recent lesson history:
         if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
@@ -1016,8 +1014,6 @@ class App extends Component {
           writePersonalPreferences('recentLessons', recentLessons);
         }
       });
-
-    });
   }
 
   handleLesson(path) {

--- a/src/App.js
+++ b/src/App.js
@@ -1101,7 +1101,10 @@ class App extends Component {
     this.setState({globalLookupDictionary: combinedLookupDictionary});
   }
 
-  // updatePreset(studyType: Study) {
+  /**
+   * 
+   * @param {"discover" | "revise" | "drill" | "practice"} studyType should have type Study
+   */
   updatePreset(studyType) {
     const newUserSettings = Object.assign({}, this.state.userSettings);
     const presetSettings = {

--- a/src/App.js
+++ b/src/App.js
@@ -928,92 +928,97 @@ class App extends Component {
     // Update newSettings using URL search query parameters:
     applyQueryParamsToUserSettings(newSettings, parsedParams);
 
-    // Write updated user settings to local storage:
-    writePersonalPreferences('userSettings', newSettings);
-
-    // Clean up URL, remove parameters:
-    const newHistory = Object.assign({}, this.props.location)
-    newHistory.search = "";
-    // Note: this affects StrokesForWords lookup ?q= behaviour:
-    this.props.history.replace(newHistory);
-
-    // Replace smart typography in presented material:
-    if (simpleTypography) {
-      newLesson.presentedMaterial = replaceSmartTypographyInPresentedMaterial.call(this, newLesson.presentedMaterial, newSettings);
-    }
-
-    // Filter lesson by familiarity:
-    newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, metWords, newSettings, revisionMode);
-
-    // Sort lesson:
-    newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, metWords, newSettings);
-
-    // Apply range (start from & limit) to lesson:
-    if (revisionMode && limitNumberOfWords > 0) {
-      newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0, limitNumberOfWords);
-    }
-    else if (revisionMode) {
-      // Don't do anything to limit material if it's a revision lesson without limitNumberOfWords set
-      // newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0);
-    }
-    else if (startFromWord > 0 && limitNumberOfWords > 0) {
-      let startFrom = startFromWord - 1;
-      newLesson.presentedMaterial = newLesson.presentedMaterial.slice(startFrom, startFrom + limitNumberOfWords);
-    }
-    else if (startFromWord > 0) {
-      let startFrom = startFromWord - 1;
-      newLesson.presentedMaterial = newLesson.presentedMaterial.slice(startFrom);
-    }
-    else if (limitNumberOfWords > 0) {
-      newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0, limitNumberOfWords);
-    }
-
-    // Repeat words in lesson:
-    let repeatedLesson = newLesson.presentedMaterial;
-    if (reps > 0) {
-      for (let i = 1; i < reps && i < 30; i++) {
-        repeatedLesson = repeatedLesson.concat(newLesson.presentedMaterial);
-      }
-    }
-    newLesson.presentedMaterial = repeatedLesson;
-    
-    // Zipper the lesson:
-    newLesson.newPresentedMaterial = new Zipper(repeatedLesson);
-
-    // Get target stroke count:
-    const target = getTargetStrokeCount(newLesson.presentedMaterial[0] || { phrase: '', stroke: 'TK-LS' });
-
-    // Update lesson progress and recent lesson history:
-    if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
-      const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings, prevLessonsProgress);
-      const recentLessons = this.updateRecentLessons(lessonPath, study, prevRecentLessons);
-      writePersonalPreferences('lessonsProgress', lessonsProgress);
-      writePersonalPreferences('recentLessons', recentLessons);
-    }
-
-    // Reset lesson state for starting lesson:
     this.setState({
-      actualText: ``,
-      currentPhraseAttempts: [],
-      currentLessonStrokes: [],
-      disableUserSettings: false,
-      numberOfMatchedChars: 0,
-      previousCompletedPhraseAsTyped: '',
-      repetitionsRemaining: reps,
-      startTime: null,
-      timer: 0,
-      targetStrokeCount: target,
-      totalNumberOfMatchedChars: 0,
-      totalNumberOfMatchedWords: 0,
-      totalNumberOfNewWordsMet: 0,
-      totalNumberOfLowExposuresSeen: 0,
-      totalNumberOfRetainedWords: 0,
-      totalNumberOfMistypedWords: 0,
-      totalNumberOfHintedWords: 0,
-      lesson: newLesson,
-      currentPhraseID: 0,
-      lookupTerm,
+      lookupTerm: lookupTerm,
       userSettings: newSettings
+    }, () => {
+      // Write updated user settings to local storage:
+      writePersonalPreferences('userSettings', newSettings);
+
+      // Clean up URL, remove parameters:
+      const newHistory = Object.assign({}, this.props.location)
+      newHistory.search = "";
+      // Note: this affects StrokesForWords lookup ?q= behaviour:
+      this.props.history.replace(newHistory);
+
+      // Replace smart typography in presented material:
+      if (simpleTypography) {
+        newLesson.presentedMaterial = replaceSmartTypographyInPresentedMaterial.call(this, newLesson.presentedMaterial, newSettings);
+      }
+
+      // Filter lesson by familiarity:
+      newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, metWords, newSettings, revisionMode);
+
+      // Sort lesson:
+      newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, metWords, newSettings);
+
+      // Apply range (start from & limit) to lesson:
+      if (revisionMode && limitNumberOfWords > 0) {
+        newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0, limitNumberOfWords);
+      }
+      else if (revisionMode) {
+        // Don't do anything to limit material if it's a revision lesson without limitNumberOfWords set
+        // newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0);
+      }
+      else if (startFromWord > 0 && limitNumberOfWords > 0) {
+        let startFrom = startFromWord - 1;
+        newLesson.presentedMaterial = newLesson.presentedMaterial.slice(startFrom, startFrom + limitNumberOfWords);
+      }
+      else if (startFromWord > 0) {
+        let startFrom = startFromWord - 1;
+        newLesson.presentedMaterial = newLesson.presentedMaterial.slice(startFrom);
+      }
+      else if (limitNumberOfWords > 0) {
+        newLesson.presentedMaterial = newLesson.presentedMaterial.slice(0, limitNumberOfWords);
+      }
+
+      // Repeat words in lesson:
+      let repeatedLesson = newLesson.presentedMaterial;
+      if (reps > 0) {
+        for (let i = 1; i < reps && i < 30; i++) {
+          repeatedLesson = repeatedLesson.concat(newLesson.presentedMaterial);
+        }
+      }
+      newLesson.presentedMaterial = repeatedLesson;
+      
+      // Zipper the lesson:
+      newLesson.newPresentedMaterial = new Zipper(repeatedLesson);
+
+      // Get target stroke count:
+      const target = getTargetStrokeCount(newLesson.presentedMaterial[0] || { phrase: '', stroke: 'TK-LS' });
+
+      // Update lesson progress and recent lesson history:
+      if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
+        const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings, prevLessonsProgress);
+        const recentLessons = this.updateRecentLessons(lessonPath, study, prevRecentLessons);
+        writePersonalPreferences('lessonsProgress', lessonsProgress);
+        writePersonalPreferences('recentLessons', recentLessons);
+      }
+
+      // Reset lesson state for starting lesson:
+      this.setState({
+        actualText: ``,
+        currentPhraseAttempts: [],
+        currentLessonStrokes: [],
+        disableUserSettings: false,
+        numberOfMatchedChars: 0,
+        previousCompletedPhraseAsTyped: '',
+        repetitionsRemaining: reps,
+        startTime: null,
+        timer: 0,
+        targetStrokeCount: target,
+        totalNumberOfMatchedChars: 0,
+        totalNumberOfMatchedWords: 0,
+        totalNumberOfNewWordsMet: 0,
+        totalNumberOfLowExposuresSeen: 0,
+        totalNumberOfRetainedWords: 0,
+        totalNumberOfMistypedWords: 0,
+        totalNumberOfHintedWords: 0,
+        lesson: newLesson,
+        currentPhraseID: 0,
+        lookupTerm,
+        userSettings: newSettings
+      });
     });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,8 @@ import {
   updateRevisionMaterial,
 } from './pages/lessons/components/UserSettings/updateLessonSetting';
 import {
-  changeWriterInput
+  changeWriterInput,
+  toggleExperiment,
 } from './pages/lessons/components/UserSettings/updateGlobalUserSetting';
 import {
   changeFullscreen
@@ -696,31 +697,6 @@ class App extends Component {
       console.error(error);
       // this.showDictionaryErrorNotification();
     });
-  }
-
-  toggleExperiment(event) {
-    let newState = Object.assign({}, this.state.globalUserSettings);
-
-    const target = event.target;
-    const value = target.checked;
-    const name = target.name;
-
-    newState.experiments[name] = value;
-
-    this.setState({globalUserSettings: newState}, () => {
-      writePersonalPreferences('globalUserSettings', this.state.globalUserSettings);
-    });
-
-    let labelString = value;
-    if (value === undefined) { labelString = "BAD_INPUT"; } else { labelString.toString(); }
-
-    GoogleAnalytics.event({
-      category: 'Global user settings',
-      action: 'Change ' + name,
-      label: labelString
-    });
-
-    return value;
   }
 
   changeFlashcardCourseLevel(event) {
@@ -1506,7 +1482,7 @@ class App extends Component {
               startCustomLesson: this.startCustomLesson.bind(this),
               startFromWordOne: this.startFromWordOne.bind(this),
               stopLesson: this.stopLesson.bind(this),
-              toggleExperiment: this.toggleExperiment.bind(this),
+              toggleExperiment: toggleExperiment.bind(this),
               updateFlashcardsMetWords: this.updateFlashcardsMetWords.bind(this),
               updateFlashcardsProgress: this.updateFlashcardsProgress.bind(this),
               updateFlashcardsRecommendation: this.updateFlashcardsRecommendation.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -1386,6 +1386,7 @@ class App extends Component {
 
       let newHistory = Object.assign({}, this.props.location)
       newHistory.search = "";
+      // Note: this affects StrokesForWords lookup ?q= behaviour:
       this.props.history.replace(newHistory);
 
       if (this.state.userSettings.simpleTypography) {

--- a/src/App.js
+++ b/src/App.js
@@ -51,6 +51,7 @@ import {
   handleDiagramSize,
   handleLimitWordsChange,
   handleRepetitionsChange,
+  handleStartFromWordChange,
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import AppRoutes from './AppRoutes';
 
@@ -391,34 +392,6 @@ class App extends Component {
       action: 'Start from word 1',
       label: 'true'
     });
-  }
-
-  handleStartFromWordChange(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = "startFromWord"
-    const value = event;
-
-    newState[name] = value;
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Change start from word',
-      label: labelString
-    });
-
-    return value;
   }
 
   handleUpcomingWordsLayout(event) {
@@ -1842,7 +1815,7 @@ class App extends Component {
               handleLesson: this.handleLesson.bind(this),
               handleLimitWordsChange: handleLimitWordsChange.bind(this),
               handleRepetitionsChange: handleRepetitionsChange.bind(this),
-              handleStartFromWordChange: this.handleStartFromWordChange.bind(this),
+              handleStartFromWordChange: handleStartFromWordChange.bind(this),
               handleStopLesson: this.handleStopLesson.bind(this),
               handleUpcomingWordsLayout: this.handleUpcomingWordsLayout.bind(this),
               restartLesson: this.restartLesson.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -60,6 +60,7 @@ import {
 } from './pages/lessons/components/UserSettings/updateUserSetting';
 import {
   changeShowStrokesInLesson,
+  updateRevisionMaterial,
 } from './pages/lessons/components/UserSettings/updateLessonSetting';
 import {
   changeWriterInput
@@ -695,19 +696,6 @@ class App extends Component {
       console.error(error);
       // this.showDictionaryErrorNotification();
     });
-  }
-
-  updateRevisionMaterial(event) {
-    let newCurrentLessonStrokes = this.state.currentLessonStrokes.map(stroke => ({...stroke}));
-    const target = event.target;
-    const checked = target.type === 'checkbox' ? target.checked : target.value;
-    const name = target.name.replace(/-checkbox/,'');
-    const index = name;
-
-    newCurrentLessonStrokes[index].checked = checked;
-
-    this.setState({currentLessonStrokes: newCurrentLessonStrokes});
-    return checked;
   }
 
   toggleExperiment(event) {
@@ -1528,7 +1516,7 @@ class App extends Component {
               updatePersonalDictionaries: this.updatePersonalDictionaries.bind(this),
               updatePreset: this.updatePreset.bind(this),
               updateRecommendationHistory: this.updateRecommendationHistory.bind(this),
-              updateRevisionMaterial: this.updateRevisionMaterial.bind(this),
+              updateRevisionMaterial: updateRevisionMaterial.bind(this),
               updateStartingMetWordsAndCounts: this.updateStartingMetWordsAndCounts.bind(this),
               updateTopSpeedPersonalBest: this.updateTopSpeedPersonalBest.bind(this),
               updateUserGoals: this.updateUserGoals.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -139,6 +139,7 @@ class App extends Component {
       repetitionsRemaining: 1,
       startTime: null,
       showStrokesInLesson: false,
+      targetStrokeCount: 1,
       timer: 0,
       topSpeedPersonalBest: 0,
       totalNumberOfMatchedWords: 0,

--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,7 @@ import {
   changeStenoLayout,
   changeUserSetting,
   changeVoiceUserSetting,
+  chooseStudy,
   handleBeatsPerMinute,
   handleDiagramSize,
   handleLimitWordsChange,
@@ -759,79 +760,6 @@ class App extends Component {
     GoogleAnalytics.event({
       category: 'Global user settings',
       action: 'Change ' + name,
-      label: labelString
-    });
-
-    return value;
-  }
-
-  chooseStudy(event) {
-    let currentState = this.state.userSettings;
-    let newState = Object.assign({}, currentState);
-
-    const name = 'study'
-    const value = event.target.value;
-
-    newState[name] = value;
-
-    switch (value) {
-      case "discover":
-        newState.showStrokes = PARAMS.discover.showStrokes;
-        newState.hideStrokesOnLastRepetition = PARAMS.discover.hideStrokesOnLastRepetition;
-        newState.newWords = PARAMS.discover.newWords;
-        newState.seenWords = PARAMS.discover.seenWords;
-        newState.retainedWords = PARAMS.discover.retainedWords;
-        newState.repetitions = this.state.userSettings.studyPresets[0].repetitions || PARAMS.discover.repetitions;
-        newState.limitNumberOfWords = this.state.userSettings.studyPresets[0].limitNumberOfWords || PARAMS.discover.limitNumberOfWords;
-        newState.sortOrder = PARAMS.discover.sortOrder;
-        break;
-      case "revise":
-        newState.showStrokes = PARAMS.revise.showStrokes;
-        newState.hideStrokesOnLastRepetition = PARAMS.revise.hideStrokesOnLastRepetition;
-        newState.newWords = PARAMS.revise.newWords;
-        newState.seenWords = PARAMS.revise.seenWords;
-        newState.retainedWords = PARAMS.revise.retainedWords;
-        newState.repetitions = this.state.userSettings.studyPresets[1].repetitions || PARAMS.revise.repetitions;
-        newState.limitNumberOfWords = this.state.userSettings.studyPresets[1].limitNumberOfWords || PARAMS.revise.limitNumberOfWords;
-        newState.sortOrder = PARAMS.revise.sortOrder;
-        break;
-      case "drill":
-        newState.showStrokes = PARAMS.drill.showStrokes;
-        newState.hideStrokesOnLastRepetition = PARAMS.drill.hideStrokesOnLastRepetition;
-        newState.newWords = PARAMS.drill.newWords;
-        newState.seenWords = PARAMS.drill.seenWords;
-        newState.retainedWords = PARAMS.drill.retainedWords;
-        newState.repetitions = this.state.userSettings.studyPresets[2].repetitions || PARAMS.drill.repetitions;
-        newState.limitNumberOfWords = this.state.userSettings.studyPresets[2].limitNumberOfWords || PARAMS.drill.limitNumberOfWords;
-        newState.sortOrder = PARAMS.drill.sortOrder;
-        break;
-      case "practice":
-        newState.showStrokes = PARAMS.practice.showStrokes;
-        newState.hideStrokesOnLastRepetition = PARAMS.practice.hideStrokesOnLastRepetition;
-        newState.newWords = PARAMS.practice.newWords;
-        newState.seenWords = PARAMS.practice.seenWords;
-        newState.retainedWords = PARAMS.practice.retainedWords;
-        newState.repetitions = this.state.userSettings.studyPresets[3].repetitions || PARAMS.practice.repetitions;
-        newState.limitNumberOfWords = this.state.userSettings.studyPresets[3].limitNumberOfWords || PARAMS.practice.limitNumberOfWords;
-        newState.sortOrder = PARAMS.practice.sortOrder;
-        break;
-      default:
-        break;
-    }
-
-    this.setState({userSettings: newState}, () => {
-      if (!(name === 'caseSensitive')) {
-        this.setupLesson();
-      }
-      writePersonalPreferences('userSettings', this.state.userSettings);
-    });
-
-    let labelString = value;
-    if (!value) { labelString = "BAD_INPUT"; }
-
-    GoogleAnalytics.event({
-      category: 'UserSettings',
-      action: 'Choose Study Type',
       label: labelString
     });
 
@@ -1622,7 +1550,7 @@ class App extends Component {
               changeUserSetting: changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting,
               changeWriterInput: this.changeWriterInput.bind(this),
-              chooseStudy: this.chooseStudy.bind(this),
+              chooseStudy: chooseStudy.bind(this),
               createCustomLesson: this.createCustomLesson.bind(this),
               handleBeatsPerMinute: handleBeatsPerMinute.bind(this),
               handleDiagramSize: handleDiagramSize.bind(this),

--- a/src/App.js
+++ b/src/App.js
@@ -440,7 +440,11 @@ class App extends Component {
   }
 
   updateLessonsProgress(lessonpath) {
-    let lessonsProgress = Object.assign({}, this.state.lessonsProgress);
+    const prevlessonsProgress = this.state.lessonsProgress;
+    const userSettings = this.state.userSettings;
+    const metWords = this.state.metWords;
+    const lessonsProgress = Object.assign({}, prevlessonsProgress);
+    const lesson = this.state.lesson;
 
     // This is actually UNIQUE numberOfWordsSeen.
     // It seems low value to update localStorage data to rename it only for readability.
@@ -454,12 +458,11 @@ class App extends Component {
       numberOfWordsSeen = lessonsProgress[lessonpath].numberOfWordsSeen;
     }
 
-    let material = this.state.lesson?.sourceMaterial ? this.state.lesson.sourceMaterial.map(copy => ({...copy})) : [{phrase: "the", stroke: "-T"}];
-    if (this.state.userSettings.simpleTypography) {
-      material = replaceSmartTypographyInPresentedMaterial.call(this, material, this.state.userSettings);
+    let material = lesson?.sourceMaterial ? lesson.sourceMaterial.map(copy => ({...copy})) : [{phrase: "the", stroke: "-T"}];
+    if (userSettings.simpleTypography) {
+      material = replaceSmartTypographyInPresentedMaterial.call(this, material, userSettings);
     }
 
-    let metWords = this.state.metWords;
     let len = material.length;
     let seenAccumulator = 0;
     let memorisedAccumulator = 0;
@@ -525,7 +528,7 @@ class App extends Component {
     this.setState({
       lessonsProgress: lessonsProgress,
     }, () => {
-      writePersonalPreferences('lessonsProgress', this.state.lessonsProgress);
+      writePersonalPreferences('lessonsProgress', lessonsProgress);
     });
     return lessonsProgress;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -892,6 +892,7 @@ class App extends Component {
     const metWords = this.state.metWords;
     const lessonPath = this.state.lesson.path;
     let newLesson = Object.assign({}, this.state.lesson);
+    const prevRecentLessons = this.state.recentLessons;
 
     // Copy userSettings before mutating:
     const newSettings = Object.assign({}, userSettings);
@@ -984,7 +985,7 @@ class App extends Component {
     // Update lesson progress and recent lesson history:
     if (lessonPath && !lessonPath.endsWith("/lessons/custom") && !lessonPath.endsWith("/lessons/custom/setup")) {
       const lessonsProgress = this.updateLessonsProgress(lessonPath, newLesson, newSettings);
-      const recentLessons = this.updateRecentLessons(lessonPath, study, this.state.recentLessons);
+      const recentLessons = this.updateRecentLessons(lessonPath, study, prevRecentLessons);
       writePersonalPreferences('lessonsProgress', lessonsProgress);
       writePersonalPreferences('recentLessons', recentLessons);
     }

--- a/src/App.js
+++ b/src/App.js
@@ -893,6 +893,14 @@ class App extends Component {
     const lessonPath = this.state.lesson.path;
     let newLesson = Object.assign({}, this.state.lesson);
 
+    // Copy userSettings before mutating:
+    const newSettings = Object.assign({}, userSettings);
+    const limitNumberOfWords = newSettings.limitNumberOfWords;
+    const startFromWord = newSettings.startFromWord;
+    const simpleTypography = newSettings.simpleTypography;
+    const reps = newSettings.repetitions;
+    const study = newSettings.study
+
     // If there's no lesson data, use fallback lesson:
     if ((typeof newLesson === 'object' && Object.entries(newLesson).length === 0 && newLesson.constructor === Object) || newLesson === null ) {
       newLesson = fallbackLesson;
@@ -911,14 +919,6 @@ class App extends Component {
 
     // Get URL search query parameters:
     const parsedParams = queryString.parse(search);
-
-    // Copy userSettings before mutating:
-    const newSettings = Object.assign({}, userSettings);
-    const limitNumberOfWords = newSettings.limitNumberOfWords;
-    const startFromWord = newSettings.startFromWord;
-    const simpleTypography = newSettings.simpleTypography;
-    const reps = newSettings.repetitions;
-    const study = newSettings.study
     
     // Get lookupTerm from URL:
     const lookupTerm = parsedParams['q'];

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -161,7 +161,6 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                       }
                       metWords={appState.metWords}
                       startingMetWordsToday={appState.startingMetWordsToday}
-                      personalDictionaries={appState.personalDictionaries}
                       updateMetWords={appMethods.updateMetWords}
                       updateMultipleMetWords={appMethods.updateMultipleMetWords}
                       globalUserSettings={appState.globalUserSettings}
@@ -305,7 +304,6 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                       }
                       globalUserSettings={appState.globalUserSettings}
                       lookupTerm={appState.lookupTerm}
-                      personalDictionaries={appState.personalDictionaries}
                       setCustomLessonContent={appMethods.setCustomLessonContent}
                       userSettings={appState.userSettings}
                       {...props}
@@ -332,7 +330,6 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                         appState.globalLookupDictionaryLoaded
                       }
                       globalUserSettings={appState.globalUserSettings}
-                      personalDictionaries={appState.personalDictionaries}
                       stenohintsonthefly={appProps.stenohintsonthefly}
                       toggleExperiment={appMethods.toggleExperiment}
                       updateGlobalLookupDictionary={

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -307,12 +307,6 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                       lookupTerm={appState.lookupTerm}
                       personalDictionaries={appState.personalDictionaries}
                       setCustomLessonContent={appMethods.setCustomLessonContent}
-                      updateGlobalLookupDictionary={
-                        appMethods.updateGlobalLookupDictionary
-                      }
-                      updatePersonalDictionaries={
-                        appMethods.updatePersonalDictionaries
-                      }
                       userSettings={appState.userSettings}
                       {...props}
                     />

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -333,7 +333,7 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                       }
                       globalUserSettings={appState.globalUserSettings}
                       personalDictionaries={appState.personalDictionaries}
-                      stenoHintsOnTheFly={appProps.stenohintsonthefly}
+                      stenohintsonthefly={appProps.stenohintsonthefly}
                       toggleExperiment={appMethods.toggleExperiment}
                       updateGlobalLookupDictionary={
                         appMethods.updateGlobalLookupDictionary

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -1,10 +1,8 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import SOURCE_NAMESPACES from "../constant/sourceNamespaces";
+import misstrokes from "../json/misstrokes.json";
 import lookupListOfStrokesAndDicts from "../utils/lookupListOfStrokesAndDicts";
 import splitBriefsIntoStrokes from "./../utils/splitBriefsIntoStrokes";
-
-import misstrokes from "../json/misstrokes.json";
 import LookupResultsOutlinesAndDicts from "./LookupResultsOutlinesAndDicts";
 import MatchedModifiedTranslation from "./MatchedModifiedTranslation";
 import PloverMisstrokesDetail from "./PloverMisstrokesDetail";

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -22,7 +22,7 @@ type Props = {
     importedPersonalDictionaries?: any
   ) => Promise<any>;
   lookupTerm?: string;
-  onChange?: any;
+  onChange?: (phrase: string) => void;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -10,7 +10,7 @@ import StrokesAsDiagrams from "./StrokesAsDiagrams";
 
 import type {
   GlobalUserSettings,
-  // LookupDictWithNamespacedDictsAndConfig,
+  LookupDictWithNamespacedDictsAndConfig,
   StenoDictionary,
   StrokeAndDictionaryAndNamespace,
   UserSettings,
@@ -23,8 +23,7 @@ type Props = {
   ) => Promise<any>;
   lookupTerm?: string;
   onChange?: any;
-  globalLookupDictionary: any;
-  // globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
   trackPhrase?: (value: React.SetStateAction<string>) => void;

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -9,6 +9,7 @@ import PloverMisstrokesDetail from "./PloverMisstrokesDetail";
 import StrokesAsDiagrams from "./StrokesAsDiagrams";
 
 import type {
+  FetchAndSetupGlobalDict,
   GlobalUserSettings,
   LookupDictWithNamespacedDictsAndConfig,
   StenoDictionary,
@@ -17,10 +18,7 @@ import type {
 } from "../types";
 
 type Props = {
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   lookupTerm?: string;
   onChange?: (phrase: string) => void;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -13,13 +13,11 @@ import LookupResultsOutlinesAndDicts from "./LookupResultsOutlinesAndDicts";
 import type {
   GlobalUserSettings,
   // LookupDictWithNamespacedDictsAndConfig,
-  PersonalDictionaryNameAndContents,
   StenoDictionary,
   UserSettings,
 } from "../types";
 
 type Props = {
-  personalDictionaries: PersonalDictionaryNameAndContents[];
   fetchAndSetupGlobalDict: (
     withPlover: boolean,
     importedPersonalDictionaries?: any
@@ -35,7 +33,6 @@ type Props = {
 };
 
 const StrokesForWords = ({
-  personalDictionaries,
   fetchAndSetupGlobalDict,
   lookupTerm,
   onChange,
@@ -57,16 +54,7 @@ const StrokesForWords = ({
   useEffect(() => {
     // if (this.props.globalLookupDictionary && this.props.globalLookupDictionary.size < 2 && !this.props.globalLookupDictionaryLoaded) {
 
-    const shouldUsePersonalDictionaries =
-      personalDictionaries &&
-      Object.entries(personalDictionaries).length > 0 &&
-      // @ts-ignore FIXME: check if the types are wrong…
-      !!personalDictionaries.dictionariesNamesAndContents;
-
-    fetchAndSetupGlobalDict(
-      true,
-      shouldUsePersonalDictionaries ? personalDictionaries : null
-    )
+    fetchAndSetupGlobalDict(true, null)
       .then(() => {
         if (lookupTerm && lookupTerm !== undefined && lookupTerm.length > 0) {
           setPhraseState(lookupTerm);

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -68,8 +68,8 @@ const StrokesForWords = ({
     // }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  // }, [fetchAndSetupGlobalDict, lookupTerm, personalDictionaries, updateWordsForStrokes]);
+  }, [fetchAndSetupGlobalDict, lookupTerm]);
+  // }, [fetchAndSetupGlobalDict, lookupTerm, updateWordsForStrokes]);
 
   const handleWordsOnChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
     event

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import SOURCE_NAMESPACES from "../constant/sourceNamespaces";
-import splitBriefsIntoStrokes from "./../utils/splitBriefsIntoStrokes";
 import lookupListOfStrokesAndDicts from "../utils/lookupListOfStrokesAndDicts";
+import splitBriefsIntoStrokes from "./../utils/splitBriefsIntoStrokes";
 
 import misstrokes from "../json/misstrokes.json";
+import LookupResultsOutlinesAndDicts from "./LookupResultsOutlinesAndDicts";
+import MatchedModifiedTranslation from "./MatchedModifiedTranslation";
 import PloverMisstrokesDetail from "./PloverMisstrokesDetail";
 import StrokesAsDiagrams from "./StrokesAsDiagrams";
-import MatchedModifiedTranslation from "./MatchedModifiedTranslation";
-import LookupResultsOutlinesAndDicts from "./LookupResultsOutlinesAndDicts";
 
 import type {
   GlobalUserSettings,

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -4,11 +4,35 @@ import SOURCE_NAMESPACES from "../constant/sourceNamespaces";
 import splitBriefsIntoStrokes from "./../utils/splitBriefsIntoStrokes";
 import lookupListOfStrokesAndDicts from "../utils/lookupListOfStrokesAndDicts";
 
-import misstrokesJSON from "../json/misstrokes.json";
+import misstrokes from "../json/misstrokes.json";
 import PloverMisstrokesDetail from "./PloverMisstrokesDetail";
 import StrokesAsDiagrams from "./StrokesAsDiagrams";
 import MatchedModifiedTranslation from "./MatchedModifiedTranslation";
 import LookupResultsOutlinesAndDicts from "./LookupResultsOutlinesAndDicts";
+
+import type {
+  GlobalUserSettings,
+  // LookupDictWithNamespacedDictsAndConfig,
+  PersonalDictionaryNameAndContents,
+  StenoDictionary,
+  UserSettings,
+} from "../types";
+
+type Props = {
+  personalDictionaries: PersonalDictionaryNameAndContents[];
+  fetchAndSetupGlobalDict: (
+    withPlover: boolean,
+    importedPersonalDictionaries?: any
+  ) => Promise<any>;
+  lookupTerm?: string;
+  onChange?: any;
+  globalLookupDictionary: any;
+  // globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
+  globalLookupDictionaryLoaded: boolean;
+  globalUserSettings: GlobalUserSettings;
+  trackPhrase?: any;
+  userSettings: UserSettings;
+};
 
 const StrokesForWords = ({
   personalDictionaries,
@@ -20,7 +44,7 @@ const StrokesForWords = ({
   globalUserSettings,
   trackPhrase,
   userSettings,
-}) => {
+}: Props) => {
   const [modifiedWordOrPhraseState, setModifiedWordOrPhraseState] =
     useState("");
   const [phraseState, setPhraseState] = useState("");
@@ -28,12 +52,15 @@ const StrokesForWords = ({
     []
   );
 
+  const misstrokesJSON = misstrokes as StenoDictionary;
+
   useEffect(() => {
     // if (this.props.globalLookupDictionary && this.props.globalLookupDictionary.size < 2 && !this.props.globalLookupDictionaryLoaded) {
 
     const shouldUsePersonalDictionaries =
       personalDictionaries &&
       Object.entries(personalDictionaries).length > 0 &&
+      // @ts-ignore FIXME: check if the types are wrong…
       !!personalDictionaries.dictionariesNamesAndContents;
 
     fetchAndSetupGlobalDict(
@@ -56,12 +83,14 @@ const StrokesForWords = ({
   }, []);
   // }, [fetchAndSetupGlobalDict, lookupTerm, personalDictionaries, updateWordsForStrokes]);
 
-  function handleWordsOnChange(event) {
+  const handleWordsOnChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
+    event
+  ) => {
     let phrase = event.target.value;
     updateWordsForStrokes(phrase);
-  }
+  };
 
-  function updateWordsForStrokes(phrase) {
+  function updateWordsForStrokes(phrase: string) {
     if (onChange) {
       onChange(phrase);
     }
@@ -86,6 +115,7 @@ const StrokesForWords = ({
 
     setModifiedWordOrPhraseState(modifiedWordOrPhrase);
     setPhraseState(phrase);
+    // @ts-ignore FIXME
     setListOfStrokesAndDictsState(listOfStrokesAndDicts);
   }
 
@@ -116,7 +146,7 @@ const StrokesForWords = ({
         autoCorrect="off"
         className="input-textarea input-textarea--large mb3 w-100 overflow-hidden"
         id="words-for-strokes"
-        onChange={handleWordsOnChange.bind(this)}
+        onChange={handleWordsOnChange}
         placeholder="e.g. quadruplicate"
         rows={1}
         spellCheck={false}

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -78,6 +78,9 @@ const StrokesForWords = ({
     updateWordsForStrokes(phrase);
   };
 
+  const showMisstrokesInLookup =
+    globalUserSettings?.showMisstrokesInLookup ?? false;
+
   function updateWordsForStrokes(phrase: string) {
     if (onChange) {
       onChange(phrase);
@@ -86,7 +89,7 @@ const StrokesForWords = ({
     let [listOfStrokesAndDicts, modifiedWordOrPhrase] =
       lookupListOfStrokesAndDicts(phrase, globalLookupDictionary);
 
-    if (!globalUserSettings?.showMisstrokesInLookup) {
+    if (!showMisstrokesInLookup) {
       listOfStrokesAndDicts = listOfStrokesAndDicts.filter(
         (row) =>
           row[2] === SOURCE_NAMESPACES.get("user") ||

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -12,6 +12,7 @@ import type {
   GlobalUserSettings,
   // LookupDictWithNamespacedDictsAndConfig,
   StenoDictionary,
+  StrokeAndDictionaryAndNamespace,
   UserSettings,
 } from "../types";
 
@@ -26,7 +27,7 @@ type Props = {
   // globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
-  trackPhrase?: any;
+  trackPhrase?: (value: React.SetStateAction<string>) => void;
   userSettings: UserSettings;
 };
 
@@ -43,9 +44,9 @@ const StrokesForWords = ({
   const [modifiedWordOrPhraseState, setModifiedWordOrPhraseState] =
     useState("");
   const [phraseState, setPhraseState] = useState("");
-  const [listOfStrokesAndDictsState, setListOfStrokesAndDictsState] = useState(
-    []
-  );
+  const [listOfStrokesAndDictsState, setListOfStrokesAndDictsState] = useState<
+    StrokeAndDictionaryAndNamespace[]
+  >([]);
 
   const misstrokesJSON = misstrokes as StenoDictionary;
 
@@ -104,7 +105,6 @@ const StrokesForWords = ({
 
     setModifiedWordOrPhraseState(modifiedWordOrPhrase);
     setPhraseState(phrase);
-    // @ts-ignore FIXME
     setListOfStrokesAndDictsState(listOfStrokesAndDicts);
   }
 

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -7,7 +7,7 @@ import PageLoading from "../../components/PageLoading";
 import type {
   Experiments,
   GlobalUserSettings,
-  LookupDictWithNamespacedDicts,
+  LookupDictWithNamespacedDictsAndConfig,
   UserSettings,
 } from "../../types";
 
@@ -29,7 +29,7 @@ type Props = {
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  globalLookupDictionary: LookupDictWithNamespacedDicts;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
   setDictionaryIndex: () => void;

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -6,6 +6,7 @@ import PageLoading from "../../components/PageLoading";
 
 import type {
   Experiments,
+  FetchAndSetupGlobalDict,
   GlobalUserSettings,
   LookupDictWithNamespacedDictsAndConfig,
   UserSettings,
@@ -25,10 +26,7 @@ const AsyncDictionaryManagement = Loadable({
 
 type Props = {
   dictionaryIndex: any;
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -8,7 +8,6 @@ import type {
   Experiments,
   GlobalUserSettings,
   LookupDictWithNamespacedDicts,
-  PersonalDictionaryNameAndContents,
   UserSettings,
 } from "../../types";
 
@@ -33,11 +32,9 @@ type Props = {
   globalLookupDictionary: LookupDictWithNamespacedDicts;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
-  personalDictionaries: PersonalDictionaryNameAndContents[];
   setDictionaryIndex: () => void;
   stenohintsonthefly: Pick<Experiments, "stenohintsonthefly">;
   toggleExperiment: any;
-  updateGlobalLookupDictionary: any;
   updatePersonalDictionaries: any;
   userSettings: UserSettings;
   [restProps: string]: any;
@@ -48,11 +45,9 @@ const Dictionaries = ({
   globalLookupDictionaryLoaded,
   globalLookupDictionary,
   globalUserSettings,
-  personalDictionaries,
   setDictionaryIndex,
   stenohintsonthefly,
   toggleExperiment,
-  updateGlobalLookupDictionary,
   updatePersonalDictionaries,
   userSettings,
   fetchAndSetupGlobalDict,
@@ -101,9 +96,6 @@ const Dictionaries = ({
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
             globalUserSettings={globalUserSettings}
             fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
-            personalDictionaries={personalDictionaries}
-            updateGlobalLookupDictionary={updateGlobalLookupDictionary}
-            updatePersonalDictionaries={updatePersonalDictionaries}
             {...dictionaryProps}
           />
         </Route>

--- a/src/pages/dictionaries/DictionariesIndex.tsx
+++ b/src/pages/dictionaries/DictionariesIndex.tsx
@@ -438,9 +438,6 @@ const DictionariesIndex = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               globalUserSettings={globalUserSettings}
-              lookupTerm={undefined} /* FIXME: should be optional */
-              onChange={undefined} /* FIXME: should this be optional? */
-              trackPhrase={undefined} /* FIXME: should be optional */
               userSettings={userSettings}
             />
           </div>

--- a/src/pages/dictionaries/DictionariesIndex.tsx
+++ b/src/pages/dictionaries/DictionariesIndex.tsx
@@ -11,7 +11,6 @@ import type {
   Experiments,
   GlobalUserSettings,
   LookupDictWithNamespacedDicts,
-  PersonalDictionaryNameAndContents,
   PrettyLessonTitle,
   StenoDictionary,
   UserSettings,
@@ -29,11 +28,8 @@ type Props = {
   globalLookupDictionary: LookupDictWithNamespacedDicts;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
-  personalDictionaries: PersonalDictionaryNameAndContents[];
   setDictionaryIndex: () => void;
   stenohintsonthefly: Pick<Experiments, "stenohintsonthefly">;
-  updateGlobalLookupDictionary: any;
-  updatePersonalDictionaries: any;
   userSettings: UserSettings;
 };
 
@@ -103,10 +99,7 @@ const DictionariesIndex = ({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
   globalUserSettings,
-  personalDictionaries,
   stenohintsonthefly,
-  updateGlobalLookupDictionary,
-  updatePersonalDictionaries,
   userSettings,
 }: Props) => {
   const mainHeading = useRef<HTMLHeadingElement>(null);
@@ -447,7 +440,6 @@ const DictionariesIndex = ({
               globalUserSettings={globalUserSettings}
               lookupTerm={undefined} /* FIXME: should be optional */
               onChange={undefined} /* FIXME: should this be optional? */
-              personalDictionaries={personalDictionaries}
               trackPhrase={undefined} /* FIXME: should be optional */
               userSettings={userSettings}
             />

--- a/src/pages/dictionaries/DictionariesIndex.tsx
+++ b/src/pages/dictionaries/DictionariesIndex.tsx
@@ -10,7 +10,7 @@ import useAnnounceTooltip from "../../components/Announcer/useAnnounceTooltip";
 import type {
   Experiments,
   GlobalUserSettings,
-  LookupDictWithNamespacedDicts,
+  LookupDictWithNamespacedDictsAndConfig,
   PrettyLessonTitle,
   StenoDictionary,
   UserSettings,
@@ -25,7 +25,7 @@ type Props = {
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  globalLookupDictionary: LookupDictWithNamespacedDicts;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
   setDictionaryIndex: () => void;

--- a/src/pages/dictionaries/DictionariesIndex.tsx
+++ b/src/pages/dictionaries/DictionariesIndex.tsx
@@ -9,6 +9,7 @@ import useAnnounceTooltip from "../../components/Announcer/useAnnounceTooltip";
 
 import type {
   Experiments,
+  FetchAndSetupGlobalDict,
   GlobalUserSettings,
   LookupDictWithNamespacedDictsAndConfig,
   PrettyLessonTitle,
@@ -21,10 +22,7 @@ type DictLink = string;
 
 type Props = {
   dictionaryIndex: any;
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -9,7 +9,6 @@ import type {
   GlobalUserSettings,
   LookupDictWithNamespacedDicts,
   MetWords,
-  PersonalDictionaryNameAndContents,
   UserSettings,
 } from "../../types";
 
@@ -58,7 +57,6 @@ type Props = {
   globalLookupDictionary: LookupDictWithNamespacedDicts;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
-  personalDictionaries: PersonalDictionaryNameAndContents[];
   startingMetWordsToday: MetWords;
   globalUserSettings: GlobalUserSettings;
   userSettings: UserSettings;
@@ -72,7 +70,6 @@ const Games = ({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
   metWords,
-  personalDictionaries,
   globalUserSettings,
   userSettings,
   startingMetWordsToday,
@@ -94,7 +91,6 @@ const Games = ({
             <AsyncKHAERT
               fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
               globalLookupDictionary={globalLookupDictionary}
-              personalDictionaries={personalDictionaries}
             />
           </ErrorBoundary>
         </DocumentTitle>
@@ -106,7 +102,6 @@ const Games = ({
               fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              personalDictionaries={personalDictionaries}
               startingMetWordsToday={startingMetWordsToday}
               updateMetWords={updateMetWords}
             />
@@ -128,7 +123,6 @@ const Games = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               metWords={metWords}
-              personalDictionaries={personalDictionaries}
               globalUserSettings={globalUserSettings}
               userSettings={userSettings}
               updateMultipleMetWords={updateMultipleMetWords}

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -6,6 +6,7 @@ import Loadable from "react-loadable";
 import PageLoading from "../../components/PageLoading";
 import "./Games.scss";
 import type {
+  FetchAndSetupGlobalDict,
   GlobalUserSettings,
   LookupDictWithNamespacedDictsAndConfig,
   MetWords,
@@ -50,10 +51,7 @@ const AsyncKPOES = Loadable({
 
 type Props = {
   match: any;
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -7,7 +7,7 @@ import PageLoading from "../../components/PageLoading";
 import "./Games.scss";
 import type {
   GlobalUserSettings,
-  LookupDictWithNamespacedDicts,
+  LookupDictWithNamespacedDictsAndConfig,
   MetWords,
   UserSettings,
 } from "../../types";
@@ -54,7 +54,7 @@ type Props = {
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  globalLookupDictionary: LookupDictWithNamespacedDicts;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
   startingMetWordsToday: MetWords;

--- a/src/pages/games/KHAERT/Index.jsx
+++ b/src/pages/games/KHAERT/Index.jsx
@@ -5,26 +5,17 @@ import Subheader from "../../../components/Subheader";
 export default function Index({
   fetchAndSetupGlobalDict,
   globalLookupDictionary,
-  personalDictionaries,
 }) {
   const mainHeading = useRef(null);
   useEffect(() => {
-    const shouldUsePersonalDictionaries =
-      personalDictionaries &&
-      Object.entries(personalDictionaries).length > 0 &&
-      !!personalDictionaries.dictionariesNamesAndContents;
-
-    fetchAndSetupGlobalDict(
-      false,
-      shouldUsePersonalDictionaries ? personalDictionaries : null
-    ).catch((error) => {
+    fetchAndSetupGlobalDict(false, null).catch((error) => {
       console.error(error);
     });
 
     if (mainHeading) {
       mainHeading.current.focus();
     }
-  }, [fetchAndSetupGlobalDict, personalDictionaries]);
+  }, [fetchAndSetupGlobalDict]);
 
   return (
     <main id="main">

--- a/src/pages/games/KPOES/Game.stories.jsx
+++ b/src/pages/games/KPOES/Game.stories.jsx
@@ -16,7 +16,6 @@ const Template = (args) => (
       globalLookupDictionary={new Map()}
       globalLookupDictionaryLoaded={true}
       metWords={{}}
-      personalDictionaries={{}}
       globalUserSettings={globalUserSettings}
       userSettings={userSettings}
       updateMultipleMetWords={() => {}}

--- a/src/pages/games/KPOES/Game.tsx
+++ b/src/pages/games/KPOES/Game.tsx
@@ -6,11 +6,7 @@ import { ReactComponent as ComposingRobot } from "../../../images/ComposingRobot
 import StrokesForWords from "../../../components/StrokesForWords";
 import "./styles.scss";
 
-import type {
-  LookupDictWithNamespacedDicts,
-  MetWords,
-  PersonalDictionaryNameAndContents,
-} from "../../../types";
+import type { LookupDictWithNamespacedDicts, MetWords } from "../../../types";
 
 type Props = {
   fetchAndSetupGlobalDict: (
@@ -20,7 +16,6 @@ type Props = {
   globalLookupDictionary: LookupDictWithNamespacedDicts;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
-  personalDictionaries: PersonalDictionaryNameAndContents[];
   globalUserSettings: any;
   userSettings: any;
   updateMultipleMetWords: (newMetWords: string[]) => void;
@@ -35,7 +30,6 @@ export default function Game({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
   metWords,
-  personalDictionaries,
   globalUserSettings,
   userSettings,
   updateMultipleMetWords,
@@ -76,7 +70,6 @@ export default function Game({
             globalUserSettings={globalUserSettings}
             lookupTerm={undefined} /* FIXME: should be optional */
             onChange={undefined} /* FIXME: should be optional */
-            personalDictionaries={personalDictionaries}
             trackPhrase={undefined} /* FIXME: should be optional */
             userSettings={userSettings}
           />

--- a/src/pages/games/KPOES/Game.tsx
+++ b/src/pages/games/KPOES/Game.tsx
@@ -7,15 +7,13 @@ import StrokesForWords from "../../../components/StrokesForWords";
 import "./styles.scss";
 
 import type {
+  FetchAndSetupGlobalDict,
   LookupDictWithNamespacedDictsAndConfig,
   MetWords,
 } from "../../../types";
 
 type Props = {
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;

--- a/src/pages/games/KPOES/Game.tsx
+++ b/src/pages/games/KPOES/Game.tsx
@@ -68,9 +68,6 @@ export default function Game({
             globalLookupDictionary={globalLookupDictionary}
             globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
             globalUserSettings={globalUserSettings}
-            lookupTerm={undefined} /* FIXME: should be optional */
-            onChange={undefined} /* FIXME: should be optional */
-            trackPhrase={undefined} /* FIXME: should be optional */
             userSettings={userSettings}
           />
         </div>

--- a/src/pages/games/KPOES/Game.tsx
+++ b/src/pages/games/KPOES/Game.tsx
@@ -6,14 +6,17 @@ import { ReactComponent as ComposingRobot } from "../../../images/ComposingRobot
 import StrokesForWords from "../../../components/StrokesForWords";
 import "./styles.scss";
 
-import type { LookupDictWithNamespacedDicts, MetWords } from "../../../types";
+import type {
+  LookupDictWithNamespacedDictsAndConfig,
+  MetWords,
+} from "../../../types";
 
 type Props = {
   fetchAndSetupGlobalDict: (
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  globalLookupDictionary: LookupDictWithNamespacedDicts;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
   globalUserSettings: any;

--- a/src/pages/games/KPOES/Index.tsx
+++ b/src/pages/games/KPOES/Index.tsx
@@ -3,15 +3,13 @@ import Game from "./Game";
 import Subheader from "../../../components/Subheader";
 
 import type {
+  FetchAndSetupGlobalDict,
   LookupDictWithNamespacedDictsAndConfig,
   MetWords,
 } from "../../../types";
 
 type Props = {
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;

--- a/src/pages/games/KPOES/Index.tsx
+++ b/src/pages/games/KPOES/Index.tsx
@@ -12,7 +12,6 @@ type Props = {
   globalLookupDictionary: LookupDictWithNamespacedDicts;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
-  personalDictionaries: any; // PersonalDictionaryNameAndContents[];
   globalUserSettings: any;
   userSettings: any;
   updateMultipleMetWords: (newMetWords: string[]) => void;
@@ -23,7 +22,6 @@ export default function Index({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
   metWords,
-  personalDictionaries,
   globalUserSettings,
   userSettings,
   updateMultipleMetWords,
@@ -35,18 +33,10 @@ export default function Index({
   }, []);
 
   useEffect(() => {
-    const shouldUsePersonalDictionaries =
-      personalDictionaries &&
-      Object.entries(personalDictionaries).length > 0 &&
-      !!personalDictionaries.dictionariesNamesAndContents;
-
-    fetchAndSetupGlobalDict(
-      false,
-      shouldUsePersonalDictionaries ? personalDictionaries : null
-    ).catch((error) => {
+    fetchAndSetupGlobalDict(false, null).catch((error) => {
       console.error(error);
     });
-  }, [fetchAndSetupGlobalDict, personalDictionaries]);
+  }, [fetchAndSetupGlobalDict]);
 
   return (
     <main id="main">
@@ -62,7 +52,6 @@ export default function Index({
       <Game
         fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
         metWords={metWords}
-        personalDictionaries={personalDictionaries}
         globalLookupDictionary={globalLookupDictionary}
         globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
         globalUserSettings={globalUserSettings}

--- a/src/pages/games/KPOES/Index.tsx
+++ b/src/pages/games/KPOES/Index.tsx
@@ -2,14 +2,17 @@ import React, { useEffect, useRef } from "react";
 import Game from "./Game";
 import Subheader from "../../../components/Subheader";
 
-import type { LookupDictWithNamespacedDicts, MetWords } from "../../../types";
+import type {
+  LookupDictWithNamespacedDictsAndConfig,
+  MetWords,
+} from "../../../types";
 
 type Props = {
   fetchAndSetupGlobalDict: (
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  globalLookupDictionary: LookupDictWithNamespacedDicts;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
   metWords: MetWords;
   globalUserSettings: any;

--- a/src/pages/games/SHUFL/Index.jsx
+++ b/src/pages/games/SHUFL/Index.jsx
@@ -7,7 +7,6 @@ export default function Index({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
   startingMetWordsToday,
-  personalDictionaries,
   updateMetWords,
 }) {
   const mainHeading = useRef(null);
@@ -18,18 +17,10 @@ export default function Index({
   }, []);
 
   useEffect(() => {
-    const shouldUsePersonalDictionaries =
-      personalDictionaries &&
-      Object.entries(personalDictionaries).length > 0 &&
-      !!personalDictionaries.dictionariesNamesAndContents;
-
-    fetchAndSetupGlobalDict(
-      false,
-      shouldUsePersonalDictionaries ? personalDictionaries : null
-    ).catch((error) => {
+    fetchAndSetupGlobalDict(false, null).catch((error) => {
       console.error(error);
     });
-  }, [fetchAndSetupGlobalDict, personalDictionaries]);
+  }, [fetchAndSetupGlobalDict]);
 
   return (
     <main id="main">

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -278,7 +278,6 @@ const Lessons = ({
               fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              personalDictionaries={personalDictionaries}
               {...lessonProps}
               {...props}
             />
@@ -299,7 +298,6 @@ const Lessons = ({
                 fetchAndSetupGlobalDict={fetchAndSetupGlobalDict}
                 generateCustomLesson={generateCustomLesson}
                 globalLookupDictionary={globalLookupDictionary}
-                personalDictionaries={personalDictionaries}
                 {...lessonProps}
               />
             </ErrorBoundary>

--- a/src/pages/lessons/MainLessonView.stories.jsx
+++ b/src/pages/lessons/MainLessonView.stories.jsx
@@ -115,7 +115,6 @@ const Template = (args) => {
             stopLesson={stopLesson}
             userSettings={userSettings}
             updateFlashcardsProgress={() => undefined}
-            changeFullscreen={() => undefined}
             flashcardsMetWords={{}}
             customLessonMaterial={[]}
             customLessonMaterialValidationState={[]}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -10,7 +10,7 @@ import Material from "../../components/Material";
 import TypedText from "../../components/TypedText";
 import Scores from "../../components/Scores";
 import StrokeTip from "./components/StrokeTip";
-import UserSettings from "./components/UserSettings";
+import UserSettings from "./components/UserSettings/UserSettings";
 import AussieDictPrompt from "../../components/LessonPrompts/AussieDictPrompt";
 import SedSaidPrompt from "../../components/LessonPrompts/SedSaidPrompt";
 import WordBoundaryErrorPrompt from "../../components/LessonPrompts/WordBoundaryErrorPrompt";

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import LessonCanvasFooter from "./LessonCanvasFooter";
 import FinishedZeroAndEmptyStateMessage from "./FinishedZeroAndEmptyState";
-import UserSettings from "./UserSettings";
+import UserSettings from "./UserSettings/UserSettings";
 import {
   stitchTogetherLessonData,
   transformLessonDataToChartData,

--- a/src/pages/lessons/components/UserSettings.stories.jsx
+++ b/src/pages/lessons/components/UserSettings.stories.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import UserSettings from "./UserSettings";
+import UserSettings from "./UserSettings/UserSettings";
 import userSettingsFixture from "../../../stories/fixtures/userSettings";
 
 const meta = {

--- a/src/pages/lessons/components/UserSettings/UserSettings.stories.jsx
+++ b/src/pages/lessons/components/UserSettings/UserSettings.stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import UserSettings from "./UserSettings/UserSettings";
-import userSettingsFixture from "../../../stories/fixtures/userSettings";
+import UserSettings from "./UserSettings";
+import userSettingsFixture from "../../../../stories/fixtures/userSettings";
 
 const meta = {
   title: "Pages/UserSettings",

--- a/src/pages/lessons/components/UserSettings/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings/UserSettings.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Tooltip } from "react-tippy";
-import ErrorBoundary from "../../../components/ErrorBoundary";
+import ErrorBoundary from "../../../../components/ErrorBoundary";
 import NumericInput from "react-numeric-input";
-import SettingCheckbox from "../../../components/SettingCheckbox";
-import SettingListItem from "../../../components/SettingListItem";
-import SpeakWordsHelp from "./SpeakWordsHelp";
-import VoiceSetting from "./VoiceSetting";
-import useAnnounceTooltip from "../../../components/Announcer/useAnnounceTooltip";
+import SettingCheckbox from "../../../../components/SettingCheckbox";
+import SettingListItem from "../../../../components/SettingListItem";
+import SpeakWordsHelp from "../SpeakWordsHelp";
+import VoiceSetting from "../VoiceSetting";
+import useAnnounceTooltip from "../../../../components/Announcer/useAnnounceTooltip";
 
-import type { UserSettings as UserSettingsObjectType } from "../../../types";
+import type { UserSettings as UserSettingsObjectType } from "../../../../types";
 
 const grabStyle = function () {
   return false;

--- a/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
+++ b/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
@@ -1,9 +1,9 @@
 import isNormalInteger from "../../../../utils/isNormalInteger";
 
-const applyQueryParamsToUserSettings = (newSettings, parsedParams, userSettings) => {
+const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
     // Update newSettings using URL search query parameters:
     for (const [param, paramVal] of Object.entries(parsedParams)) {
-      if (param in userSettings) {
+      if (param in newSettings) {
         const booleanParams = [
           'blurMaterial',
           'caseSensitive',

--- a/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
+++ b/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
@@ -1,0 +1,90 @@
+import isNormalInteger from "../../../../utils/isNormalInteger";
+
+const applyQueryParamsToUserSettings = (newSettings, parsedParams, userSettings) => {
+    // Update newSettings using URL search query parameters:
+    for (const [param, paramVal] of Object.entries(parsedParams)) {
+      if (param in userSettings) {
+        const booleanParams = [
+          'blurMaterial',
+          'caseSensitive',
+          'simpleTypography',
+          'punctuationDescriptions',
+          'retainedWords',
+          'newWords',
+          'showScoresWhileTyping',
+          'showStrokes',
+          'showStrokesAsDiagrams',
+          'showStrokesAsList',
+          'hideStrokesOnLastRepetition',
+          'speakMaterial',
+          'textInputAccessibility',
+          'seenWords'
+        ];
+
+        if (booleanParams.includes(param)) {
+          if (paramVal === "1") { newSettings[param] = true; }
+          if (paramVal === "0") { newSettings[param] = false; }
+        }
+
+        const spacePlacementValidValues = [
+          'spaceOff',
+          'spaceBeforeOutput',
+          'spaceAfterOutput',
+          'spaceExact'
+        ];
+
+        if (param === 'spacePlacement' && spacePlacementValidValues.includes(paramVal)) {
+          newSettings[param] = paramVal;
+        }
+
+        const sortOrderValidValues = [
+          'sortOff',
+          'sortNew',
+          'sortOld',
+          'sortRandom',
+          'sortLongest',
+          'sortShortest'
+        ];
+
+        if (param === 'sortOrder' && sortOrderValidValues.includes(paramVal)) {
+          newSettings[param] = paramVal;
+        }
+
+        const studyValidValues = [
+          'discover',
+          'revise',
+          'drill',
+          'practice'
+        ];
+
+        if (param === 'study' && studyValidValues.includes(paramVal)) {
+          newSettings[param] = paramVal;
+        }
+
+        const stenoLayoutValidValues = [
+          'stenoLayoutAmericanSteno',
+          'stenoLayoutNoNumberBarInnerThumbNumbers',
+          'stenoLayoutNoNumberBarOuterThumbNumbers',
+          'stenoLayoutPalantype',
+          'stenoLayoutBrazilianPortugueseSteno',
+          'stenoLayoutDanishSteno',
+          'stenoLayoutItalianMichelaSteno',
+          'stenoLayoutItalianMelaniSteno',
+          'stenoLayoutJapanese',
+          'stenoLayoutKoreanModernC',
+          // 'stenoLayoutKoreanModernS'
+        ];
+
+        if (param === 'stenoLayout' && stenoLayoutValidValues.includes(paramVal)) {
+          newSettings[param] = paramVal;
+        }
+
+        if ((param === 'repetitions' || param === 'limitNumberOfWords' || param === 'startFromWord') && isNormalInteger(paramVal)) {
+          let paramValNumber = Number(paramVal);
+          newSettings[param] = paramValNumber;
+        }
+      }
+    }
+}
+
+export default applyQueryParamsToUserSettings;

--- a/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
+++ b/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.js
@@ -1,90 +1,100 @@
 import isNormalInteger from "../../../../utils/isNormalInteger";
 
 const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
-    // Update newSettings using URL search query parameters:
-    for (const [param, paramVal] of Object.entries(parsedParams)) {
-      if (param in newSettings) {
-        const booleanParams = [
-          'blurMaterial',
-          'caseSensitive',
-          'simpleTypography',
-          'punctuationDescriptions',
-          'retainedWords',
-          'newWords',
-          'showScoresWhileTyping',
-          'showStrokes',
-          'showStrokesAsDiagrams',
-          'showStrokesAsList',
-          'hideStrokesOnLastRepetition',
-          'speakMaterial',
-          'textInputAccessibility',
-          'seenWords'
-        ];
+  // Update newSettings using URL search query parameters:
+  for (const [param, paramVal] of Object.entries(parsedParams)) {
+    if (param in newSettings) {
+      const booleanParams = [
+        "blurMaterial",
+        "caseSensitive",
+        "simpleTypography",
+        "punctuationDescriptions",
+        "retainedWords",
+        "newWords",
+        "showScoresWhileTyping",
+        "showStrokes",
+        "showStrokesAsDiagrams",
+        "showStrokesAsList",
+        "hideStrokesOnLastRepetition",
+        "speakMaterial",
+        "textInputAccessibility",
+        "seenWords",
+      ];
 
-        if (booleanParams.includes(param)) {
-          if (paramVal === "1") { newSettings[param] = true; }
-          if (paramVal === "0") { newSettings[param] = false; }
+      if (booleanParams.includes(param)) {
+        if (paramVal === "1") {
+          newSettings[param] = true;
         }
-
-        const spacePlacementValidValues = [
-          'spaceOff',
-          'spaceBeforeOutput',
-          'spaceAfterOutput',
-          'spaceExact'
-        ];
-
-        if (param === 'spacePlacement' && spacePlacementValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const sortOrderValidValues = [
-          'sortOff',
-          'sortNew',
-          'sortOld',
-          'sortRandom',
-          'sortLongest',
-          'sortShortest'
-        ];
-
-        if (param === 'sortOrder' && sortOrderValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const studyValidValues = [
-          'discover',
-          'revise',
-          'drill',
-          'practice'
-        ];
-
-        if (param === 'study' && studyValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        const stenoLayoutValidValues = [
-          'stenoLayoutAmericanSteno',
-          'stenoLayoutNoNumberBarInnerThumbNumbers',
-          'stenoLayoutNoNumberBarOuterThumbNumbers',
-          'stenoLayoutPalantype',
-          'stenoLayoutBrazilianPortugueseSteno',
-          'stenoLayoutDanishSteno',
-          'stenoLayoutItalianMichelaSteno',
-          'stenoLayoutItalianMelaniSteno',
-          'stenoLayoutJapanese',
-          'stenoLayoutKoreanModernC',
-          // 'stenoLayoutKoreanModernS'
-        ];
-
-        if (param === 'stenoLayout' && stenoLayoutValidValues.includes(paramVal)) {
-          newSettings[param] = paramVal;
-        }
-
-        if ((param === 'repetitions' || param === 'limitNumberOfWords' || param === 'startFromWord') && isNormalInteger(paramVal)) {
-          let paramValNumber = Number(paramVal);
-          newSettings[param] = paramValNumber;
+        if (paramVal === "0") {
+          newSettings[param] = false;
         }
       }
+
+      const spacePlacementValidValues = [
+        "spaceOff",
+        "spaceBeforeOutput",
+        "spaceAfterOutput",
+        "spaceExact",
+      ];
+
+      if (
+        param === "spacePlacement" &&
+        spacePlacementValidValues.includes(paramVal)
+      ) {
+        newSettings[param] = paramVal;
+      }
+
+      const sortOrderValidValues = [
+        "sortOff",
+        "sortNew",
+        "sortOld",
+        "sortRandom",
+        "sortLongest",
+        "sortShortest",
+      ];
+
+      if (param === "sortOrder" && sortOrderValidValues.includes(paramVal)) {
+        newSettings[param] = paramVal;
+      }
+
+      const studyValidValues = ["discover", "revise", "drill", "practice"];
+
+      if (param === "study" && studyValidValues.includes(paramVal)) {
+        newSettings[param] = paramVal;
+      }
+
+      const stenoLayoutValidValues = [
+        "stenoLayoutAmericanSteno",
+        "stenoLayoutNoNumberBarInnerThumbNumbers",
+        "stenoLayoutNoNumberBarOuterThumbNumbers",
+        "stenoLayoutPalantype",
+        "stenoLayoutBrazilianPortugueseSteno",
+        "stenoLayoutDanishSteno",
+        "stenoLayoutItalianMichelaSteno",
+        "stenoLayoutItalianMelaniSteno",
+        "stenoLayoutJapanese",
+        "stenoLayoutKoreanModernC",
+        // 'stenoLayoutKoreanModernS'
+      ];
+
+      if (
+        param === "stenoLayout" &&
+        stenoLayoutValidValues.includes(paramVal)
+      ) {
+        newSettings[param] = paramVal;
+      }
+
+      if (
+        (param === "repetitions" ||
+          param === "limitNumberOfWords" ||
+          param === "startFromWord") &&
+        isNormalInteger(paramVal)
+      ) {
+        let paramValNumber = Number(paramVal);
+        newSettings[param] = paramValNumber;
+      }
     }
-}
+  }
+};
 
 export default applyQueryParamsToUserSettings;

--- a/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.ts
+++ b/src/pages/lessons/components/UserSettings/applyQueryParamsToUserSettings.ts
@@ -1,9 +1,17 @@
+import queryString from "query-string";
+import type { UserSettings } from "../../../../types";
 import isNormalInteger from "../../../../utils/isNormalInteger";
 
-const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
-  // Update newSettings using URL search query parameters:
+const applyQueryParamsToUserSettings = (
+  newSettings: UserSettings,
+  parsedParams: queryString.ParsedQuery<string>
+) => {
+  function isKeyOfNewSettings(key: string): key is keyof UserSettings {
+    return key in newSettings;
+  }
+
   for (const [param, paramVal] of Object.entries(parsedParams)) {
-    if (param in newSettings) {
+    if (isKeyOfNewSettings(param)) {
       const booleanParams = [
         "blurMaterial",
         "caseSensitive",
@@ -23,9 +31,11 @@ const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
 
       if (booleanParams.includes(param)) {
         if (paramVal === "1") {
+          // @ts-ignore
           newSettings[param] = true;
         }
         if (paramVal === "0") {
+          // @ts-ignore
           newSettings[param] = false;
         }
       }
@@ -39,8 +49,10 @@ const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
 
       if (
         param === "spacePlacement" &&
-        spacePlacementValidValues.includes(paramVal)
+        // @ts-ignore
+        spacePlacementValidValues.includes(paramVal ?? "")
       ) {
+        // @ts-ignore
         newSettings[param] = paramVal;
       }
 
@@ -53,13 +65,17 @@ const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
         "sortShortest",
       ];
 
+      // @ts-ignore
       if (param === "sortOrder" && sortOrderValidValues.includes(paramVal)) {
+        // @ts-ignore
         newSettings[param] = paramVal;
       }
 
       const studyValidValues = ["discover", "revise", "drill", "practice"];
 
+      // @ts-ignore
       if (param === "study" && studyValidValues.includes(paramVal)) {
+        // @ts-ignore
         newSettings[param] = paramVal;
       }
 
@@ -79,8 +95,10 @@ const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
 
       if (
         param === "stenoLayout" &&
+        // @ts-ignore
         stenoLayoutValidValues.includes(paramVal)
       ) {
+        // @ts-ignore
         newSettings[param] = paramVal;
       }
 
@@ -88,7 +106,8 @@ const applyQueryParamsToUserSettings = (newSettings, parsedParams) => {
         (param === "repetitions" ||
           param === "limitNumberOfWords" ||
           param === "startFromWord") &&
-        isNormalInteger(paramVal)
+        // @ts-ignore
+        isNormalInteger(paramVal ?? "")
       ) {
         let paramValNumber = Number(paramVal);
         newSettings[param] = paramValNumber;

--- a/src/pages/lessons/components/UserSettings/updateFlashcardSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateFlashcardSetting.js
@@ -1,3 +1,30 @@
+import GoogleAnalytics from "react-ga4";
+import { writePersonalPreferences } from "../../../../utils/typey-type";
+
+export function changeFlashcardCourseLevel(event) {
+  const value = event.target.value;
+  let globalUserSettings = Object.assign({}, this.state.globalUserSettings);
+  globalUserSettings["flashcardsCourseLevel"] = value;
+
+  this.setState({ globalUserSettings: globalUserSettings }, () => {
+    this.updateFlashcardsRecommendation();
+    writePersonalPreferences("globalUserSettings", globalUserSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "Flashcards",
+    action: "Change course level",
+    label: labelString,
+  });
+
+  return value;
+}
+
 export function changeFullscreen(event) {
   const target = event.target;
   const value = target.type === "checkbox" ? target.checked : target.value;

--- a/src/pages/lessons/components/UserSettings/updateFlashcardSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateFlashcardSetting.js
@@ -1,0 +1,6 @@
+export function changeFullscreen(event) {
+  const target = event.target;
+  const value = target.type === "checkbox" ? target.checked : target.value;
+  this.setState({ fullscreen: value });
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
@@ -1,0 +1,28 @@
+import GoogleAnalytics from "react-ga4";
+import { writePersonalPreferences } from "../../../../utils/typey-type";
+
+// changeWriterInput(event: SyntheticInputEvent<HTMLInputElement>) {
+export function changeWriterInput(event) {
+  let globalUserSettings = Object.assign({}, this.state.globalUserSettings);
+  let name = "BAD_INPUT";
+
+  if (event && event.target && event.target.name) {
+    globalUserSettings["writerInput"] = event.target.name;
+    name = event.target.name;
+  }
+
+  this.setState({ globalUserSettings: globalUserSettings }, () => {
+    writePersonalPreferences("globalUserSettings", globalUserSettings);
+  });
+
+  let labelString = name;
+  if (!name) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "Global user settings",
+    action: "Change writer input",
+    label: labelString,
+  });
+}

--- a/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
@@ -26,3 +26,35 @@ export function changeWriterInput(event) {
     label: labelString,
   });
 }
+
+export function toggleExperiment(event) {
+  let newState = Object.assign({}, this.state.globalUserSettings);
+
+  const target = event.target;
+  const value = target.checked;
+  const name = target.name;
+
+  newState.experiments[name] = value;
+
+  this.setState({ globalUserSettings: newState }, () => {
+    writePersonalPreferences(
+      "globalUserSettings",
+      this.state.globalUserSettings
+    );
+  });
+
+  let labelString = value;
+  if (value === undefined) {
+    labelString = "BAD_INPUT";
+  } else {
+    labelString.toString();
+  }
+
+  GoogleAnalytics.event({
+    category: "Global user settings",
+    action: "Change " + name,
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateLessonSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateLessonSetting.js
@@ -1,0 +1,36 @@
+import GoogleAnalytics from "react-ga4";
+
+export function changeShowStrokesInLesson(event) {
+  const target = event.target;
+  const value = target.type === "checkbox" ? target.checked : target.value;
+
+  this.setState({ showStrokesInLesson: value });
+  const yourTypedText = document.getElementById("your-typed-text");
+  if (yourTypedText) {
+    yourTypedText.focus();
+  }
+
+  if (this.props.location.pathname.includes("custom")) {
+    GoogleAnalytics.event({
+      category: "Stroke hint",
+      action: "Reveal",
+      label: "CUSTOM_LESSON",
+    });
+  } else {
+    let labelShowStrokesInLesson = "true";
+    try {
+      labelShowStrokesInLesson =
+        this.state.lesson.newPresentedMaterial.current.phrase +
+        ": " +
+        this.state.lesson.newPresentedMaterial.current.stroke;
+    } catch {}
+
+    GoogleAnalytics.event({
+      category: "Stroke hint",
+      action: "Reveal",
+      label: labelShowStrokesInLesson,
+    });
+  }
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateLessonSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateLessonSetting.js
@@ -34,3 +34,18 @@ export function changeShowStrokesInLesson(event) {
 
   return value;
 }
+
+export function updateRevisionMaterial(event) {
+  let newCurrentLessonStrokes = this.state.currentLessonStrokes.map(
+    (stroke) => ({ ...stroke })
+  );
+  const target = event.target;
+  const checked = target.type === "checkbox" ? target.checked : target.value;
+  const name = target.name.replace(/-checkbox/, "");
+  const index = name;
+
+  newCurrentLessonStrokes[index].checked = checked;
+
+  this.setState({ currentLessonStrokes: newCurrentLessonStrokes });
+  return checked;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -254,3 +254,31 @@ export function handleRepetitionsChange(event) {
 
   return value;
 }
+
+export function handleStartFromWordChange(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "startFromWord";
+  const value = event;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    this.setupLesson();
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change start from word",
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -1,4 +1,5 @@
 import GoogleAnalytics from "react-ga4";
+import PARAMS from "../../../../utils/params";
 import { writePersonalPreferences } from "../../../../utils/typey-type";
 
 /** @type {SpeechSynthesis | null} */
@@ -269,6 +270,99 @@ export function changeVoiceUserSetting(voiceName, voiceURI) {
     action: "Change voice",
     label: labelString,
   });
+}
+
+export function chooseStudy(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "study";
+  const value = event.target.value;
+
+  newState[name] = value;
+
+  switch (value) {
+    case "discover":
+      newState.showStrokes = PARAMS.discover.showStrokes;
+      newState.hideStrokesOnLastRepetition =
+        PARAMS.discover.hideStrokesOnLastRepetition;
+      newState.newWords = PARAMS.discover.newWords;
+      newState.seenWords = PARAMS.discover.seenWords;
+      newState.retainedWords = PARAMS.discover.retainedWords;
+      newState.repetitions =
+        this.state.userSettings.studyPresets[0].repetitions ||
+        PARAMS.discover.repetitions;
+      newState.limitNumberOfWords =
+        this.state.userSettings.studyPresets[0].limitNumberOfWords ||
+        PARAMS.discover.limitNumberOfWords;
+      newState.sortOrder = PARAMS.discover.sortOrder;
+      break;
+    case "revise":
+      newState.showStrokes = PARAMS.revise.showStrokes;
+      newState.hideStrokesOnLastRepetition =
+        PARAMS.revise.hideStrokesOnLastRepetition;
+      newState.newWords = PARAMS.revise.newWords;
+      newState.seenWords = PARAMS.revise.seenWords;
+      newState.retainedWords = PARAMS.revise.retainedWords;
+      newState.repetitions =
+        this.state.userSettings.studyPresets[1].repetitions ||
+        PARAMS.revise.repetitions;
+      newState.limitNumberOfWords =
+        this.state.userSettings.studyPresets[1].limitNumberOfWords ||
+        PARAMS.revise.limitNumberOfWords;
+      newState.sortOrder = PARAMS.revise.sortOrder;
+      break;
+    case "drill":
+      newState.showStrokes = PARAMS.drill.showStrokes;
+      newState.hideStrokesOnLastRepetition =
+        PARAMS.drill.hideStrokesOnLastRepetition;
+      newState.newWords = PARAMS.drill.newWords;
+      newState.seenWords = PARAMS.drill.seenWords;
+      newState.retainedWords = PARAMS.drill.retainedWords;
+      newState.repetitions =
+        this.state.userSettings.studyPresets[2].repetitions ||
+        PARAMS.drill.repetitions;
+      newState.limitNumberOfWords =
+        this.state.userSettings.studyPresets[2].limitNumberOfWords ||
+        PARAMS.drill.limitNumberOfWords;
+      newState.sortOrder = PARAMS.drill.sortOrder;
+      break;
+    case "practice":
+      newState.showStrokes = PARAMS.practice.showStrokes;
+      newState.hideStrokesOnLastRepetition =
+        PARAMS.practice.hideStrokesOnLastRepetition;
+      newState.newWords = PARAMS.practice.newWords;
+      newState.seenWords = PARAMS.practice.seenWords;
+      newState.retainedWords = PARAMS.practice.retainedWords;
+      newState.repetitions =
+        this.state.userSettings.studyPresets[3].repetitions ||
+        PARAMS.practice.repetitions;
+      newState.limitNumberOfWords =
+        this.state.userSettings.studyPresets[3].limitNumberOfWords ||
+        PARAMS.practice.limitNumberOfWords;
+      newState.sortOrder = PARAMS.practice.sortOrder;
+      break;
+    default:
+      break;
+  }
+
+  this.setState({ userSettings: newState }, () => {
+    this.setupLesson();
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Choose Study Type",
+    label: labelString,
+  });
+
+  return value;
 }
 
 export function handleBeatsPerMinute(event) {

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -140,6 +140,36 @@ export function changeSortOrderUserSetting(event) {
   return value;
 }
 
+export function changeSpacePlacementUserSetting(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "spacePlacement";
+  const value = event.target.value;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    if (!(name === "caseSensitive")) {
+      this.setupLesson();
+    }
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change spacePlacement",
+    label: labelString,
+  });
+
+  return value;
+}
+
 /**
  * @param {string} voiceName
  * @param {string} voiceURI

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -170,7 +170,7 @@ export function handleDiagramSize(event) {
   let newState = Object.assign({}, currentState);
 
   const name = "diagramSize";
-  let value = typeof event === "number" ? event.toFixed(1) : 1.0;
+  let value = typeof event === "number" ? +event.toFixed(1) : 1.0;
   if (value > 2) {
     value = 2.0;
   }
@@ -184,10 +184,7 @@ export function handleDiagramSize(event) {
     writePersonalPreferences("userSettings", this.state.userSettings);
   });
 
-  let labelString = value;
-  if (!value) {
-    labelString = "BAD_INPUT";
-  }
+  const labelString = !!value ? `${value}` : "BAD_INPUT";
 
   GoogleAnalytics.event({
     category: "UserSettings",

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -128,9 +128,7 @@ export function changeSortOrderUserSetting(event) {
   newState[name] = value;
 
   this.setState({ userSettings: newState }, () => {
-    if (!(name === "caseSensitive")) {
-      this.setupLesson();
-    }
+    this.setupLesson();
     writePersonalPreferences("userSettings", this.state.userSettings);
   });
 
@@ -158,9 +156,7 @@ export function changeSpacePlacementUserSetting(event) {
   newState[name] = value;
 
   this.setState({ userSettings: newState }, () => {
-    if (!(name === "caseSensitive")) {
-      this.setupLesson();
-    }
+    this.setupLesson();
     writePersonalPreferences("userSettings", this.state.userSettings);
   });
 
@@ -342,9 +338,7 @@ export function handleLimitWordsChange(event) {
   newState[name] = value;
 
   this.setState({ userSettings: newState }, () => {
-    if (!(name === "caseSensitive")) {
-      this.setupLesson();
-    }
+    this.setupLesson();
     writePersonalPreferences("userSettings", this.state.userSettings);
   });
 
@@ -372,9 +366,7 @@ export function handleRepetitionsChange(event) {
   newState[name] = value;
 
   this.setState({ userSettings: newState }, () => {
-    if (!(name === "caseSensitive")) {
-      this.setupLesson();
-    }
+    this.setupLesson();
     writePersonalPreferences("userSettings", this.state.userSettings);
   });
 

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -1,0 +1,199 @@
+import GoogleAnalytics from "react-ga4";
+import { writePersonalPreferences } from "../../../../utils/typey-type";
+
+export function changeShowScoresWhileTyping(event) {
+  let newState = Object.assign({}, this.state.userSettings);
+
+  newState["showScoresWhileTyping"] = !newState["showScoresWhileTyping"];
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change show scores while typing",
+    label: newState["showScoresWhileTyping"].toString(),
+  });
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+  return newState["showScoresWhileTyping"];
+}
+
+export function changeShowStrokesAs(event) {
+  let newState = Object.assign({}, this.state.userSettings);
+
+  const name = "showStrokesAsDiagrams";
+  const value = event.target.value;
+
+  if (value === "strokesAsText") {
+    newState[name] = false;
+  } else {
+    newState[name] = true;
+  }
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change show strokes as",
+    label: labelString,
+  });
+
+  return value;
+}
+
+export function changeShowStrokesAsList(event) {
+  let newState = Object.assign({}, this.state.userSettings);
+
+  const name = "showStrokesAsList";
+  const value = event.target.checked;
+
+  if (value) {
+    newState[name] = true;
+
+    this.appFetchAndSetupGlobalDict(true, null).catch((error) =>
+      console.error(error)
+    );
+  } else {
+    newState[name] = false;
+  }
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change show strokes as list",
+    label: labelString,
+  });
+
+  return value;
+}
+
+export function changeShowStrokesOnMisstroke(event) {
+  let newState = Object.assign({}, this.state.userSettings);
+
+  const name = "showStrokesOnMisstroke";
+  const value = event.target.value;
+
+  newState[name] = !newState[name];
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  } else {
+    labelString = value.toString();
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change show strokes on misstroke",
+    label: labelString,
+  });
+
+  return value;
+}
+
+/**
+ * @param {string} voiceName
+ * @param {string} voiceURI
+ */
+export function changeVoiceUserSetting(voiceName, voiceURI) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  newState["voiceName"] = voiceName;
+  newState["voiceURI"] = voiceURI;
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  // Let's not bother with tracking voice name. URI is enough.
+  let labelString = voiceURI;
+  if (!voiceURI) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change voice",
+    label: labelString,
+  });
+}
+
+export function handleBeatsPerMinute(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "beatsPerMinute";
+  const value = event;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change beats per minute",
+    label: labelString,
+  });
+
+  return value;
+}
+
+export function handleDiagramSize(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "diagramSize";
+  let value = typeof event === "number" ? event.toFixed(1) : 1.0;
+  if (value > 2) {
+    value = 2.0;
+  }
+  if (value < 1) {
+    value = 1.0;
+  }
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change diagram size",
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -110,6 +110,36 @@ export function changeShowStrokesOnMisstroke(event) {
   return value;
 }
 
+export function changeSortOrderUserSetting(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "sortOrder";
+  const value = event.target.value;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    if (!(name === "caseSensitive")) {
+      this.setupLesson();
+    }
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change sort order",
+    label: labelString,
+  });
+
+  return value;
+}
+
 /**
  * @param {string} voiceName
  * @param {string} voiceURI

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -224,3 +224,33 @@ export function handleLimitWordsChange(event) {
 
   return value;
 }
+
+export function handleRepetitionsChange(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "repetitions";
+  const value = event;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    if (!(name === "caseSensitive")) {
+      this.setupLesson();
+    }
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change repetitions",
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -170,6 +170,38 @@ export function changeSpacePlacementUserSetting(event) {
   return value;
 }
 
+export function changeStenoLayout(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = event.target.name;
+  const value = event.target.value;
+
+  newState["stenoLayout"] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    this.setupLesson();
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  let actionString = "Change steno layout";
+  if (name === "writerStenoLayout") {
+    actionString = "Change writer steno layout";
+  }
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: actionString,
+    label: labelString,
+  });
+
+  return value;
+}
+
 /**
  * @param {string} voiceName
  * @param {string} voiceURI

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -282,3 +282,31 @@ export function handleStartFromWordChange(event) {
 
   return value;
 }
+
+export function handleUpcomingWordsLayout(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = event.target.name;
+  const value = event.target.value;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    this.setupLesson();
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change upcoming words layout",
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -194,3 +194,33 @@ export function handleDiagramSize(event) {
 
   return value;
 }
+
+export function handleLimitWordsChange(event) {
+  let currentState = this.state.userSettings;
+  let newState = Object.assign({}, currentState);
+
+  const name = "limitNumberOfWords";
+  const value = event;
+
+  newState[name] = value;
+
+  this.setState({ userSettings: newState }, () => {
+    if (!(name === "caseSensitive")) {
+      this.setupLesson();
+    }
+    writePersonalPreferences("userSettings", this.state.userSettings);
+  });
+
+  let labelString = value;
+  if (!value) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "UserSettings",
+    action: "Change limit word count",
+    label: labelString,
+  });
+
+  return value;
+}

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -533,3 +533,38 @@ export function handleUpcomingWordsLayout(event) {
 
   return value;
 }
+
+/**
+ *
+ * @param {"discover" | "revise" | "drill" | "practice"} studyType should have type Study
+ */
+export function updatePreset(studyType) {
+  const newUserSettings = Object.assign({}, this.state.userSettings);
+  const presetSettings = {
+    limitNumberOfWords: this.state.userSettings.limitNumberOfWords,
+    repetitions: this.state.userSettings.repetitions,
+  };
+
+  switch (studyType) {
+    case "discover":
+      newUserSettings.studyPresets[0] = presetSettings;
+      break;
+
+    case "revise":
+      newUserSettings.studyPresets[1] = presetSettings;
+      break;
+
+    case "drill":
+      newUserSettings.studyPresets[2] = presetSettings;
+      break;
+
+    case "practice":
+      newUserSettings.studyPresets[3] = presetSettings;
+      break;
+
+    default:
+      break;
+  }
+
+  this.setState({ userSettings: newUserSettings });
+}

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -21,6 +21,7 @@ import GeneratorHelp from "./GeneratorHelp";
 
 import type {
   CustomLesson,
+  FetchAndSetupGlobalDict,
   LookupDictWithNamespacedDicts,
 } from "../../../types";
 import type { Rules } from "./generator/types";
@@ -35,10 +36,7 @@ type Props = {
     rules: Rules,
     regexRules: RegexRules
   ) => void;
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDicts;
 };
 

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -39,7 +39,6 @@ type Props = {
     withPlover: boolean,
     importedPersonalDictionaries?: any
   ) => Promise<any>;
-  personalDictionaries: any;
   globalLookupDictionary: LookupDictWithNamespacedDicts;
 };
 
@@ -53,7 +52,6 @@ const CustomLessonGenerator = ({
   fetchAndSetupGlobalDict,
   generateCustomLesson,
   globalLookupDictionary,
-  personalDictionaries,
 }: Props) => {
   const mainHeading = useRef<HTMLHeadingElement>(null);
 
@@ -66,21 +64,13 @@ const CustomLessonGenerator = ({
   };
 
   useEffect(() => {
-    const shouldUsePersonalDictionaries =
-      personalDictionaries &&
-      Object.entries(personalDictionaries).length > 0 &&
-      !!personalDictionaries.dictionariesNamesAndContents;
-
-    fetchAndSetupGlobalDict(
-      false,
-      shouldUsePersonalDictionaries ? personalDictionaries : null
-    ).catch((error: Error) => {
+    fetchAndSetupGlobalDict(false, null).catch((error: Error) => {
       console.error(error);
     });
-    // }, [fetchAndSetupGlobalDict, personalDictionaries]);
+    // }, [fetchAndSetupGlobalDict]);
     // Excluding fetchAndSetupGlobalDict…
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [personalDictionaries]);
+  }, []);
 
   useEffect(() => {
     mainHeading.current?.focus();

--- a/src/pages/lessons/custom/CustomLessonSetup.tsx
+++ b/src/pages/lessons/custom/CustomLessonSetup.tsx
@@ -7,16 +7,14 @@ import CustomWordListLesson from "./components/CustomWordListLesson";
 import Subheader from "../../../components/Subheader";
 
 import type { CustomLessonMaterialValidationState } from "./components/CustomLessonIntro";
+import { FetchAndSetupGlobalDict } from "../../../types";
 
 type Props = {
   createCustomLesson: () => void;
   customLessonMaterial: any;
   customLessonMaterialValidationState: CustomLessonMaterialValidationState;
   customLessonMaterialValidationMessages: string[];
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: any;
   globalLookupDictionaryLoaded: boolean;
 };

--- a/src/pages/lessons/custom/CustomLessonSetup.tsx
+++ b/src/pages/lessons/custom/CustomLessonSetup.tsx
@@ -19,7 +19,6 @@ type Props = {
   ) => Promise<any>;
   globalLookupDictionary: any;
   globalLookupDictionaryLoaded: boolean;
-  personalDictionaries: any;
 };
 
 const CustomLessonSetup = ({
@@ -30,7 +29,6 @@ const CustomLessonSetup = ({
   fetchAndSetupGlobalDict,
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
-  personalDictionaries,
 }: Props) => {
   const mainHeading = useRef<HTMLHeadingElement>(null);
 
@@ -44,15 +42,7 @@ const CustomLessonSetup = ({
       globalLookupDictionary.size < 2 &&
       !globalLookupDictionaryLoaded
     ) {
-      const shouldUsePersonalDictionaries =
-        personalDictionaries &&
-        Object.entries(personalDictionaries).length > 0 &&
-        !!personalDictionaries.dictionariesNamesAndContents;
-
-      fetchAndSetupGlobalDict(
-        false,
-        shouldUsePersonalDictionaries ? personalDictionaries : null
-      ).catch((error) => {
+      fetchAndSetupGlobalDict(false).catch((error) => {
         console.error(error);
         // this.showDictionaryErrorNotification();
       });
@@ -61,7 +51,6 @@ const CustomLessonSetup = ({
     fetchAndSetupGlobalDict,
     globalLookupDictionary,
     globalLookupDictionaryLoaded,
-    personalDictionaries,
   ]);
 
   const match = useRouteMatch({

--- a/src/pages/lessons/flashcards/Flashcards.js
+++ b/src/pages/lessons/flashcards/Flashcards.js
@@ -459,9 +459,6 @@ currentSlide: currentSlide
                   globalLookupDictionary={this.props.globalLookupDictionary}
                   globalLookupDictionaryLoaded={this.props.globalLookupDictionaryLoaded}
                   globalUserSettings={this.props.globalUserSettings}
-                  lookupTerm={undefined} /* FIXME: should be optional */
-                  onChange={undefined} /* FIXME: should this be optional? */
-                  trackPhrase={undefined} /* FIXME: should be optional */
                   userSettings={this.props.userSettings}
                 />
               </div>

--- a/src/pages/lessons/flashcards/Flashcards.js
+++ b/src/pages/lessons/flashcards/Flashcards.js
@@ -461,7 +461,6 @@ currentSlide: currentSlide
                   globalUserSettings={this.props.globalUserSettings}
                   lookupTerm={undefined} /* FIXME: should be optional */
                   onChange={undefined} /* FIXME: should this be optional? */
-                  personalDictionaries={this.props.personalDictionaries}
                   trackPhrase={undefined} /* FIXME: should be optional */
                   userSettings={this.props.userSettings}
                 />

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -5,10 +5,7 @@ import PseudoContentButton from "../../components/PseudoContentButton";
 import Subheader from "../../components/Subheader";
 import getWordFamilyGroup from "./utilities/getWordFamilyGroup";
 
-import type {
-  GlobalUserSettings,
-  UserSettings,
-} from "../../types";
+import type { GlobalUserSettings, UserSettings } from "../../types";
 
 type Props = {
   fetchAndSetupGlobalDict: (

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -19,10 +19,7 @@ type Props = {
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;
   lookupTerm?: string;
-  personalDictionaries: any;
   setCustomLessonContent: any;
-  updateGlobalLookupDictionary: any;
-  updatePersonalDictionaries: any;
   userSettings: UserSettings;
 };
 
@@ -32,9 +29,6 @@ const Lookup = ({
   globalLookupDictionaryLoaded,
   globalUserSettings,
   lookupTerm,
-  personalDictionaries,
-  updateGlobalLookupDictionary,
-  updatePersonalDictionaries,
   userSettings,
   setCustomLessonContent,
 }: Props) => {
@@ -121,7 +115,6 @@ const Lookup = ({
                 globalUserSettings={globalUserSettings}
                 lookupTerm={lookupTerm}
                 onChange={strokesForWordsChange}
-                personalDictionaries={personalDictionaries}
                 trackPhrase={setTrackPhrase}
                 userSettings={userSettings}
               />

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -5,13 +5,14 @@ import PseudoContentButton from "../../components/PseudoContentButton";
 import Subheader from "../../components/Subheader";
 import getWordFamilyGroup from "./utilities/getWordFamilyGroup";
 
-import type { GlobalUserSettings, UserSettings } from "../../types";
+import type {
+  FetchAndSetupGlobalDict,
+  GlobalUserSettings,
+  UserSettings,
+} from "../../types";
 
 type Props = {
-  fetchAndSetupGlobalDict: (
-    withPlover: boolean,
-    importedPersonalDictionaries?: any
-  ) => Promise<any>;
+  fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: any;
   globalLookupDictionaryLoaded: boolean;
   globalUserSettings: GlobalUserSettings;

--- a/src/types.ts
+++ b/src/types.ts
@@ -376,8 +376,8 @@ export type UserSettings = {
   studyPresets: StudyPresets;
   stenoLayout: StenoLayout;
   upcomingWordsLayout: UpcomingWordsLayout;
-  voiceName: SpeechSynthesisVoice["name"]
-  voiceURI: SpeechSynthesisVoice["voiceURI"]
+  voiceName: SpeechSynthesisVoice["name"];
+  voiceURI: SpeechSynthesisVoice["voiceURI"];
 };
 
 export type GlobalUserSettings = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,15 @@ export type DictName = string;
  */
 export type PersonalDictionaryNameAndContents = [DictName, StenoDictionary];
 
+type ImportedPersonalDictionaries = {
+  dictionariesNamesAndContents: PersonalDictionaryNameAndContents[];
+};
+
+export type FetchAndSetupGlobalDict = (
+  withPlover: boolean,
+  importedPersonalDictionaries?: ImportedPersonalDictionaries | null
+) => Promise<any>;
+
 /**
  * Examples:
  * "user"

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,14 @@ export type LookupDictWithNamespacedDicts = Map<
 > &
   OptionalDictionaryConfig;
 
+/**
+ * A lookup dictionary and configuration list
+ *
+ * Example:
+ * Map (74602)
+ * configuration: ['typey:typey-type.json', 'user:personal.json', 'plover:plover-main-3-jun-2018.json']
+ * 
+ */
 export type LookupDictWithNamespacedDictsAndConfig = Omit<
   LookupDictWithNamespacedDicts,
   "configuration"

--- a/src/utils/app/fetchAndSetupGlobalDict.ts
+++ b/src/utils/app/fetchAndSetupGlobalDict.ts
@@ -11,7 +11,12 @@ import type { PersonalDictionaryNameAndContents } from "../../types";
 let loadingPromise = null;
 let isGlobalDictionaryUpToDate = null;
 
-// The withPlover flag here is just about whether or not to fetch the Plover dictionary file.
+/**
+ *
+ * @param withPlover whether or not to fetch the Plover dictionary file. We don't need to load that extra 4.2MB for new users on first use in lessons until they turn on "Show other stroke hints". We don't need multiple outlines for entries in games like SHUFL.
+ * @param importedPersonalDictionaries recently imported personal dictionaries (on dictionary management page) OR personal dictionaries passed down from props or null.
+ * @returns a loading promise
+ */
 function fetchAndSetupGlobalDict(
   withPlover: boolean,
   importedPersonalDictionaries: any

--- a/src/utils/lookupListOfStrokesAndDicts.ts
+++ b/src/utils/lookupListOfStrokesAndDicts.ts
@@ -5,13 +5,16 @@ import misstrokesJSON from "../json/misstrokes.json";
 import getModifiedWordOrPhraseForLookup from "../utils/getModifiedWordOrPhraseForLookup";
 import createListOfStrokes from "../utils/createListOfStrokes";
 
-import type { LookupDictWithNamespacedDictsAndConfig } from "../types";
+import type {
+  LookupDictWithNamespacedDictsAndConfig,
+  StrokeAndDictionaryAndNamespace,
+} from "../types";
 
 function lookupListOfStrokesAndDicts(
   phrase: string,
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig,
   affixList = AffixList.getSharedInstance()
-) {
+): [StrokeAndDictionaryAndNamespace[], string] {
   let lookupText = phrase;
   let modifiedWordOrPhrase = lookupText.slice();
   modifiedWordOrPhrase = getModifiedWordOrPhraseForLookup(phrase);

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -772,7 +772,7 @@ function writePersonalPreferences(itemToStore, JSONToStore) {
   }
 }
 
-function targetStrokeCount(currentOutline) {
+function getTargetStrokeCount(currentOutline) {
   // console.log(currentOutline.stroke.split(/[/ ]/).length);
   return currentOutline.stroke.split(/[/ ]/).length || 1;
 }
@@ -845,7 +845,7 @@ export {
   setupLessonProgress,
   shouldShowStroke,
   strokeAccuracy,
-  targetStrokeCount,
+  getTargetStrokeCount,
   updateCapitalisationStrokesInNextItem,
   writePersonalPreferences
 };


### PR DESCRIPTION
This PR refactors random things:

- [Remove shouldUsePersonalDictionaries…](https://github.com/didoesdigital/typey-type/commit/c97d5662f4cd0d0397cc5266791a1c9d2a93a0c2) … because personal dictionaries is currently always: `{ dictionariesNamesAndContents: null }` For now, we will simplify the code to set up the global dictionary by always getting personal dictionaries from local storage instead of props and revisit this in the future when we clean up all the fetching and global dictionary setup code.
- FIX: add missing dependencies in hook deps array
- FIX: [Fix case on prop](https://github.com/didoesdigital/typey-type/commit/efbc6a1a825a1b71b0c9da70817f9356b92b84d8)
- [Remove redundant stopTimer()](https://github.com/didoesdigital/typey-type/commit/c7b2732149d59a327b574666ac2d37b789a17c5e)
- FIX: [Add initial state for targetStrokeCount](https://github.com/didoesdigital/typey-type/commit/a220acd5bbb2ccf7a501b7aff38636a65ad20bf3)
- [Fix type errors in JS](https://github.com/didoesdigital/typey-type/commit/0fb14d7222fbcb4a90576fe6f0fa57a91769a510)
- Chore: Extracts heaps of functions from `App.js`, especially updating user settings, lesson settings, flashcard settings and global user settings, bringing number of lines down from 2120 to 1455.
- Chore: Extracts `applyQueryParamsToUserSettings`
- Chore: Cleans up `setupLesson` function
- Chore: converts `StrokesForWords` to a TSX function component
- Chore: refines types and JSDocs
- Chore: formats files

In theory, this should not break anything but it was a bit adventurous and some issues might slip through.