### PR TITLE
Fix matched characters count for affix lessons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,7 @@ import {
 } from './pages/lessons/components/UserSettings/updateFlashcardSetting';
 import AppRoutes from './AppRoutes';
 import applyQueryParamsToUserSettings from './pages/lessons/components/UserSettings/applyQueryParamsToUserSettings';
+import removeIgnoredCharsFromSplitText from './utils/app/removeIgnoredCharsFromSplitText';
 
 /** @type {SpeechSynthesis | null} */
 let synth = null;
@@ -1147,13 +1148,6 @@ class App extends Component {
       matchSplitText(this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase, actualText, this.state.lesson.settings, this.state.userSettings);
     
     if (this.state.lesson.settings.ignoredChars) {
-      function removeIgnoredCharsFromSplitText(matchedChars, ignoredChars) {
-        let newMatchedChars = matchedChars;
-        for (let i = 0; i < ignoredChars.length; i++) {
-          newMatchedChars = [...newMatchedChars].filter(char => !ignoredChars.includes(char)).join('');
-        }
-        return newMatchedChars;
-      }
       matchedChars = removeIgnoredCharsFromSplitText(matchedChars, this.state.lesson.settings.ignoredChars);
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1145,8 +1145,17 @@ class App extends Component {
     // eslint-disable-next-line
     let [matchedChars, unmatchedChars, _, unmatchedActual] =
       matchSplitText(this.state.lesson.presentedMaterial[this.state.currentPhraseID].phrase, actualText, this.state.lesson.settings, this.state.userSettings);
-
-    matchedChars = matchedChars.replace(new RegExp(this.state.lesson.settings.ignoredChars,'g'), '');
+    
+    if (this.state.lesson.settings.ignoredChars) {
+      function removeIgnoredCharsFromSplitText(matchedChars, ignoredChars) {
+        let newMatchedChars = matchedChars;
+        for (let i = 0; i < ignoredChars.length; i++) {
+          newMatchedChars = [...newMatchedChars].filter(char => !ignoredChars.includes(char)).join('');
+        }
+        return newMatchedChars;
+      }
+      matchedChars = removeIgnoredCharsFromSplitText(matchedChars, this.state.lesson.settings.ignoredChars);
+    }
 
     let [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
 

--- a/src/App.js
+++ b/src/App.js
@@ -1150,7 +1150,7 @@ class App extends Component {
 
     let [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
 
-    let currentPhraseAttempts = this.state.currentPhraseAttempts.map(copy => ({...copy}));
+    const currentPhraseAttempts = this.state.currentPhraseAttempts.map(copy => ({...copy}));
 
     currentPhraseAttempts.push({
       text: actualText,

--- a/src/App.js
+++ b/src/App.js
@@ -1133,6 +1133,7 @@ class App extends Component {
   updateMarkup(event) {
     let actualText = event.target.value;
 
+    // Start timer on first key stroke
     if (this.state.startTime === null) {
       this.setState({
         startTime: new Date(),
@@ -1152,7 +1153,7 @@ class App extends Component {
       unmatchedChars = removeIgnoredCharsFromSplitText(unmatchedChars, this.state.lesson.settings.ignoredChars);
     }
 
-    let [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
+    const [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
 
     // @ts-ignore this should be ok when currentPhraseAttempts is typed correctly instead of never[]
     const currentPhraseAttempts = this.state.currentPhraseAttempts.map(copy => ({...copy}));

--- a/src/App.js
+++ b/src/App.js
@@ -1149,6 +1149,7 @@ class App extends Component {
     
     if (this.state.lesson.settings.ignoredChars) {
       matchedChars = removeIgnoredCharsFromSplitText(matchedChars, this.state.lesson.settings.ignoredChars);
+      unmatchedChars = removeIgnoredCharsFromSplitText(unmatchedChars, this.state.lesson.settings.ignoredChars);
     }
 
     let [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);

--- a/src/App.js
+++ b/src/App.js
@@ -1150,6 +1150,7 @@ class App extends Component {
 
     let [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
 
+    // @ts-ignore this should be ok when currentPhraseAttempts is typed correctly instead of never[]
     const currentPhraseAttempts = this.state.currentPhraseAttempts.map(copy => ({...copy}));
 
     currentPhraseAttempts.push({

--- a/src/App.js
+++ b/src/App.js
@@ -91,7 +91,7 @@ class App extends Component {
     this.charsPerWord = 5;
     // When updating default state for anything stored in local storage,
     // add the same default to load/set personal preferences code and test.
-    let metWords = loadPersonalPreferences()[0];
+    let metWordsFromStorage = loadPersonalPreferences()[0];
     let startingMetWordsToday = loadPersonalPreferences()[0];
     let recentLessons = loadPersonalPreferences()[6];
     this.appFetchAndSetupGlobalDict = fetchAndSetupGlobalDict.bind(this);
@@ -165,7 +165,7 @@ class App extends Component {
       totalNumberOfMistypedWords: 0,
       totalNumberOfHintedWords: 0,
       disableUserSettings: false,
-      metWords: metWords,
+      metWords: metWordsFromStorage,
       revisionMode: false,
       oldWordsGoalUnveiled: false,
       newWordsGoalUnveiled: false,
@@ -228,8 +228,8 @@ class App extends Component {
       revisionMaterial: [
       ],
       startingMetWordsToday: startingMetWordsToday,
-      yourSeenWordCount: calculateSeenWordCount(metWords),
-      yourMemorisedWordCount: calculateMemorisedWordCount(metWords)
+      yourSeenWordCount: calculateSeenWordCount(metWordsFromStorage),
+      yourMemorisedWordCount: calculateMemorisedWordCount(metWordsFromStorage)
     };
   }
 
@@ -579,11 +579,11 @@ class App extends Component {
     return flashcardsMetWords;
   }
 
-  updateStartingMetWordsAndCounts(metWords) {
+  updateStartingMetWordsAndCounts(providedMetWords) {
     this.setState({
-      startingMetWordsToday: metWords,
-      yourSeenWordCount: calculateSeenWordCount(metWords),
-      yourMemorisedWordCount: calculateMemorisedWordCount(metWords)
+      startingMetWordsToday: providedMetWords,
+      yourSeenWordCount: calculateSeenWordCount(providedMetWords),
+      yourMemorisedWordCount: calculateMemorisedWordCount(providedMetWords)
     });
   }
 
@@ -604,7 +604,7 @@ class App extends Component {
     });
   }
 
-  setUpProgressRevisionLesson(metWords, userSettings, newSeenOrMemorised) {
+  setUpProgressRevisionLesson(metWordsFromStorage, userSettings, newSeenOrMemorised) {
     let newUserSettings = Object.assign({}, userSettings);
     newUserSettings.newWords = newSeenOrMemorised[0];
     newUserSettings.seenWords = newSeenOrMemorised[1];
@@ -648,7 +648,7 @@ class App extends Component {
 
     this.appFetchAndSetupGlobalDict(loadPlover, null).then(() => {
       // grab metWords, trim spaces, and sort by times seen
-      let myWords = createWordListFromMetWords(metWords).join("\n");
+      let myWords = createWordListFromMetWords(metWordsFromStorage).join("\n");
       // parseWordList appears to remove empty lines and other garbage, we might not need it here
       let result = parseWordList(myWords);
         // perhaps we can replace these with result = createWordListFromMetWords?
@@ -706,7 +706,6 @@ class App extends Component {
     const revisionMaterial = this.state.revisionMaterial;
     const search = this.props.location.search;
     const userSettings = this.state.userSettings;
-    const metWords = this.state.metWords;
     const lessonPath = this.state.lesson.path;
     let newLesson = Object.assign({}, this.state.lesson);
     const prevRecentLessons = this.state.recentLessons;
@@ -764,10 +763,10 @@ class App extends Component {
       }
 
       // Filter lesson by familiarity:
-      newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, metWords, newSettings, revisionMode);
+      newLesson.presentedMaterial = filterByFamiliarity.call(this, newLesson.presentedMaterial, this.state.metWords, newSettings, revisionMode);
 
       // Sort lesson:
-      newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, metWords, newSettings);
+      newLesson.presentedMaterial = sortLesson.call(this, newLesson.presentedMaterial, this.state.metWords, newSettings);
 
       // Apply range (start from & limit) to lesson:
       if (revisionMode && limitNumberOfWords > 0) {

--- a/src/App.js
+++ b/src/App.js
@@ -320,43 +320,43 @@ class App extends Component {
   }
 
   setPersonalPreferences(source) {
-    let metWords = this.state.metWords;
-    let flashcardsMetWords = this.state.flashcardsMetWords;
-    let flashcardsProgress = this.state.flashcardsProgress;
-    let globalUserSettings = this.state.globalUserSettings;
-    let lessonsProgress = this.state.lessonsProgress;
-    let recentLessons = this.state.recentLessons;
-    let topSpeedPersonalBest = this.state.topSpeedPersonalBest;
-    let userGoals = this.state.userGoals;
-    let userSettings = this.state.userSettings;
+    let metWordsFromStateOrArg = this.state.metWords;
+    let flashcardsMetWordsState = this.state.flashcardsMetWords;
+    let flashcardsProgressState = this.state.flashcardsProgress;
+    let globalUserSettingsState = this.state.globalUserSettings;
+    let lessonsProgressState = this.state.lessonsProgress;
+    let recentLessonsState = this.state.recentLessons;
+    let topSpeedPersonalBestState = this.state.topSpeedPersonalBest;
+    let userGoalsState = this.state.userGoals;
+    let userSettingsState = this.state.userSettings;
     if (source && source !== '') {
       try {
         let parsedSource = JSON.parse(source);
         if (parsedSource && typeof parsedSource === "object") {
-          metWords = parsedSource;
+          metWordsFromStateOrArg = parsedSource;
         }
       }
       catch (error) { }
     }
     else {
-      [metWords, userSettings, flashcardsMetWords, flashcardsProgress, globalUserSettings, lessonsProgress, recentLessons, topSpeedPersonalBest, userGoals] = loadPersonalPreferences();
+      [metWordsFromStateOrArg, userSettingsState, flashcardsMetWordsState, flashcardsProgressState, globalUserSettingsState, lessonsProgressState, recentLessonsState, topSpeedPersonalBestState, userGoalsState] = loadPersonalPreferences();
     }
 
-    let yourSeenWordCount = calculateSeenWordCount(this.state.metWords);
-    let yourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
+    let calculatedYourSeenWordCount = calculateSeenWordCount(this.state.metWords);
+    let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
     this.setState({
-      flashcardsMetWords: flashcardsMetWords,
-      flashcardsProgress: flashcardsProgress,
-      globalUserSettings: globalUserSettings,
-      lessonsProgress: lessonsProgress,
-      recentLessons: recentLessons,
-      topSpeedPersonalBest: topSpeedPersonalBest,
-      metWords: metWords,
-      userSettings: userSettings,
-      userGoals: userGoals,
-      yourSeenWordCount: yourSeenWordCount,
-      yourMemorisedWordCount: yourMemorisedWordCount,
+      flashcardsMetWords: flashcardsMetWordsState,
+      flashcardsProgress: flashcardsProgressState,
+      globalUserSettings: globalUserSettingsState,
+      lessonsProgress: lessonsProgressState,
+      recentLessons: recentLessonsState,
+      topSpeedPersonalBest: topSpeedPersonalBestState,
+      metWords: metWordsFromStateOrArg,
+      userSettings: userSettingsState,
+      userGoals: userGoalsState,
+      yourSeenWordCount: calculatedYourSeenWordCount,
+      yourMemorisedWordCount: calculatedYourMemorisedWordCount,
     }, () => {
       writePersonalPreferences('flashcardsMetWords', this.state.flashcardsMetWords);
       writePersonalPreferences('flashcardsProgress', this.state.flashcardsProgress);
@@ -370,7 +370,7 @@ class App extends Component {
       this.setupLesson();
     });
 
-    return [metWords, userSettings, flashcardsMetWords, flashcardsProgress, globalUserSettings, lessonsProgress, recentLessons, topSpeedPersonalBest['wpm'], userGoals];
+    return [metWordsFromStateOrArg, userSettingsState, flashcardsMetWordsState, flashcardsProgressState, globalUserSettingsState, lessonsProgressState, recentLessonsState, topSpeedPersonalBestState['wpm'], userGoalsState];
   }
 
   startFromWordOne() {

--- a/src/utils/app/removeIgnoredCharsFromSplitText.ts
+++ b/src/utils/app/removeIgnoredCharsFromSplitText.ts
@@ -1,0 +1,16 @@
+function removeIgnoredCharsFromSplitText(
+  /** e.g. "^e" */
+  matchedChars: string,
+  /** e.g. "^" */
+  ignoredChars: string
+) {
+  let newMatchedChars = matchedChars;
+  for (let i = 0; i < ignoredChars.length; i++) {
+    newMatchedChars = [...newMatchedChars]
+      .filter((char) => !ignoredChars.includes(char))
+      .join("");
+  }
+  return newMatchedChars;
+}
+
+export default removeIgnoredCharsFromSplitText;

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -215,14 +215,6 @@ function matchSplitText(expected, actualText, settings={ignoredChars: ''}, userS
   let matchedActual = actualTextChars.slice(0,actualTextIndex).join('');
   let unmatchedActual = actualTextChars.slice(actualTextIndex).join('');
 
-  // Alternative approach to matching trailing ignored character ^ … does not work?
-  // if (ignoredChars.indexOf(expectedChars[expectedIndex]) !== -1) {
-  //   unmatchedExpected = '';
-  // }
-  // if (ignoredChars.indexOf(actualTextChars[actualTextIndex]) !== -1) {
-  //   unmatchedActual = '';
-  // }
-
   return [matchedExpected, unmatchedExpected, matchedActual, unmatchedActual];
 }
 

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -215,9 +215,6 @@ function matchSplitText(expected, actualText, settings={ignoredChars: ''}, userS
   let matchedActual = actualTextChars.slice(0,actualTextIndex).join('');
   let unmatchedActual = actualTextChars.slice(actualTextIndex).join('');
 
-  if ((unmatchedExpected.length === 1) && (ignoredChars.indexOf(unmatchedExpected) !== -1)) {
-    unmatchedExpected = '';
-  }
   // Alternative approach to matching trailing ignored character ^ … does not work?
   // if (ignoredChars.indexOf(expectedChars[expectedIndex]) !== -1) {
   //   unmatchedExpected = '';


### PR DESCRIPTION
This branch was originally intended for refactoring `App.js` and led to finding a bug in how matched characters are calculated. This PR contains some refactoring and a bug fix.

Previously, the RegExp containing `^` would not remove an `ignoredChars` `^` but instead treat it as a regex beginning of string. This ever so slightly inflated WPM throughout the lesson on affix lessons. Now, we use a dedicated `removeIgnoredCharsFromSplitText` function that uses filtering instead of regexes. By fixing the calculation of `unmatchedChars`, we can also remove the special case handling in `matchSplitText` to treat trailing ignored characters as an empty string for the unmatched expected string. That special case was the reason that lessons still progressed words correctly despite the incorrect "unmatched chars" count.