### PR TITLE
Handle postfix overrun

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!d3-array)/\" --env=jsdom",
+    "test:unit": "yarn test --testMatch \"**/*.test.{js,ts}\"",
+    "test:ui": "yarn test --testMatch \"**/*.test.{jsx,tsx}\"",
     "eject": "react-scripts eject",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/src/App.js
+++ b/src/App.js
@@ -1223,7 +1223,9 @@ class App extends Component {
     const phraseMisstrokes = strokeAccuracy(
       buffer ? currentPhraseAttempts : this.state.currentPhraseAttempts,
       this.state.targetStrokeCount,
-      unmatchedActual);
+      unmatchedActual,
+      !!buffer
+    );
     const accurateStroke = phraseMisstrokes.strokeAccuracy; // false
     const attempts = phraseMisstrokes.attempts; // [" sign", " ss"]
 

--- a/src/App.js
+++ b/src/App.js
@@ -1220,7 +1220,10 @@ class App extends Component {
     };
 
     // NOTE: here is where attempts are defined before being pushed with completed phrases
-    const phraseMisstrokes = strokeAccuracy(this.state.currentPhraseAttempts, this.state.targetStrokeCount, unmatchedActual);
+    const phraseMisstrokes = strokeAccuracy(
+      buffer ? currentPhraseAttempts : this.state.currentPhraseAttempts,
+      this.state.targetStrokeCount,
+      unmatchedActual);
     const accurateStroke = phraseMisstrokes.strokeAccuracy; // false
     const attempts = phraseMisstrokes.attempts; // [" sign", " ss"]
 

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import {
   shouldShowStroke,
   strokeAccuracy,
   getTargetStrokeCount,
+  getTargetObservableStrokeCount,
   updateCapitalisationStrokesInNextItem,
   writePersonalPreferences
 } from './utils/typey-type';
@@ -1218,11 +1219,10 @@ class App extends Component {
       metWords: this.state.metWords,
       userSettings: this.state.userSettings
     };
-
     // NOTE: here is where attempts are defined before being pushed with completed phrases
     const phraseMisstrokes = strokeAccuracy(
       buffer ? currentPhraseAttempts : this.state.currentPhraseAttempts,
-      this.state.targetStrokeCount,
+      buffer ? getTargetObservableStrokeCount(this.state.lesson.presentedMaterial[this.state.currentPhraseID]) : this.state.targetStrokeCount,
       unmatchedActual,
       !!buffer
     );

--- a/src/App.js
+++ b/src/App.js
@@ -1160,7 +1160,11 @@ class App extends Component {
       const buffer = this.markupBuffer;
       this.markupBuffer = [];
       this.updateBufferSingle(null, buffer);
-    }, 16); // 60fps
+    }, this.bufferIntervalMillis());
+  }
+
+  bufferIntervalMillis() {
+    return 16; // 60 fps
   }
 
   updateBufferSingle(actualText, buffer) {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -431,15 +431,19 @@ describe(App, () => {
                   "word": "You"
                 },
                 {
-                  // TODO(na2hiro): why inaccurate for space exact?
-                  // TODO(na2hiro): should this be inaccurate?
-                  accuracy: false,
-                  attempts: [{
-                    hintWasShown: true,
-                    numberOfMatchedWordsSoFar: spacePlacement === "spaceBeforeOutput" ? 1.6 : spacePlacement === "spaceAfterOutput" ? 1.4 : 1.2,
-                    text: spBefore + "can't" + spAfter,
-                    time: 1234567890123
-                  }],
+                  ...(spacePlacement === "spaceExact" ? {
+                    accuracy: true,
+                    attempts: [],
+                  } : {
+                    // TODO(na2hiro): should this be inaccurate?
+                    accuracy: false,
+                    attempts: [{
+                      hintWasShown: true,
+                      numberOfMatchedWordsSoFar: spacePlacement === "spaceBeforeOutput" ? 1.6 : spacePlacement === "spaceAfterOutput" ? 1.4 : 1.2,
+                      text: spBefore + "can't" + spAfter,
+                      time: 1234567890123
+                    }],
+                  }),
                   "checked": true,
                   "hintWasShown": true,
                   "numberOfMatchedWordsSoFar": hasExtraSpaces ? 1.6 : 1.2,
@@ -471,7 +475,7 @@ describe(App, () => {
             "totalNumberOfHintedWords": 3,
             "totalNumberOfLowExposuresSeen": 0,
             "totalNumberOfMatchedChars": hasExtraSpaces ? 13 : 10,
-            "totalNumberOfMistypedWords": spacePlacement === "spaceExact" ? 2 : 1,
+            "totalNumberOfMistypedWords": 1,
             "totalNumberOfNewWordsMet": 0,
             "totalNumberOfRetainedWords": 0
           }
@@ -503,7 +507,7 @@ describe(App, () => {
             "currentLessonStrokes":
               [
                 {
-                  // TODO(na2hiro): why inaccurate for exact?
+                ...(spacePlacement === "spaceExact" ? {accuracy: true, attempts: []} : {
                   "accuracy": false,
                   "attempts": [{
                     "hintWasShown": true,
@@ -511,6 +515,7 @@ describe(App, () => {
                     "text": spBefore+"too bads"+spAfter,
                     "time": 1234567890123
                   }],
+                }),
                   "checked": true,
                   "hintWasShown": true,
                   "numberOfMatchedWordsSoFar": hasExtraSpaces ? 1.6 : 1.4,
@@ -543,7 +548,7 @@ describe(App, () => {
             "totalNumberOfHintedWords": 2,
             "totalNumberOfLowExposuresSeen": 0,
             "totalNumberOfMatchedChars": hasExtraSpaces ? 16 : 14,
-            "totalNumberOfMistypedWords": spacePlacement === "spaceExact" ? 2 : 1,
+            "totalNumberOfMistypedWords": 1,
             "totalNumberOfNewWordsMet": 0,
             "totalNumberOfRetainedWords": 0
           }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -75,6 +75,7 @@ describe(App, () => {
       ).toMatchInlineSnapshot(
         `"You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a"`
       );
+      document.cookie = "batchUpdate=1";
     });
 
     function getStatsState() {
@@ -157,6 +158,7 @@ describe(App, () => {
     });
     // Current behavior
     it("accepts excess chars", async () => {
+      document.cookie = "batchUpdate=0";
       // This user with spaceOff setting actually puts space after
       const spBefore = spacePlacement === "spaceBeforeOutput" ? " " : "";
       const spAfter = spacePlacement === "spaceAfterOutput" || spacePlacement === "spaceOff" ? " " : "";
@@ -210,7 +212,7 @@ describe(App, () => {
       );
     });
     // Future behavior
-    it.skip("doesn't accept excess chars", async () => {
+    it("doesn't accept excess chars", async () => {
       // This user with spaceOff setting actually puts space before
       const spBefore = spacePlacement === "spaceBeforeOutput" || spacePlacement === "spaceOff" ? " " : "";
       const spAfter = spacePlacement === "spaceAfterOutput" ? " " : "";

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,304 @@
+import App from "./App";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useHistory, useLocation } from "react-router-dom";
+import React from "react";
+import { userEvent } from "@storybook/testing-library";
+import { promises as fs } from "node:fs";
+import Mock = jest.Mock;
+import { SpacePlacement } from "./types";
+
+describe(App, () => {
+  let currentState: any = undefined;
+
+  class StateLoggingApp extends App {
+    render() {
+      currentState = this.state;
+      return super.render();
+    }
+  }
+
+  function AppWithRouterInfo() {
+    const location = useLocation();
+    const history = useHistory();
+    return <StateLoggingApp location={location} history={history} />;
+  }
+
+  beforeEach(() => {
+    currentState = undefined;
+    Date.now = jest.fn(() => 1234567890123);
+    window.URL.createObjectURL = jest.fn();
+    global.fetch = jest.fn(async (path, options) => {
+      let content = (await fs.readFile(`./public${path}`)).toString();
+      return new Response(content);
+    });
+  });
+
+  afterEach(() => {
+    (window.URL.createObjectURL as jest.Mock).mockReset();
+    jest.resetAllMocks();
+  });
+
+
+  describe.each([
+    "spaceBeforeOutput",
+    "spaceAfterOutput",
+    "spaceOff",
+    "spaceExact"
+  ] as SpacePlacement[])("a lesson page (spacePlacement=%s)", (spacePlacement) => {
+    const input = () => screen.findByTestId("your-typed-text");
+    const typeIn = async (text: string) => userEvent.type(await input(), text);
+    const assertText = async (text: string) =>
+      await waitFor(async () => expect(await input()).toHaveValue(text));
+    const assertCurrentPhrase = async (text: string) =>
+      await waitFor(async () =>
+        expect(await screen.findByTestId("current-phrase")).toHaveTextContent(
+          text
+        )
+      );
+    beforeEach(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            "/lessons/stories/proverbs/proverbs-starting-with-y/"
+          ]}
+        >
+          <AppWithRouterInfo />
+        </MemoryRouter>
+      );
+      // Wait for files to be loaded
+      await waitFor(async () =>
+        expect(await input()).toHaveAccessibleName("Write You")
+      );
+      await userEvent.selectOptions(screen.getByRole("combobox", { name: "Match spaces" }), spacePlacement);
+      expect(
+        screen.getByTestId("current-and-upcoming-phrases").textContent!.trim().replace("​", "")
+      ).toMatchInlineSnapshot(
+        `"You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a You can lead a horse to water but you can't make it drink. You can't have it both ways. You can't have your cake and eat it too. You can't make an omelette without breaking eggs. You can't make a silk purse out of a"`
+      );
+    });
+
+    function getStatsState() {
+      // TODO: what else we want to check?
+      return {
+        currentLessonStrokes: currentState.currentLessonStrokes.map((stroke: any) => Object.fromEntries(
+          Object.entries(stroke).filter(([k, v]) =>
+            !["typedText"].includes(k)
+          )
+        )),
+        ...Object.fromEntries(Object.entries(currentState).filter(([k, v]) =>
+          ["totalNumberOfMatchedChars",
+            "totalNumberOfNewWordsMet",
+            "totalNumberOfLowExposuresSeen",
+            "totalNumberOfRetainedWords",
+            "totalNumberOfMistypedWords",
+            "totalNumberOfHintedWords"].includes(k)))
+      };
+    }
+
+    const hasExtraSpaces = ["spaceBeforeOutput", "spaceAfterOutput"].includes(spacePlacement);
+
+    it("accepts inputs letter by letter", async () => {
+      // This user with spaceOff setting actually puts space before
+      const spBefore = spacePlacement === "spaceBeforeOutput" || spacePlacement === "spaceOff" ? " " : "";
+      const spAfter = spacePlacement === "spaceAfterOutput" ? " " : "";
+
+      await assertCurrentPhrase("You");
+      await assertText("");
+      await typeIn(spBefore + "yo");
+      await assertText(spBefore + "yo");
+      await typeIn("u" + spAfter);
+      await assertText("");
+      await assertCurrentPhrase("can");
+      const expectedFirstStroke = {
+        "accuracy": true,
+        "attempts": [],
+        "checked": true,
+        "hintWasShown": true,
+        "numberOfMatchedWordsSoFar": hasExtraSpaces ? 0.8 : 0.6,
+        "stroke": "KPA/U",
+        "time": 1234567890123,
+        "word": "You"
+      };
+      expect(getStatsState()).toEqual(
+        {
+          "currentLessonStrokes": [expectedFirstStroke],
+          "totalNumberOfHintedWords": 1,
+          "totalNumberOfLowExposuresSeen": 0,
+          "totalNumberOfMatchedChars": hasExtraSpaces ? 4 : 3,
+          "totalNumberOfMistypedWords": 0,
+          "totalNumberOfNewWordsMet": 0,
+          "totalNumberOfRetainedWords": 0
+        }
+      );
+      await typeIn(spBefore + "can" + spAfter);
+      await assertText("");
+      await assertCurrentPhrase("lead");
+      const expectedSecondStroke = {
+        "accuracy": true,
+        "attempts": [],
+        "checked": true,
+        "hintWasShown": true,
+        "numberOfMatchedWordsSoFar": hasExtraSpaces ? 1.6 : 1.2,
+        "stroke": "K",
+        "time": 1234567890123,
+        "word": "can"
+      };
+      expect(getStatsState()).toEqual(
+        {
+          "currentLessonStrokes": [expectedFirstStroke, expectedSecondStroke],
+          "totalNumberOfHintedWords": 2,
+          "totalNumberOfLowExposuresSeen": 0,
+          "totalNumberOfMatchedChars": hasExtraSpaces ? 8 : 6,
+          "totalNumberOfMistypedWords": 0,
+          "totalNumberOfNewWordsMet": 0,
+          "totalNumberOfRetainedWords": 0
+        }
+      );
+    });
+    // Current behavior
+    it("accepts excess chars", async () => {
+      // This user with spaceOff setting actually puts space after
+      const spBefore = spacePlacement === "spaceBeforeOutput" ? " " : "";
+      const spAfter = spacePlacement === "spaceAfterOutput" || spacePlacement === "spaceOff" ? " " : "";
+      await assertCurrentPhrase("You");
+      await assertText("");
+      await typeIn(spBefore + "yours" + spAfter);
+      await timer(100);
+      if (spacePlacement === "spaceAfterOutput") {
+        await assertCurrentPhrase("You");
+        await assertText("yours ");
+        await typeIn("{backspace}{backspace}{backspace} ");
+      } else {
+        await assertCurrentPhrase("can");
+        if (spacePlacement === "spaceOff") {
+          await assertText("rs ");
+          await typeIn("{backspace}{backspace}{backspace}");
+        } else {
+          await assertText("rs");
+          await typeIn("{backspace}{backspace}");
+        }
+      }
+      await assertText("");
+      await assertCurrentPhrase("can");
+      expect(getStatsState()).toEqual({
+          "currentLessonStrokes": [
+            {
+              "accuracy": true,
+              "attempts": spacePlacement === "spaceAfterOutput" ?
+                [{
+                  "hintWasShown": true,
+                  "numberOfMatchedWordsSoFar": 0.6,
+                  "text": "yours ",
+                  "time": 1234567890123
+                }]
+                : [],
+              "checked": true,
+              "hintWasShown": true,
+              "numberOfMatchedWordsSoFar": hasExtraSpaces ? 0.8 : 0.6,
+              "stroke": "KPA/U",
+              "time": 1234567890123,
+              "word": "You"
+            }
+          ],
+          "totalNumberOfHintedWords": 1,
+          "totalNumberOfLowExposuresSeen": 0,
+          "totalNumberOfMatchedChars": hasExtraSpaces ? 4 : 3,
+          "totalNumberOfMistypedWords": 0,
+          "totalNumberOfNewWordsMet": 0,
+          "totalNumberOfRetainedWords": 0
+        }
+      );
+    });
+    // Future behavior
+    it.skip("doesn't accept excess chars", async () => {
+      // This user with spaceOff setting actually puts space before
+      const spBefore = spacePlacement === "spaceBeforeOutput" || spacePlacement === "spaceOff" ? " " : "";
+      const spAfter = spacePlacement === "spaceAfterOutput" ? " " : "";
+      await assertCurrentPhrase("You");
+      await assertText("");
+      await typeIn(spBefore + "yours" + spAfter);
+      await timer(100);
+      if (spacePlacement === "spaceExact") {
+        await assertText("rs");
+        await typeIn("{backspace}{backspace}");
+      } else {
+        await assertCurrentPhrase("You");
+        await assertText(spBefore + "yours" + spAfter);
+        if (spacePlacement === "spaceAfterOutput") {
+          await typeIn("{backspace}{backspace}{backspace} ");
+        } else {
+          await typeIn("{backspace}{backspace}");
+        }
+      }
+      await assertText("");
+      await assertCurrentPhrase("can");
+      expect(getStatsState()).toEqual({
+        "currentLessonStrokes": [
+          {
+            "accuracy": true,
+            "attempts": [],
+            "checked": true,
+            "hintWasShown": true,
+            "numberOfMatchedWordsSoFar": hasExtraSpaces ? 0.8 : 0.6,
+            "stroke": "KPA/U",
+            "time": 1234567890123,
+            "word": "You"
+          }
+        ],
+        "totalNumberOfHintedWords": 1,
+        "totalNumberOfLowExposuresSeen": 0,
+        "totalNumberOfMatchedChars": hasExtraSpaces ? 4 : 3,
+        "totalNumberOfMistypedWords": 0,
+        "totalNumberOfNewWordsMet": 0,
+        "totalNumberOfRetainedWords": 0
+      });
+    });
+    it("accepts inputs at once", async () => {
+      // This user with spaceOff setting actually puts space before
+      const spBefore = spacePlacement === "spaceBeforeOutput" || spacePlacement === "spaceOff" ? " " : "";
+      const spAfter = spacePlacement === "spaceAfterOutput" ? " " : "";
+      await assertText("");
+      // This is somewhat artificial for spaceExact. In practice, each word looks like "y" "o" and "u"
+      await typeIn(`${spBefore}you${spAfter}${spBefore}can${spAfter}`);
+
+      await assertText("");
+      expect(getStatsState()).toEqual(
+        {
+          "currentLessonStrokes":
+            [
+              {
+                "accuracy": true,
+                "attempts": [],
+                "checked": true,
+                "hintWasShown": true,
+                "numberOfMatchedWordsSoFar": hasExtraSpaces ? 0.8 : 0.6,
+                "stroke": "KPA/U",
+                "time": 1234567890123,
+                "word": "You"
+              },
+              {
+                "accuracy": true,
+                "attempts": [],
+                "checked": true,
+                "hintWasShown": true,
+                "numberOfMatchedWordsSoFar": hasExtraSpaces ? 1.6 : 1.2,
+                "stroke": "K",
+                "time": 1234567890123,
+                "word": "can"
+              }
+            ],
+          "totalNumberOfHintedWords": 2,
+          "totalNumberOfLowExposuresSeen": 0,
+          "totalNumberOfMatchedChars": hasExtraSpaces ? 8 : 6,
+          "totalNumberOfMistypedWords": 0,
+          "totalNumberOfNewWordsMet": 0,
+          "totalNumberOfRetainedWords": 0
+        }
+      );
+    });
+  });
+});
+
+async function timer(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/components/Material/OnePhraseMaterial.tsx
+++ b/src/components/Material/OnePhraseMaterial.tsx
@@ -43,8 +43,8 @@ export default function OnePhraseMaterial({
               {completedPhrases.join(" ")}&#8203;
               {userSettings.spacePlacement === "spaceBeforeOutput" ? "" : " "}
             </span>
-            <div className={currentAndUpcomingPhrasesClasses}>
-              <strong className="fw7" tabIndex={0}>
+            <div className={currentAndUpcomingPhrasesClasses} data-testid="current-and-upcoming-phrases">
+              <strong className="fw7" tabIndex={0} data-testid="current-phrase">
                 <span className="matched steno-material">{matched}</span>
                 <span className="steno-material">{unmatched}</span>
               </strong>

--- a/src/components/Material/SingleLineMaterial.tsx
+++ b/src/components/Material/SingleLineMaterial.tsx
@@ -57,8 +57,8 @@ export default function SingleLineMaterial({
               {completedPhrases.join(" ")}&#8203;
               {userSettings.spacePlacement === "spaceBeforeOutput" ? "" : " "}
             </span>
-            <div className={currentAndUpcomingPhrasesClasses}>
-              <strong className="fw7" tabIndex={0}>
+            <div className={currentAndUpcomingPhrasesClasses} data-testid="current-and-upcoming-phrases">
+              <strong className="fw7" tabIndex={0} data-testid="current-phrase">
                 <span className="matched steno-material">{matched}</span>
                 <span className="steno-material">{unmatched}</span>
               </strong>

--- a/src/components/TypedText.tsx
+++ b/src/components/TypedText.tsx
@@ -135,6 +135,7 @@ const TypedText = (props: Props) => {
                 isMultiline ? " text-center" : ""
               }`}
               id="your-typed-text"
+              data-testid="your-typed-text"
               aria-describedby="punctuation-description"
               onChange={props.updateMarkup}
               onKeyPress={keyPress.bind(this)}

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -84,9 +84,10 @@ function mapQWERTYKeysToStenoStroke(qwertyString, stenoLayout = "stenoLayoutAmer
  * @param {import('../types').Attempt[]} currentPhraseAttempts
  * @param {number} targetStrokeCount
  * @param {string} unmatchedActual
+ * @param {boolean=} batchUpdate
  * @returns {{strokeAccuracy: boolean, attempts: import('../types').Attempt[]}}
  */
-function strokeAccuracy(currentPhraseAttempts, targetStrokeCount, unmatchedActual) {
+function strokeAccuracy(currentPhraseAttempts, targetStrokeCount, unmatchedActual, batchUpdate) {
   let strokeAccuracy = true;
   let attempts = [];
 
@@ -128,17 +129,18 @@ function strokeAccuracy(currentPhraseAttempts, targetStrokeCount, unmatchedActua
     return {strokeAccuracy: false, attempts: attempts};
   }
 
-  // If it's the final stroke, fail any unmatched characters immediately
-  // (unless you're undoing a stroke and typed text is getting shorter)
-  let nextAttempt = attempts.length + 1;
-  let isFinalStroke = nextAttempt >= targetStrokeCount;
-  let hasUnmatchedChars = unmatchedActual.length > 0;
-  let failedSingleStrokeBrief = currentPhraseAttempts.length === 1 && targetStrokeCount === 1;
-  let isTypedTextLongerThanPrevious = currentPhraseAttempts.length > 1 && currentPhraseAttempts[currentPhraseAttempts.length - 1].text.length > currentPhraseAttempts[currentPhraseAttempts.length - 2].text.length;
-
-  if (isFinalStroke && hasUnmatchedChars && (failedSingleStrokeBrief || isTypedTextLongerThanPrevious)) {
-    attempts.push(currentPhraseAttempts[currentPhraseAttempts.length - 1]);
-    return {strokeAccuracy: false, attempts: attempts};
+  if (!batchUpdate) {
+    // If it's the final stroke, fail any unmatched characters immediately
+    // (unless you're undoing a stroke and typed text is getting shorter)
+    let nextAttempt = attempts.length + 1;
+    let isFinalStroke = nextAttempt >= targetStrokeCount;
+    let hasUnmatchedChars = unmatchedActual.length > 0;
+    let failedSingleStrokeBrief = currentPhraseAttempts.length === 1 && targetStrokeCount === 1;
+    let isTypedTextLongerThanPrevious = currentPhraseAttempts.length > 1 && currentPhraseAttempts[currentPhraseAttempts.length - 1].text.length > currentPhraseAttempts[currentPhraseAttempts.length - 2].text.length;
+    if (isFinalStroke && hasUnmatchedChars && (failedSingleStrokeBrief || isTypedTextLongerThanPrevious)) {
+      attempts.push(currentPhraseAttempts[currentPhraseAttempts.length - 1]);
+      return { strokeAccuracy: false, attempts: attempts };
+    }
   }
 
   return {strokeAccuracy: strokeAccuracy, attempts: attempts};

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -772,9 +772,27 @@ function writePersonalPreferences(itemToStore, JSONToStore) {
   }
 }
 
+/**
+ * Real target count, used for display etc.
+ * @param {{stroke: string}} currentOutline
+ * @return {number}
+ */
 function getTargetStrokeCount(currentOutline) {
   // console.log(currentOutline.stroke.split(/[/ ]/).length);
   return currentOutline.stroke.split(/[/ ]/).length || 1;
+}
+
+/**
+ * Target count, used for calculating misstrokes
+ * @param {{stroke: string}} currentOutline
+ * @return {number}
+ */
+function getTargetObservableStrokeCount(currentOutline) {
+  const nonObservableStrokes = ["KPA", "KPA*", "TK-LS"];
+  const nonObservableStrokeCount = currentOutline.stroke.split(/[/ ]/)
+    .filter(stroke => nonObservableStrokes.includes(stroke))
+    .length;
+  return getTargetStrokeCount(currentOutline) - nonObservableStrokeCount;
 }
 
 function repetitionsRemaining(userSettings, presentedMaterial, currentPhraseID) {
@@ -846,6 +864,7 @@ export {
   shouldShowStroke,
   strokeAccuracy,
   getTargetStrokeCount,
+  getTargetObservableStrokeCount,
   updateCapitalisationStrokesInNextItem,
   writePersonalPreferences
 };

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -80,6 +80,12 @@ function mapQWERTYKeysToStenoStroke(qwertyString, stenoLayout = "stenoLayoutAmer
   return stenoStroke;
 }
 
+/**
+ * @param {import('../types').Attempt[]} currentPhraseAttempts
+ * @param {number} targetStrokeCount
+ * @param {string} unmatchedActual
+ * @returns {{strokeAccuracy: boolean, attempts: import('../types').Attempt[]}}
+ */
 function strokeAccuracy(currentPhraseAttempts, targetStrokeCount, unmatchedActual) {
   let strokeAccuracy = true;
   let attempts = [];

--- a/src/utils/typey-type.test.js
+++ b/src/utils/typey-type.test.js
@@ -744,6 +744,20 @@ describe('matchSplitText', () => {
       const expected = ["over-the-", "", "over-the-", ""];
       expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
     });
+
+    it("splits a word with excess chars", () => {
+      const expectedText = "French";
+      const actualText = "Frenches";
+      const expected = ["French", "", "French", "es"];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("splits multiple words", () => {
+      const expectedText = "There";
+      const actualText = "There are";
+      const expected = ["There", "", "There", " are"];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
   });
 
   describe('case sensitive, no spacing', () => {
@@ -887,6 +901,20 @@ describe('matchSplitText', () => {
       const expected = [" over-the-", "", " over-the-", ""];
       expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
     });
+
+    it("splits a word with excess chars", () => {
+      const expectedText = " French";
+      const actualText = " Frenches";
+      const expected = [" French", "", " French", "es"];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("splits multiple words", () => {
+      const expectedText = " There";
+      const actualText = " There are";
+      const expected = [" There", "", " There", " are"];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
   });
 
   describe('case sensitive, space before, ignoredChars', () => {
@@ -1015,6 +1043,20 @@ describe('matchSplitText', () => {
       const expectedText = "over-the-^ ";
       const actualText = "over-the- ";
       const expected = ["over-the- ", "", "over-the- ", ""];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("splits a word with excess chars", () => {
+      const expectedText = "French ";
+      const actualText = "Frenches ";
+      const expected = ["French", " ", "French", "es "];
+      expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("splits multiple words", () => {
+      const expectedText = "There ";
+      const actualText = "There are ";
+      const expected = ["There ", "", "There ", "are "];
       expect(matchSplitText(expectedText, actualText, settings, userSettings)).toEqual(expect.arrayContaining(expected));
     });
   });

--- a/src/utils/typey-type.test.js
+++ b/src/utils/typey-type.test.js
@@ -203,6 +203,24 @@ describe('stroke accuracy for current phrase', () => {
 //       let targetStrokeCount = 1;
 //       expect(strokeAccuracy(currentPhraseAttempts, targetStrokeCount)).toEqual(false);
 //     });
+    it("should detect attempts with overrun", () => {
+      let currentPhraseAttempts = [
+        { text: " ", time: 1 },
+        { text: " y", time: 2 },
+        { text: " yo", time: 3 },
+        { text: " you", time: 4 },
+        { text: " your", time: 5 },
+        { text: " yours", time: 6 },
+        { text: " your", time: 7 },
+        { text: " you", time: 8 }
+      ];
+      let targetStrokeCount = 1;
+      let unmatchedActual = "";
+      expect(strokeAccuracy(currentPhraseAttempts, targetStrokeCount, unmatchedActual)).toEqual({
+        strokeAccuracy: false,
+        attempts: [{ text: " yours", time: 6 }]
+      });
+    });
   });
 
   describe('should return true for real successful meetings', () => {


### PR DESCRIPTION
This is to address the issue #15 with the _batch update_ strategy that is described in https://github.com/didoesdigital/typey-type/issues/15#issuecomment-2058007673. 

* 1st commit: add end-to-end test around app and simulate user typing whole state update. Confirm current behavior
* 2nd & 3rd commit: implement the batch update strategy under a flag and update the test case accordingly

I've confirmed following with manual and end-to-end tests:

* A') fails "yours" for "you" in /lessons/stories/proverbs/proverbs-starting-with-y/
  * (I reused the lesson for C. It should be the same thing as French vs Frenches)
* B) fails "too bads" for "too bad" as 1 word in /lessons/collections/two-word-briefs-same-beginnings/too/
* C) passes "You can" for "You" and "can" as 2 words typed quickly (in 1 stroke) in /lessons/stories/proverbs/proverbs-starting-with-y/

At this point, I'd like to get your feedback if this is going to a good direction or not. Also before removing the flag and current implementation, I'd like your input on stats to cover. The entire `App` state is huge, so I listed up some fields to test against in `getStatsState()` method, but I'm not sure that covers enough.

I'd appreciate if you can try this out. Thanks as always!