### PR TITLE
Reduce Google translate errors

### DIFF
--- a/src/pages/games/components/Hint.jsx
+++ b/src/pages/games/components/Hint.jsx
@@ -56,9 +56,7 @@ export default function Hint({
             role="note"
             aria-label={[...currentStroke].join(" ").replace("-", "dash")}
           >
-            {[...currentStroke].map((item, i) => (
-              <React.Fragment key={i}>{item}</React.Fragment>
-            ))}
+            {currentStroke}
           </span>
         </pre>
       </div>

--- a/src/pages/progress/components/ProgressSummaryAndLinks.tsx
+++ b/src/pages/progress/components/ProgressSummaryAndLinks.tsx
@@ -38,16 +38,17 @@ const ProgressSummaryAndLinks = ({
   );
 
   const IntroSentence = () => (
-    <>{`You’ve successfully typed ${yourWordCount} ${
-      yourWordCount === 1 ? "word" : "words"
-    } without misstrokes. `}</>
+    <span>
+      You’ve successfully typed {yourWordCount}{" "}
+      {yourWordCount === 1 ? "word" : "words"} without misstrokes.
+    </span>
   );
 
   const MaybeProgressPercentSentence = ({
     yourSeenWordCount,
   }: MaybeProgressPercentSentenceProps) =>
     yourSeenWordCount > 1 ? (
-      <>{`You’re ${progressPercent}% of the way to 10,000 words. `}</>
+      <span>{`You’re ${progressPercent}% of the way to 10,000 words. `}</span>
     ) : null;
 
   return yourWordCount >= 10000 ? (


### PR DESCRIPTION
This PR is an attempt to reduce errors like `Failed to execute 'removeChild' on 'Node'`

<img width="576" alt="page translated to Japanese causing exceptions that result in error page" src="https://github.com/didoesdigital/typey-type/assets/2476974/8458a761-473b-4f14-b0ea-88a5868cd6b6">
