### PR TITLE
Fix miscellaneous errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -118,7 +118,7 @@ class App extends Component {
         lastSeen: Date.now(), // Saturday, May 18, 2019 12:00:55 PM GMT+10:00
         linkTitle: "Loading…",
         linkText: "Study",
-        link: process.env.PUBLIC_URL + "/lessons/drills/prefixes/flashcards"// + "?recommended=true&" + PARAMS.practiceParams
+        link: "/lessons/drills/prefixes/flashcards"// + "?recommended=true&" + PARAMS.practiceParams
       },
       flashcardsCourseIndex: 0,
       fullscreen: false,

--- a/src/components/FinishedSpeedChart.jsx
+++ b/src/components/FinishedSpeedChart.jsx
@@ -138,11 +138,15 @@ export default function FinishedSpeedChart({ data }) {
   const bisect = bisector((d) => xAccessor(d));
 
   const onMove = (event) => {
-    const pointerX = pointer(event)[0] - dimensions.marginLeft;
-    const pointerXValue = xScale.invert(pointerX);
-    const nearestXIndex = bisect.center(data.dataPoints, pointerXValue);
-    const datum = data.dataPoints[nearestXIndex];
-    setHighlightedDatum(datum);
+    try {
+      const pointerX = pointer(event)?.[0] || 0 - dimensions.marginLeft;
+      const pointerXValue = xScale.invert(pointerX);
+      const nearestXIndex = bisect.center(data.dataPoints, pointerXValue);
+      const datum = data.dataPoints[nearestXIndex];
+      setHighlightedDatum(datum);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const onOut = () => {

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -247,7 +247,7 @@ export function useChooseStudy() {
           currentState.studyPresets?.[0]?.repetitions ||
           PARAMS.discover.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets?.[0]?.limitNumberOfWords ||
+          currentState.studyPresets?.[0]?.limitNumberOfWords ??
           PARAMS.discover.limitNumberOfWords;
         newState.sortOrder = PARAMS.discover.sortOrder;
         break;
@@ -262,7 +262,7 @@ export function useChooseStudy() {
           currentState.studyPresets?.[1]?.repetitions ||
           PARAMS.revise.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets?.[1]?.limitNumberOfWords ||
+          currentState.studyPresets?.[1]?.limitNumberOfWords ??
           PARAMS.revise.limitNumberOfWords;
         newState.sortOrder = PARAMS.revise.sortOrder;
         break;
@@ -277,7 +277,7 @@ export function useChooseStudy() {
           currentState.studyPresets?.[2]?.repetitions ||
           PARAMS.drill.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets?.[2]?.limitNumberOfWords ||
+          currentState.studyPresets?.[2]?.limitNumberOfWords ??
           PARAMS.drill.limitNumberOfWords;
         newState.sortOrder = PARAMS.drill.sortOrder;
         break;
@@ -292,7 +292,7 @@ export function useChooseStudy() {
           currentState.studyPresets?.[3]?.repetitions ||
           PARAMS.practice.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets?.[3]?.limitNumberOfWords ||
+          currentState.studyPresets?.[3]?.limitNumberOfWords ??
           PARAMS.practice.limitNumberOfWords;
         newState.sortOrder = PARAMS.practice.sortOrder;
         break;

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.js
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.js
@@ -244,10 +244,10 @@ export function useChooseStudy() {
         newState.seenWords = PARAMS.discover.seenWords;
         newState.retainedWords = PARAMS.discover.retainedWords;
         newState.repetitions =
-          currentState.studyPresets[0].repetitions ||
+          currentState.studyPresets?.[0]?.repetitions ||
           PARAMS.discover.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets[0].limitNumberOfWords ||
+          currentState.studyPresets?.[0]?.limitNumberOfWords ||
           PARAMS.discover.limitNumberOfWords;
         newState.sortOrder = PARAMS.discover.sortOrder;
         break;
@@ -259,10 +259,10 @@ export function useChooseStudy() {
         newState.seenWords = PARAMS.revise.seenWords;
         newState.retainedWords = PARAMS.revise.retainedWords;
         newState.repetitions =
-          currentState.studyPresets[1].repetitions ||
+          currentState.studyPresets?.[1]?.repetitions ||
           PARAMS.revise.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets[1].limitNumberOfWords ||
+          currentState.studyPresets?.[1]?.limitNumberOfWords ||
           PARAMS.revise.limitNumberOfWords;
         newState.sortOrder = PARAMS.revise.sortOrder;
         break;
@@ -274,10 +274,10 @@ export function useChooseStudy() {
         newState.seenWords = PARAMS.drill.seenWords;
         newState.retainedWords = PARAMS.drill.retainedWords;
         newState.repetitions =
-          currentState.studyPresets[2].repetitions ||
+          currentState.studyPresets?.[2]?.repetitions ||
           PARAMS.drill.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets[2].limitNumberOfWords ||
+          currentState.studyPresets?.[2]?.limitNumberOfWords ||
           PARAMS.drill.limitNumberOfWords;
         newState.sortOrder = PARAMS.drill.sortOrder;
         break;
@@ -289,10 +289,10 @@ export function useChooseStudy() {
         newState.seenWords = PARAMS.practice.seenWords;
         newState.retainedWords = PARAMS.practice.retainedWords;
         newState.repetitions =
-          currentState.studyPresets[3].repetitions ||
+          currentState.studyPresets?.[3]?.repetitions ||
           PARAMS.practice.repetitions;
         newState.limitNumberOfWords =
-          currentState.studyPresets[3].limitNumberOfWords ||
+          currentState.studyPresets?.[3]?.limitNumberOfWords ||
           PARAMS.practice.limitNumberOfWords;
         newState.sortOrder = PARAMS.practice.sortOrder;
         break;

--- a/src/pages/lessons/flashcards/Flashcards.js
+++ b/src/pages/lessons/flashcards/Flashcards.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react';
 import { Tooltip } from "react-tippy";
 import GoogleAnalytics from "react-ga4";
 import ReactModal from 'react-modal';
+import { useAppMethods } from "../../../states/legacy/AppMethodsContext";
+import { withAppMethods } from "../../../states/legacy/AppMethodsContext";
+import { userSettingsState } from "../../../states/userSettingsState";
+import { withAtomCompat } from "../../../states/atomUtils";
 import FlashcardsCarouselActionButtons from './components/FlashcardsCarouselActionButtons';
 import FlashcardsModal from './components/FlashcardsModal';
 import StrokesForWords from '../../../components/StrokesForWords';
@@ -511,4 +515,18 @@ currentSlide: currentSlide
   }
 }
 
-export default Flashcards;
+function FlashcardsWrapper(props) {
+  const { changeFullscreen, appFetchAndSetupGlobalDict } = useAppMethods();
+
+  return (
+    <Flashcards
+      {...props}
+      changeFullscreen={changeFullscreen}
+      fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
+    />
+  );
+}
+
+export default withAppMethods(
+  withAtomCompat(FlashcardsWrapper, "userSettings", userSettingsState)
+);


### PR DESCRIPTION
This PR attempts to:

- address Google search index complaint about link to soft 404 because of extra `typey-type/` in `https://didoesdigital.com/typey-type/typey-type/lessons/drills/prefixes/flashcards` from fallback default recommended flashcards `link`.
- squash errors from trying to access `[0]`, `[1]`, `[2]`, `[3]` on `studyPresets` and use fallback instead. This doesn't really fix the issue, just prevent the app from exploding over it. It's not clear to me why `studyPresets` would not be set at that point and I cannot reproduce the error locally.
- fix `/flashcards` exception in #173
- use nullish coalescing to allow a value of `0` for `limitNumberOfWords` while saving study presets
- squash error, "The provided value is non-finite" on `const pointerX = pointer(event)[0] - dimensions.marginLeft;`
