### PR TITLE
Convert AppRoutes to TS & Type Lessons' props better

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -55,11 +55,11 @@ import {
   UserSettings,
   LookupDictWithNamespacedDictsAndConfig,
   MetWords,
-  ImportedPersonalDictionaries,
-  CurrentLessonStrokes, ActualTypedText
+  CurrentLessonStrokes, ActualTypedText, PersonalDictionaryNameAndContents
 } from "./types";
 import { Location } from "history";
 import { CustomLessonMaterialValidationState } from "./pages/lessons/custom/components/CustomLessonIntro";
+import { RecentLessonHistoryItem } from "./pages/progress/components/RecentLessons";
 
 const AsyncBreak = Loadable({
   loader: () => import("./pages/break/Break"),
@@ -166,7 +166,7 @@ type AppStateForDescendants = {
   customLessonMaterial: string,
   customLessonMaterialValidationMessages: string[],
   customLessonMaterialValidationState: CustomLessonMaterialValidationState,
-  customLesson: unknown,
+  customLesson: Lesson,
   actualText: ActualTypedText,
   dictionaryIndex: unknown, // TODO: type like [{
 //   "title": "Dictionary",
@@ -202,7 +202,7 @@ type AppStateForDescendants = {
 // isGlobalLookupDictionaryLoaded: false,
   lookupTerm: string,
   recommendationHistory: unknown // TODO: type like { currentStep: null },
-  personalDictionaries: ImportedPersonalDictionaries,
+  personalDictionaries: PersonalDictionaryNameAndContents[],
   previousCompletedPhraseAsTyped: ActualTypedText,
   repetitionsRemaining: number,
   startTime: Date,
@@ -236,7 +236,7 @@ type AppStateForDescendants = {
 //   "subcategory": "",
 //   "path": process.env.PUBLIC_URL + "/drills/steno/lesson.txt"
 // }],
-  recentLessons: { history: unknown },
+  recentLessons: { history: RecentLessonHistoryItem[] },
   recommendedNextLesson: unknown, // TODO type like {
 //   studyType: "practice",
 //   limitNumberOfWords: 50,
@@ -606,7 +606,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState, appMethods }) => {
                       updatePersonalDictionaries={
                         appMethods.updatePersonalDictionaries
                       }
-                      lessonsProgress={appState.lessonsProgress}
                       lessonNotFound={appState.lessonNotFound}
                       fullscreen={appState.fullscreen}
                       changeFullscreen={appMethods.changeFullscreen}
@@ -614,7 +613,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState, appMethods }) => {
                       reviseLesson={appMethods.reviseLesson}
                       lessonSubTitle={appState.lesson.subtitle}
                       lessonTitle={appState.lesson.title}
-                      path={appState.lesson.path}
                       handleStopLesson={appMethods.handleStopLesson}
                       lessonIndex={appState.lessonIndex}
                       lesson={appState.lesson}
@@ -680,7 +678,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState, appMethods }) => {
                       sayCurrentPhraseAgain={appMethods.sayCurrentPhraseAgain}
                       startFromWordOne={appMethods.startFromWordOne}
                       startTime={appState.startTime}
-                      stenoHintsOnTheFly={appProps.stenohintsonthefly}
                       stopLesson={appMethods.stopLesson}
                       startCustomLesson={appMethods.startCustomLesson}
                       setUpProgressRevisionLesson={

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import TypeyTypeIcon from "./Icons/icon-images/TypeyTypeIcon.svg";
 import Icon from "./Icons/Icon";
 
-const Header = ({ fullscreen }: { fullscreen: string }) => {
+const Header = ({ fullscreen }: { fullscreen: boolean }) => {
   const mainHeading = useRef<HTMLHeadingElement>(null);
   useEffect(() => {
     if (mainHeading) {

--- a/src/components/TypedText.tsx
+++ b/src/components/TypedText.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import GoogleAnalytics from "react-ga4";
-import { UserSettings } from "../types";
+import { CurrentLessonStrokes, UserSettings } from "../types";
 
 type Props = {
   actualText: string;
   completedPhrases: any;
-  currentLessonStrokes: any;
+  currentLessonStrokes: CurrentLessonStrokes[];
   currentPhrase: string;
   previousCompletedPhraseAsTyped: string;
   sayCurrentPhraseAgain: () => void;

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Route, Switch } from "react-router-dom";
+import React, { ComponentProps } from "react";
+import { Route, RouteComponentProps, Switch } from "react-router-dom";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import Lesson from "./Lesson";
@@ -8,17 +8,14 @@ import CustomLessonSetup from "./custom/CustomLessonSetup";
 import Loadable from "react-loadable";
 import PageLoading from "../../components/PageLoading";
 
-type LessonsRoutingProps = {
-  customiseLesson: () => void;
-  customLesson: any;
-  generateCustomLesson: any;
-  handleLesson: any;
-  lesson: any;
-  lessonIndex: any;
-  match: any;
-  stopLesson: any;
-  [key: string]: any;
-};
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+type LessonsRoutingProps = Optional<
+  & RouteComponentProps
+  & ComponentProps<typeof Lesson>
+  & ComponentProps<typeof CustomLessonSetup>
+  & ComponentProps<typeof AsyncCustomLessonGenerator>
+  // TODO: check this. it's not passed from parent
+  , "lessonLength">
 
 const AsyncCustomLessonGenerator = Loadable({
   loader: () => import("./custom/CustomLessonGenerator"),
@@ -159,6 +156,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -246,6 +244,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -333,6 +332,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -420,6 +420,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -507,6 +508,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -594,6 +596,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -682,6 +685,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -770,6 +774,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -858,6 +863,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -987,6 +993,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -1075,6 +1082,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}
@@ -1163,6 +1171,7 @@ const Lessons = ({
             toggleHideOtherSettings={toggleHideOtherSettings}
             lesson={lesson}
             lessonIndex={lessonIndex}
+            // @ts-expect-error
             lessonLength={lessonLength}
             lessonNotFound={lessonNotFound}
             lessonSubTitle={lessonSubTitle}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -51,7 +51,7 @@ type Props = {
   changeVoiceUserSetting: (voiceName: string, voiceURI: string) => void;
   chooseStudy: () => void;
   completedPhrases: MaterialText[];
-  currentLessonStrokes: CurrentLessonStrokes;
+  currentLessonStrokes: CurrentLessonStrokes[];
   currentPhrase: MaterialText;
   currentPhraseID: number;
   currentStroke: Outline;

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -41,7 +41,7 @@ export type LessonProps = {
   changeVoiceUserSetting: (voiceName: string, voiceURI: string) => void;
   chooseStudy: () => void;
   completedPhrases: any;
-  currentLessonStrokes: CurrentLessonStrokes;
+  currentLessonStrokes: CurrentLessonStrokes[];
   currentPhrase: string;
   currentPhraseID: number;
   currentStroke: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export type DictName = string;
  */
 export type PersonalDictionaryNameAndContents = [DictName, StenoDictionary];
 
-type ImportedPersonalDictionaries = {
+export type ImportedPersonalDictionaries = {
   dictionariesNamesAndContents: PersonalDictionaryNameAndContents[];
 };
 


### PR DESCRIPTION
During #168 I noticed there are some code that are untyped but could be typed relatively easily: `AppRoutes` and Lessons' props where most of props were captured `with {[name: string]: any}`.

I started with most conservative `unknown`, which cannot be used without type guards, and repeatedly fixed where TS complains. I didn't eagerly type everything, so if some field requires `any` today, such fields are kept `unknown`.