### PR TITLE
Use batch update as default to catch overruns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -888,8 +888,9 @@ class App extends Component {
 
   updateMarkup(event) {
     let actualText = event.target.value;
-    // TODO: remove cookie thing before merging
-    const batchUpdate = document.cookie.indexOf("batchUpdate=1")>=0;
+    // TODO: once we're happy that this will be the permanent new default behaviour, remove all the `batchUpdate`-specific branching code and tests:
+    // const batchUpdate = document.cookie.indexOf("batchUpdate=1")>=0;
+    const batchUpdate = true;
     if(!batchUpdate) {
       this.updateBufferSingle(actualText);
       return;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -232,8 +232,8 @@ describe(App, () => {
           }
         );
       });
-      // Current behavior
-      it("accepts excess chars except for spaceAfterOutput", async () => {
+      // TODO: once we're happy that with the new behaviour as the permanent default, remove all the `batchUpdate`-specific branching code and tests:
+      xit("accepts excess chars except for spaceAfterOutput", async () => {
         document.cookie = "batchUpdate=0";
         // This user with spaceOff setting actually puts space after
         const spBefore = spacePlacement === "spaceBeforeOutput" ? " " : "";
@@ -607,7 +607,9 @@ describe(App, () => {
       beforeEach(async () => {
         await loadPage(PAGES.partyTricks);
       });
-      it.each([1, 0])("records interim strokes for correct phrase (batchUpdate=%s)", async (batchUpdate) => {
+      // TODO: once we're happy that this will be the permanent new default behaviour, remove all the `batchUpdate`-specific branching code and tests:
+      // it.each([1, 0])("records interim strokes for correct phrase (batchUpdate=%s)", async (batchUpdate) => {
+      it.each([1])("records interim strokes for correct phrase (batchUpdate=%s)", async (batchUpdate) => {
         document.cookie = `batchUpdate=${batchUpdate}`;
         const { spBefore, spAfter } = getSpacer(spacePlacement);
         await typeIn(spBefore + "sigh" + spAfter);


### PR DESCRIPTION
After 2 months of testing by devs that manually set the cookie, there have been no reports of issues, so we'll turn it on as the default for everyone. More details in original PR:

https://github.com/didoesdigital/typey-type/pull/167