### PR TITLE
Persist search term on lessons page

### DIFF
--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -125,12 +125,13 @@ export default function LessonList({ lessonIndex, url }: LessonListProps) {
   const history = useHistory();
   const updateSearchParams = useMemo(() =>
     debounce((q: string) => {
-      history.replace({ search: `?q=${q}` });
+      const search = q === "" ? undefined : `?q=${q}`;
+      history.replace({ search, hash: history.location.hash });
     }, 100), [history]);
 
   useEffect(() => {
     updateSearchParams(searchFilter);
-  }, [searchFilter]);
+  }, [searchFilter, updateSearchParams]);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import GoogleAnalytics from "react-ga4";
-import { Link } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { groups } from "d3-array";
 import type { LessonIndexEntry } from "../../../types";
 
@@ -72,9 +72,46 @@ const scrollToHeading = (hash: string) => {
   }
 };
 
+function filterLessons(searchTerm: string, lessonIndex: LessonIndexEntry[]) {
+  const cleanedSearchTerm = searchTerm
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^ A-Za-z0-9’',*:-]/g, ""); // all characters that don't appear in lesson titles
+
+  if(cleanedSearchTerm.length === 0) return lessonIndex;
+
+  let filteredLessons = lessonIndex.filter((lesson) => {
+    const cleanedLessonTitle = lesson.title.toLowerCase();
+    const searchSnippets = cleanedSearchTerm.split(" ");
+    const titleMatches = searchSnippets.reduce(
+      (trueSoFar, searchSnippet) =>
+        trueSoFar && cleanedLessonTitle.includes(searchSnippet),
+      true
+    );
+    return titleMatches;
+  });
+
+  if (filteredLessons.length === 0) {
+    filteredLessons = lessonIndex.filter((lesson) => {
+      const searchSnippets = cleanedSearchTerm.split(" ");
+      const categoryMatches = searchSnippets.reduce(
+        (trueSoFar, searchSnippet) =>
+          trueSoFar &&
+          (lesson.category.toLowerCase().includes(searchSnippet) ||
+            lesson.subcategory.toLowerCase().includes(searchSnippet)),
+        true
+      );
+      return categoryMatches;
+    });
+  }
+
+  return filteredLessons;
+}
+
 export default function LessonList({ lessonIndex, url }: LessonListProps) {
-  const [searchFilter, setSearchFilter] = useState("");
-  const [filteredLessonIndex, setFilteredLessonIndex] = useState(lessonIndex);
+  const location = useLocation();
+  const searchFilter = new URLSearchParams(location.search).get("q") ?? "";
+  const filteredLessonIndex = filterLessons(searchFilter, lessonIndex);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -96,41 +133,11 @@ export default function LessonList({ lessonIndex, url }: LessonListProps) {
     window.onhashchange = scrollToAnchor;
   }, [lessonIndex]);
 
-  useEffect(() => {
-    setFilteredLessonIndex(lessonIndex);
-  }, [lessonIndex]);
+  const history = useHistory()
 
   const changeSearchFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = event.target.value;
-    const cleanedSearchTerm = searchTerm
-      .trim()
-      .toLowerCase()
-      .replaceAll(/[^ A-Za-z0-9’',*:-]/g, ""); // all characters that don't appear in lesson titles
-
-    let filteredLessons = lessonIndex.filter((lesson) => {
-      const cleanedLessonTitle = lesson.title.toLowerCase();
-      const searchSnippets = cleanedSearchTerm.split(" ");
-      const titleMatches = searchSnippets.reduce(
-        (trueSoFar, searchSnippet) =>
-          trueSoFar && cleanedLessonTitle.includes(searchSnippet),
-        true
-      );
-      return titleMatches;
-    });
-
-    if (filteredLessons.length === 0) {
-      filteredLessons = lessonIndex.filter((lesson) => {
-        const searchSnippets = cleanedSearchTerm.split(" ");
-        const categoryMatches = searchSnippets.reduce(
-          (trueSoFar, searchSnippet) =>
-            trueSoFar &&
-            (lesson.category.toLowerCase().includes(searchSnippet) ||
-              lesson.subcategory.toLowerCase().includes(searchSnippet)),
-          true
-        );
-        return categoryMatches;
-      });
-    }
+    history.replace({ search: `?q=${searchTerm}` })
 
     if (searchTerm && searchTerm.toString()) {
       GoogleAnalytics.event({
@@ -145,9 +152,6 @@ export default function LessonList({ lessonIndex, url }: LessonListProps) {
         label: "EMPTY_SEARCH_TEXT",
       });
     }
-
-    setSearchFilter(searchTerm);
-    setFilteredLessonIndex(filteredLessons);
   };
 
   const groupedLessons = groups(


### PR DESCRIPTION
On the [lessons page](https://didoesdigital.com/typey-type/lessons), when I search for a term, I see a search result. The problem is, when I click one lesson and go back, the page is shown with empty search box again. It'd be expected that the same search term and result is there.

The solution is to persist the search term state in URL using react-router's useHistory().replace() ([doc](https://v5.reactrouter.com/web/api/history)).