### PR TITLE
Fix Lookup from URL

### DIFF
--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -48,24 +48,23 @@ const StrokesForWords = ({
   const misstrokesJSON = misstrokes as StenoDictionary;
 
   useEffect(() => {
-    // if (this.props.globalLookupDictionary && this.props.globalLookupDictionary.size < 2 && !this.props.globalLookupDictionaryLoaded) {
-
-    fetchAndSetupGlobalDict(true, null)
-      .then(() => {
-        if (lookupTerm && lookupTerm !== undefined && lookupTerm.length > 0) {
-          setPhraseState(lookupTerm);
-          updateWordsForStrokes(lookupTerm);
-        }
-      })
-      .catch((error) => {
-        console.error(error);
-        // this.showDictionaryErrorNotification();
-      });
-    // }
+    fetchAndSetupGlobalDict(true, null).catch((error) => {
+      console.error(error);
+      // this.showDictionaryErrorNotification();
+    });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchAndSetupGlobalDict, lookupTerm]);
   // }, [fetchAndSetupGlobalDict, lookupTerm, updateWordsForStrokes]);
+
+  useEffect(() => {
+    if (lookupTerm && lookupTerm !== undefined && lookupTerm.length > 0) {
+      setPhraseState(lookupTerm);
+      updateWordsForStrokes(lookupTerm);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lookupTerm, globalLookupDictionaryLoaded]);
+  // }, [lookupTerm, updateWordsForStrokes, globalLookupDictionaryLoaded]);
 
   const handleWordsOnChange: React.ChangeEventHandler<HTMLTextAreaElement> = (
     event


### PR DESCRIPTION
When visiting a Lookup URL like <https://didoesdigital.com/typey-type/lookup?q=sword>, Typey Type should show results for that lookup term, but instead it's showing "No results found":

<img width="954" alt="Screenshot of Typey Type Lookup page showing sword in the search field and no results found" src="https://github.com/didoesdigital/typey-type/assets/2476974/cb77d8be-2bcf-445d-9438-b639c0c8a8f5">

This PR fixes it so it shows results properly:

<img width="947" alt="Screenshot of Typey Type Lookup page showing sword in the search field and 2 results with the outline SWORD" src="https://github.com/didoesdigital/typey-type/assets/2476974/b20d4703-01e7-41f5-8418-df179d3a7e20">

The `updateWordsForStrokes(lookupTerm)` call was happening before the global dictionary had loaded. This was likely a result of a recent conversion of a class component to function component with incorrect dependencies for when to run this code.