### PR TITLE
Add QWERTY steno to KAOES game

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -65,6 +65,7 @@ import {
   updateRevisionMaterial,
 } from './pages/lessons/components/UserSettings/updateLessonSetting';
 import {
+  changeInputForKAOES,
   changeWriterInput,
   dismissBackupBanner,
   toggleExperiment
@@ -143,6 +144,7 @@ class App extends Component {
         experiments: {},
         flashcardsCourseLevel: "noviceCourse", // see types.ts noviceCourse || beginnerCourse || competentCourse || proficientCourse || expertCourse
         writerInput: "qwerty", // qwerty || raw
+        inputForKAOES: "qwerty", // qwerty || raw
         showMisstrokesInLookup: false,
         backupBannerDismissedTime: null,
       },
@@ -1410,6 +1412,7 @@ class App extends Component {
               changeStenoLayout: changeStenoLayout.bind(this),
               changeUserSetting: changeUserSetting.bind(this),
               changeVoiceUserSetting: changeVoiceUserSetting.bind(this),
+              changeInputForKAOES: changeInputForKAOES.bind(this),
               changeWriterInput: changeWriterInput.bind(this),
               chooseStudy: chooseStudy.bind(this),
               createCustomLesson: this.createCustomLesson.bind(this),

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -152,6 +152,7 @@ const AppRoutes = ({ appProps, appState, appMethods }) => {
                 <DocumentTitle title={"Typey Type | Games"}>
                   <ErrorBoundary>
                     <AsyncGames
+                      changeInputForKAOES={appMethods.changeInputForKAOES}
                       fetchAndSetupGlobalDict={
                         appMethods.appFetchAndSetupGlobalDict
                       }

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -56,6 +56,7 @@ const AsyncTPEURPBGS = Loadable({
 });
 
 type Props = {
+  changeInputForKAOES: (input: string) => void;
   match: any;
   fetchAndSetupGlobalDict: FetchAndSetupGlobalDict;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
@@ -69,6 +70,7 @@ type Props = {
 };
 
 const Games = ({
+  changeInputForKAOES,
   match,
   fetchAndSetupGlobalDict,
   globalLookupDictionary,
@@ -85,7 +87,10 @@ const Games = ({
       <Route exact={true} path={`${match.url}/KAOES`}>
         <DocumentTitle title={"Typey Type | KAOES game"}>
           <ErrorBoundary>
-            <AsyncKAOES />
+            <AsyncKAOES
+              inputForKAOES={globalUserSettings.inputForKAOES}
+              changeInputForKAOES={changeInputForKAOES}
+            />
           </ErrorBoundary>
         </DocumentTitle>
       </Route>

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -178,6 +178,12 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
       setRightWrongColor(rightColor);
       dispatch({ type: actions.roundCompleted });
     } else {
+      // Note: we don't auto-clear incorrect steno input because we need to allow multi-character
+      // keys like "-R" to be typed, but qwerty steno is always 1 char so this should make it easier
+      // for people to try again with another character
+      if (inputForKAOES === "qwerty") {
+        setTypedText("");
+      }
       setStenoStroke(stenoStroke.set(comparableTypedKeyNumber));
       setRightWrongColor(wrongColor);
     }

--- a/src/pages/games/KAOES/Game.stories.jsx
+++ b/src/pages/games/KAOES/Game.stories.jsx
@@ -14,3 +14,9 @@ const Template = (args) => (
 );
 
 export const KAOESGameStory = Template.bind({});
+KAOESGameStory.args = {
+  inputForKAOES: "raw",
+  changeInputForKAOES: () => {
+    console.log("change input for KAOES game");
+  },
+};

--- a/src/pages/games/KAOES/Index.jsx
+++ b/src/pages/games/KAOES/Index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import Game from "./Game";
 import Subheader from "../../../components/Subheader";
 
-export default function Index() {
+export default function Index({ changeInputForKAOES, inputForKAOES }) {
   const mainHeading = useRef(null);
   useEffect(() => {
     if (mainHeading) {
@@ -22,7 +22,10 @@ export default function Index() {
         </div>
       </Subheader>
       <div className="p3 mx-auto mw-1024">
-        <Game />
+        <Game
+          inputForKAOES={inputForKAOES}
+          changeInputForKAOES={changeInputForKAOES}
+        />
       </div>
     </main>
   );

--- a/src/pages/games/components/Input.jsx
+++ b/src/pages/games/components/Input.jsx
@@ -57,6 +57,7 @@ export default function Input({
           id={`${gameName}-input`}
           onChange={onChangeTypedText}
           rows={1}
+          style={{ textDecoration: "none" }}
           spellCheck={false}
           value={typedText}
           wrap="off"

--- a/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateGlobalUserSetting.js
@@ -27,6 +27,31 @@ export function changeWriterInput(event) {
   });
 }
 
+export function changeInputForKAOES(event) {
+  let globalUserSettings = Object.assign({}, this.state.globalUserSettings);
+  let name = "BAD_INPUT";
+
+  if (event && event.target && event.target.name) {
+    globalUserSettings["inputForKAOES"] = event.target.name;
+    name = event.target.name;
+  }
+
+  this.setState({ globalUserSettings: globalUserSettings }, () => {
+    writePersonalPreferences("globalUserSettings", globalUserSettings);
+  });
+
+  let labelString = name;
+  if (!name) {
+    labelString = "BAD_INPUT";
+  }
+
+  GoogleAnalytics.event({
+    category: "Global user settings",
+    action: "Change input for KAOES",
+    label: labelString,
+  });
+}
+
 export function toggleExperiment(event) {
   let newState = Object.assign({}, this.state.globalUserSettings);
 

--- a/src/pages/writer/Writer.tsx
+++ b/src/pages/writer/Writer.tsx
@@ -208,7 +208,7 @@ class Writer extends Component<Props, State> {
     return stenoStroke.toString();
   }
 
-  addKeyToStenoBrief(key: string) {
+  addKeyToStenoBrief(key: number) {
     let stenoStroke = this.state.stenoStroke.set(key);
 
     this.setState({

--- a/src/stories/fixtures/globalUserSettings.js
+++ b/src/stories/fixtures/globalUserSettings.js
@@ -6,6 +6,7 @@ const globalUserSettings = {
   "flashcardsCourseLevel": "noviceCourse",
   "showMisstrokesInLookup": true,
   "writerInput": "raw",
+  "inputForKAOES": "raw",
 };
 
 export default globalUserSettings;

--- a/src/types.ts
+++ b/src/types.ts
@@ -395,6 +395,7 @@ export type GlobalUserSettings = {
   flashcardsCourseLevel: FlashcardsCourseLevel;
   showMisstrokesInLookup: boolean;
   writerInput: "raw" | "qwerty";
+  inputForKAOES: "raw" | "qwerty";
   backupBannerDismissedTime: number | null;
 };
 

--- a/src/utils/stroke.js
+++ b/src/utils/stroke.js
@@ -33,6 +33,7 @@ class Stroke {
     this.bits = bits;
   }
 
+  /** @param key { number } e.g. `2` or two in hex: `0b00000000000000000000010` for the left S key or `16384` for the right R key (`RR`) */
   set(key) {
     return new Stroke(this.bits | key);
   }

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -618,6 +618,7 @@ function loadPersonalPreferences() {
     flashcardsCourseLevel: "noviceCourse",
     showMisstrokesInLookup: false,
     writerInput: "qwerty",
+    inputForKAOES: "qwerty",
     backupBannerDismissedTime: null,
   };
   let flashcardsMetWords = {


### PR DESCRIPTION
Closes https://github.com/didoesdigital/typey-type/issues/164

<img width="1425" alt="Screenshot of KAOES game with added Raw or QWERTY steno input form: Raw (e.g. -R) option and QWERTY (e.g. 'j') option" src="https://github.com/didoesdigital/typey-type/assets/2476974/34ac5397-5946-47db-a4d8-c930a9d970ca">

Unlike the original mockup, the "e.g. -R" and "e.g. j" placeholders are moved to the radio input labels because that's the decision point at which the exemplar text matters.

This PR also auto-clears the incorrect input when in QWERTY steno mode. Note: we don't auto-clear incorrect steno input because we need to allow multi-character keys like "-R" to be typed. QWERTY steno is always 1 char so this should make it easier for people to try again with another character.