### PR TITLE
Migrate personal best speed and today's top speed to Jotai

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,6 @@ class App extends Component {
       showStrokesInLesson: false,
       targetStrokeCount: 1,
       timer: 0,
-      topSpeedPersonalBest: 0,
       totalNumberOfMatchedWords: 0,
       numberOfMatchedChars: 0,
       totalNumberOfMatchedChars: 0,
@@ -186,7 +185,6 @@ class App extends Component {
   setPersonalPreferences(source) {
     let metWordsFromStateOrArg = this.state.metWords;
     let lessonsProgressState = this.state.lessonsProgress;
-    let topSpeedPersonalBestState = this.state.topSpeedPersonalBest;
     if (source && source !== '') {
       try {
         let parsedSource = JSON.parse(source);
@@ -197,7 +195,7 @@ class App extends Component {
       catch (error) { }
     }
     else {
-      [metWordsFromStateOrArg, lessonsProgressState, topSpeedPersonalBestState] = loadPersonalPreferences();
+      [metWordsFromStateOrArg, lessonsProgressState] = loadPersonalPreferences();
     }
 
     let calculatedYourSeenWordCount = calculateSeenWordCount(this.state.metWords);
@@ -205,13 +203,11 @@ class App extends Component {
 
     this.setState({
       lessonsProgress: lessonsProgressState,
-      topSpeedPersonalBest: topSpeedPersonalBestState,
       metWords: metWordsFromStateOrArg,
       yourSeenWordCount: calculatedYourSeenWordCount,
       yourMemorisedWordCount: calculatedYourMemorisedWordCount,
     }, () => {
       writePersonalPreferences('lessonsProgress', this.state.lessonsProgress);
-      writePersonalPreferences('topSpeedPersonalBest', this.state.topSpeedPersonalBest);
       writePersonalPreferences('metWords', this.state.metWords);
       this.setupLesson();
     });
@@ -314,11 +310,6 @@ class App extends Component {
       yourSeenWordCount: calculateSeenWordCount(providedMetWords),
       yourMemorisedWordCount: calculateMemorisedWordCount(providedMetWords)
     });
-  }
-
-  updateTopSpeedPersonalBest(wpm) {
-    this.setState({topSpeedPersonalBest: wpm});
-    writePersonalPreferences('topSpeedPersonalBest', wpm);
   }
 
   // set user settings
@@ -1005,7 +996,6 @@ class App extends Component {
               updatePersonalDictionaries: this.updatePersonalDictionaries.bind(this),
               updateRevisionMaterial: updateRevisionMaterial.bind(this),
               updateStartingMetWordsAndCounts: this.updateStartingMetWordsAndCounts.bind(this),
-              updateTopSpeedPersonalBest: this.updateTopSpeedPersonalBest.bind(this),
             }
           }>
             <AppRoutes

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -128,7 +128,6 @@ type AppStateForDescendants = {
   showStrokesInLesson: boolean,
   targetStrokeCount: number,
   timer: number,
-  topSpeedPersonalBest: number,
   totalNumberOfMatchedWords: number,
 // numberOfMatchedChars: 0,
 // totalNumberOfMatchedChars: 0,
@@ -383,7 +382,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState  }) => {
                       showStrokesInLesson={appState.showStrokesInLesson}
                       targetStrokeCount={appState.targetStrokeCount}
                       timer={appState.timer}
-                      topSpeedPersonalBest={appState.topSpeedPersonalBest}
                       totalNumberOfMatchedWords={
                         appState.totalNumberOfMatchedWords
                       }

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -70,7 +70,6 @@ const Lesson = ({
   startTime,
   targetStrokeCount,
   timer,
-  topSpeedPersonalBest,
   totalNumberOfHintedWords,
   totalNumberOfLowExposuresSeen,
   totalNumberOfMatchedWords,
@@ -99,7 +98,6 @@ const Lesson = ({
     updateMarkup,
     updatePersonalDictionaries,
     updateRevisionMaterial,
-    updateTopSpeedPersonalBest,
   } = useAppMethods();
   const lessonIndex = useLessonIndex();
   const [userSettings, setUserSettings] = useAtom(userSettingsState);
@@ -396,11 +394,9 @@ const Lesson = ({
               settings={lesson.settings}
               startTime={startTime}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               revisionMode={revisionMode}
               updatePreset={updatePreset}
               updateRevisionMaterial={updateRevisionMaterial}
-              updateTopSpeedPersonalBest={updateTopSpeedPersonalBest}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
               totalNumberOfNewWordsMet={totalNumberOfNewWordsMet}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -53,7 +53,6 @@ const Lessons = ({
   startTime,
   targetStrokeCount,
   timer,
-  topSpeedPersonalBest,
   totalNumberOfHintedWords,
   totalNumberOfLowExposuresSeen,
   totalNumberOfMatchedWords,
@@ -94,7 +93,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -135,7 +133,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -176,7 +173,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -217,7 +213,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -258,7 +253,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -299,7 +293,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -341,7 +334,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -383,7 +375,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -425,7 +416,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -504,7 +494,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -546,7 +535,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -588,7 +576,6 @@ const Lessons = ({
               startTime={startTime}
               targetStrokeCount={targetStrokeCount}
               timer={timer}
-              topSpeedPersonalBest={topSpeedPersonalBest}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
               totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
               totalNumberOfMatchedWords={totalNumberOfMatchedWords}
@@ -606,9 +593,7 @@ const Lessons = ({
           path={match.url}
           render={() => (
             <Suspense fallback={<PageLoading />}>
-              <LessonsIndex
-                customLesson={customLesson}
-              />
+              <LessonsIndex customLesson={customLesson} />
             </Suspense>
           )}
         />

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -10,12 +10,13 @@ import PageLoading from "../../components/PageLoading";
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 type LessonsRoutingProps = Optional<
-  & RouteComponentProps
-  & ComponentPropsWithoutRef<typeof Lesson>
-  & ComponentPropsWithoutRef<typeof CustomLessonSetup>
-  & ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator>
+  RouteComponentProps &
+    ComponentPropsWithoutRef<typeof Lesson> &
+    ComponentPropsWithoutRef<typeof CustomLessonSetup> &
+    ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator>,
   // TODO: check this. it's not passed from parent
-  , "lessonLength">
+  "lessonLength"
+>;
 
 const AsyncCustomLessonGenerator = Loadable({
   loader: () => import("./custom/CustomLessonGenerator"),

--- a/src/pages/lessons/components/Finished.tsx
+++ b/src/pages/lessons/components/Finished.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { useAtom } from "jotai";
 import LessonCanvasFooter from "./LessonCanvasFooter";
 import FinishedZeroAndEmptyStateMessage from "./FinishedZeroAndEmptyState";
 import UserSettings from "./UserSettings/UserSettings";
@@ -16,6 +17,11 @@ import LessonFinePrintFooter from "./LessonFinePrintFooter";
 import getNumericAccuracy from "../utilities/getNumericAccuracy";
 import type { ConfettiConfig } from "./FinishedSummaryHeadings";
 import type { FinishedProps, LessonData, TransformedData } from "../types";
+import {
+  newTopSpeedPersonalBestState,
+  newTopSpeedTodayState,
+  topSpeedPersonalBestState,
+} from "../../../states/finishedLessonState";
 
 const calculateScores = (duration: number, wordCount: number) =>
   duration > 0
@@ -46,7 +52,6 @@ const Finished = ({
   settings,
   startTime,
   timer,
-  topSpeedPersonalBest,
   totalNumberOfHintedWords,
   totalNumberOfLowExposuresSeen,
   totalNumberOfMatchedWords,
@@ -56,14 +61,20 @@ const Finished = ({
   totalWordCount,
   updatePreset,
   updateRevisionMaterial,
-  updateTopSpeedPersonalBest,
 }: FinishedProps) => {
   const location = useLocation();
 
   const [chartData, setChartData] = useState<TransformedData>(null);
   const [confettiConfig, setConfettiConfig] = useState<ConfettiConfig>(null);
-  const [newTopSpeedPersonalBest, setNewTopSpeedPersonalBest] = useState(false);
-  const [newTopSpeedToday, setNewTopSpeedToday] = useState(false);
+  const [topSpeedPersonalBest, setTopSpeedPersonalBest] = useAtom(
+    topSpeedPersonalBestState
+  );
+  const [newTopSpeedPersonalBest, setNewTopSpeedPersonalBest] = useAtom(
+    newTopSpeedPersonalBestState
+  );
+  const [newTopSpeedToday, setNewTopSpeedToday] = useAtom(
+    newTopSpeedTodayState
+  );
   const [numericAccuracy, setNumericAccuracy] = useState(0);
   const [wpm, setWpm] = useState(0);
 
@@ -103,7 +114,7 @@ const Finished = ({
   // update top speed today or ever and headings and confetti
   useEffect(() => {
     const fasterSpeedToday = wpm > topSpeedToday;
-    const fasterPersonalBest = wpm > topSpeedPersonalBest;
+    const fasterPersonalBest = wpm > topSpeedPersonalBest?.wpm ?? 0;
     const minimumStrokes = currentLessonStrokes.length > 3;
     const minimumSpeed = wpm > 3;
     const thirtyStrokesOrNotRevision =
@@ -118,7 +129,7 @@ const Finished = ({
     ) {
       setConfettiConfig({ sparsity: 17, colors: 5 });
       topSpeedToday = wpm;
-      updateTopSpeedPersonalBest(wpm);
+      setTopSpeedPersonalBest({ wpm });
       setNewTopSpeedPersonalBest(true);
       setNewTopSpeedToday(true);
     } else if (

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -48,7 +48,6 @@ export type LessonProps = {
   startTime: any;
   targetStrokeCount: any;
   timer: number;
-  topSpeedPersonalBest: any;
   totalNumberOfHintedWords: any;
   totalNumberOfLowExposuresSeen: any;
   totalNumberOfMatchedWords: any;
@@ -76,7 +75,6 @@ export type FinishedProps = {
   settings: any;
   startTime: any;
   timer: number;
-  topSpeedPersonalBest: any;
   totalNumberOfHintedWords: any;
   totalNumberOfLowExposuresSeen: any;
   totalNumberOfMatchedWords: any;
@@ -86,5 +84,4 @@ export type FinishedProps = {
   totalWordCount: any;
   updatePreset: (studyType: Study) => void;
   updateRevisionMaterial: any;
-  updateTopSpeedPersonalBest: any;
 };

--- a/src/states/finishedLessonState.ts
+++ b/src/states/finishedLessonState.ts
@@ -1,0 +1,13 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+const defaultTopSpeedPersonalBest = { wpm: 0 };
+
+export const topSpeedPersonalBestState = atomWithStorage(
+  "topSpeedPersonalBest",
+  defaultTopSpeedPersonalBest
+);
+
+export const newTopSpeedPersonalBestState = atom(false);
+
+export const newTopSpeedTodayState = atom(false);

--- a/src/states/legacy/AppMethodsContext.tsx
+++ b/src/states/legacy/AppMethodsContext.tsx
@@ -35,7 +35,6 @@ export type AppMethods = {
   updatePersonalDictionaries: typeof App.prototype.updatePersonalDictionaries,
   updateRevisionMaterial: typeof updateRevisionMaterial,
   updateStartingMetWordsAndCounts: typeof App.prototype.updateStartingMetWordsAndCounts,
-  updateTopSpeedPersonalBest: typeof App.prototype.updateTopSpeedPersonalBest,
 }
 
 const AppMethodsContext = createContext<AppMethods>(null!);

--- a/src/stories/fixtures/appMethods.ts
+++ b/src/stories/fixtures/appMethods.ts
@@ -23,8 +23,8 @@ const appMethods: AppMethods = {
   updateMultipleMetWords: () => undefined,
   updatePersonalDictionaries: () => undefined,
   updateRevisionMaterial: () => undefined,
-  updateStartingMetWordsAndCounts: () => console.log("update starting met words and counts"),
-  updateTopSpeedPersonalBest: () => undefined,
-}
+  updateStartingMetWordsAndCounts: () =>
+    console.log("update starting met words and counts"),
+};
 
 export default appMethods;

--- a/src/utils/typey-type.js
+++ b/src/utils/typey-type.js
@@ -621,7 +621,6 @@ function loadPersonalDictionariesFromLocalStorage() {
 function loadPersonalPreferences() {
   let metWords = {};
   let lessonsProgress = {};
-  let topSpeedPersonalBest = { wpm: 0 };
   try {
     if (window.localStorage) {
       if (window.localStorage.getItem('metWords')) {
@@ -630,16 +629,13 @@ function loadPersonalPreferences() {
       if (window.localStorage.getItem('lessonsProgress')) {
         lessonsProgress = Object.assign(lessonsProgress, JSON.parse(window.localStorage.getItem('lessonsProgress')));
       }
-      if (window.localStorage.getItem('topSpeedPersonalBest')) {
-        topSpeedPersonalBest = Object.assign(topSpeedPersonalBest, JSON.parse(window.localStorage.getItem('topSpeedPersonalBest')));
-      }
-      return [metWords, lessonsProgress, topSpeedPersonalBest['wpm']];
+      return [metWords, lessonsProgress];
     }
   }
   catch(error) {
     console.log('Unable to read local storage.', error);
   }
-  return [metWords, lessonsProgress, topSpeedPersonalBest['wpm']];
+  return [metWords, lessonsProgress];
 }
 
 function writePersonalPreferences(itemToStore, JSONToStore) {
@@ -662,13 +658,7 @@ function writePersonalPreferences(itemToStore, JSONToStore) {
     }
   }
 
-  let stringToStore;
-  if (itemToStore === 'topSpeedPersonalBest') {
-    stringToStore = JSON.stringify({wpm: JSONToStore});
-  }
-  else {
-    stringToStore = JSON.stringify(JSONToStore);
-  }
+  let stringToStore = JSON.stringify(JSONToStore);
 
   try {
     window.localStorage.setItem(itemToStore, stringToStore);


### PR DESCRIPTION
This PR migrates migrates `newTopSpeedTodayState`, `newTopSpeedPersonalBestState`, `topSpeedPersonalBestState` to Jotai:

<img width="1421" alt="Finished Typey Type lesson with new top speed for today!" src="https://github.com/user-attachments/assets/942ae202-15cc-44a9-be02-fd99d3ac0fc9">

<img width="1420" alt="Finished Typey Type lesson with new personal best!" src="https://github.com/user-attachments/assets/7881576d-e775-44ce-9f8f-a27ba455e700">
