### PR TITLE
Reset showStrokesInLesson to false in setupLesson

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -822,6 +822,7 @@ class App extends Component {
         previousCompletedPhraseAsTyped: '',
         repetitionsRemaining: reps,
         startTime: null,
+        showStrokesInLesson: false,
         timer: 0,
         targetStrokeCount: target,
         totalNumberOfMatchedChars: 0,


### PR DESCRIPTION
As far as I can tell, the only places showStrokesInLesson is updated are:
1. when the corresponding user setting is updated (not relevant)
2. in a codepath in App.js updateMarkup()

This leads me to believe that setting it to false on every reset is safe, since there is no reason for me to believe that the default value is based on the current lesson or something else like that, but feel free to correct me if I'm wrong here.

(untested, but I'm fairly sure it works)

Closes #155 