### PR TITLE
Migrate lookup term out of app state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -84,7 +84,6 @@ class App extends Component {
       },
       isPloverDictionaryLoaded: false,
       isGlobalLookupDictionaryLoaded: false,
-      lookupTerm: '',
       recommendationHistory: { currentStep: null },
       personalDictionaries: {
         dictionariesNamesAndContents: null,
@@ -514,14 +513,10 @@ class App extends Component {
     // Get URL search query parameters:
     const parsedParams = queryString.parse(search);
 
-    // Get lookupTerm from URL:
-    const lookupTerm = parsedParams['q'];
-
     // Update newSettings using URL search query parameters:
     applyQueryParamsToUserSettings(newSettings, parsedParams);
 
     this.setState({
-      lookupTerm: lookupTerm,
       userSettings: newSettings
     }, () => {
       // Write updated user settings to local storage:
@@ -529,9 +524,10 @@ class App extends Component {
 
       // Clean up URL, remove parameters:
       const newHistory = Object.assign({}, this.props.location)
-      newHistory.search = "";
-      // Note: this affects StrokesForWords lookup ?q= behaviour:
-      this.props.history.replace(newHistory);
+      if (!this.props.location?.pathname.includes("/lookup")) {
+        newHistory.search = "";
+        this.props.history.replace(newHistory);
+      }
 
       // Replace smart typography in presented material:
       if (simpleTypography) {

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -122,7 +122,6 @@ type AppStateForDescendants = {
   lessonsProgress: unknown,
 // isPloverDictionaryLoaded: false,
 // isGlobalLookupDictionaryLoaded: false,
-  lookupTerm: string,
   recommendationHistory: unknown // TODO: type like { currentStep: null },
   personalDictionaries: PersonalDictionaryNameAndContents[],
   previousCompletedPhraseAsTyped: ActualTypedText,
@@ -330,7 +329,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState  }) => {
                       globalLookupDictionaryLoaded={
                         appState.globalLookupDictionaryLoaded
                       }
-                      lookupTerm={appState.lookupTerm}
                       {...props}
                     />
                   </ErrorBoundary>

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import GoogleAnalytics from "react-ga4";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { groups } from "d3-array";
-import type { LessonIndexEntry } from "../../../types";
 import { useLessonIndex } from "../../../states/lessonIndexState";
+import debounce from "../../../utils/debounce";
+import type { LessonIndexEntry } from "../../../types";
 
 type LessonListProps = {
   url: string;
@@ -34,7 +35,10 @@ const LessonLink = ({
   </Link>
 );
 
-const InnerLessonList = ({ lessonIndex, url }: LessonListProps & { lessonIndex: LessonIndexEntry[] }) => (
+const InnerLessonList = ({
+  lessonIndex,
+  url,
+}: LessonListProps & { lessonIndex: LessonIndexEntry[] }) => (
   <ul className="unstyled-list">
     {lessonIndex.map((lesson) => (
       <li className="unstyled-list-item mb1" key={lesson.path}>
@@ -106,15 +110,6 @@ function filterLessons(searchTerm: string, lessonIndex: LessonIndexEntry[]) {
   }
 
   return filteredLessons;
-}
-
-export function debounce<T extends Function>(cb: T, wait = 20) {
-  let h = 0;
-  let callable = (...args: any) => {
-    clearTimeout(h);
-    h = window.setTimeout(() => cb(...args), wait);
-  };
-  return callable;
 }
 
 export default function LessonList({ url }: LessonListProps) {

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -108,7 +108,7 @@ function filterLessons(searchTerm: string, lessonIndex: LessonIndexEntry[]) {
   return filteredLessons;
 }
 
-function debounce<T extends Function>(cb: T, wait = 20) {
+export function debounce<T extends Function>(cb: T, wait = 20) {
   let h = 0;
   let callable = (...args: any) => {
     clearTimeout(h);

--- a/src/pages/lookup/Lookup.stories.jsx
+++ b/src/pages/lookup/Lookup.stories.jsx
@@ -29,7 +29,7 @@ const globalLookupDictionary = new Map([
 ]);
 
 const Template = (args) => {
-  useHydrateAtoms([[userSettingsState, userSettings]])
+  useHydrateAtoms([[userSettingsState, userSettings]]);
   return (
     <AppMethodsContext.Provider value={appMethods}>
       <Lookup
@@ -46,12 +46,14 @@ const Template = (args) => {
 
 export const LookupStory = Template.bind({});
 
-export const LookupFromURLStory = Template.bind({});
-LookupFromURLStory.args = {
-  lookupTerm: "a phrase that is not in any dictionary",
-};
-LookupFromURLStory.play = async ({ canvasElement }) => {
+export const LookupMissingWordStory = Template.bind({});
+LookupMissingWordStory.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
+
+  await userEvent.type(
+    await within(canvasElement).getByLabelText("Enter words to look up"),
+    "a phrase that is not in any dictionary"
+  );
 
   await canvas.findByText("No results found");
   await expect(canvas.getByTestId("lookup-page-contents")).toHaveTextContent(
@@ -78,11 +80,11 @@ LookupSearchStory.play = async ({ canvasElement }) => {
 };
 
 export const LookupPersonalDictionariesStory = Template.bind({});
-LookupPersonalDictionariesStory.args = {
-  lookupTerm: "!",
-};
 LookupPersonalDictionariesStory.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
+  const canvas = await within(canvasElement);
+
+  const inputElement = canvas.getByLabelText("Enter words to look up");
+  await userEvent.type(inputElement, "!");
 
   // await expect(canvas.getByTestId("lookup-page-contents")).toHaveTextContent(
   //   "text shown in dictionary"

--- a/src/pages/lookup/Lookup.stories.jsx
+++ b/src/pages/lookup/Lookup.stories.jsx
@@ -35,7 +35,6 @@ const Template = (args) => {
       <Lookup
         globalLookupDictionary={globalLookupDictionary}
         globalLookupDictionaryLoaded={true}
-        lookupTerm={undefined}
         userSettings={userSettings}
         personalDictionaries={{ dictionariesNamesAndContents: null }}
         stenohintsonthefly={true}

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import StrokesForWords from "../../components/StrokesForWords";
 import PseudoContentButton from "../../components/PseudoContentButton";
 import Subheader from "../../components/Subheader";
@@ -13,19 +13,17 @@ import { userSettingsState } from "../../states/userSettingsState";
 type Props = {
   globalLookupDictionary: any;
   globalLookupDictionaryLoaded: boolean;
-  lookupTerm?: string;
 };
 
 const Lookup = ({
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
-  lookupTerm,
 }: Props) => {
+  const location = useLocation();
+  const lookupTerm = new URLSearchParams(location.search).get("q") ?? "";
   const userSettings = useAtomValue(userSettingsState);
-  const {
-    appFetchAndSetupGlobalDict,
-    setCustomLessonContent
-  } = useAppMethods();
+  const { appFetchAndSetupGlobalDict, setCustomLessonContent } =
+    useAppMethods();
   const [bookmarkURL, setBookmarkURL] = useState(
     process.env.PUBLIC_URL + "/lookup"
   );

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -51,7 +51,7 @@ const Lookup = ({
   }, []);
 
   useEffect(() => {
-    updateSearchParams(lookupTerm);
+    updateSearchParams(encodeURIComponent(lookupTerm));
   }, [lookupTerm, updateSearchParams]);
 
   useEffect(() => {

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -9,7 +9,7 @@ import type { MaterialItem } from "../../types";
 import { useAppMethods } from "../../states/legacy/AppMethodsContext";
 import { useAtomValue } from "jotai";
 import { userSettingsState } from "../../states/userSettingsState";
-import { debounce } from "../lessons/components/LessonList";
+import debounce from "../../utils/debounce";
 
 type Props = {
   globalLookupDictionary: any;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+function debounce<T extends Function>(cb: T, wait = 20) {
+  let h = 0;
+  let callable = (...args: any) => {
+    clearTimeout(h);
+    h = window.setTimeout(() => cb(...args), wait);
+  };
+  return callable;
+}
+
+export default debounce;


### PR DESCRIPTION
This PR moves `lookupTerm` out of app state to continue the work of breaking up `app.js`.

<img width="1099" alt="Typey Type lookup for quad showing 3 results" src="https://github.com/user-attachments/assets/4732011b-9d3d-497d-ac5b-0b3676b65f79">

Changes:

- In `app.js`, if the location pathname includes `/lookup`, we no longer clear the query params
- When visiting a bookmarked lookup URL like <https://didoesdigital.com/typey-type/lookup?q=had%20the>, Typey Type no longer clears the query param after arriving
- When entering words to look up, the query param is updated (with debouncing).

Given the last point above, it's no longer *necessary* to manually provide a share link because you can now copy and paste the URL from the browser without it:
<img width="590" alt="Share link with the URL ending in lookup?q=had%20the and a button to copy link to clipboard" src="https://github.com/user-attachments/assets/00da7ca3-4d63-43e3-afaa-cdbf97b5470a">

Let's keep the manual copy button for now anyway, to encourage people to share Typey Type lookup links.

The PR also changes:

- lookup stories
- extracts the `debounce` function to its own file