### PR TITLE
Update KAOES for star key with raw steno dictionary

### DIFF
--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -414,7 +414,8 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
                             </a>{" "}
                             and set it as the highest priority dictionary in
                             Plover. When you're done playing the KAOES game,
-                            disable the raw steno dictionary.
+                            disable the raw steno dictionary. Typey Type will
+                            clear incorrect raw steno input ending in “&nbsp;*”.
                           </li>
                           <li>
                             Turn off all of your steno dictionaries to produce
@@ -432,9 +433,8 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
                         <h4>QWERTY steno</h4>
                         <p>
                           When the “QWERTY steno” setting is on, type regular
-                          QWERTY letters in the equivalent position of where the
-                          matching steno key would be. For example, to press the
-                          right{" "}
+                          QWERTY letters in the equivalent position of the
+                          matching steno key. For example, to press the right{" "}
                           <kbd className="steno-stroke steno-stroke--subtle">
                             -R
                           </kbd>{" "}

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -179,12 +179,20 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
       setRightWrongColor(rightColor);
       dispatch({ type: actions.roundCompleted });
     } else {
-      // Note: we don't auto-clear incorrect steno input because we need to allow multi-character
-      // keys like "-R" to be typed, but qwerty steno is always 1 char so this should make it easier
-      // for people to try again with another character
+      // NOTE: we don't auto-clear just *any* incorrect steno input because we
+      // need to allow multi-character keys like "-R" to be typed. Qwerty steno
+      // is always 1 char so we auto-clear that incorrect input to make it
+      // easier for people to try again with another character. For people
+      // using raw steno and raw-steno.json with no * stroke for =undo, we
+      // auto-clear incorrect input ending in ` *`
       if (inputForKAOES === "qwerty") {
         setTypedText("");
+      } else {
+        if (typedStenoKey.endsWith(" *")) {
+          setTypedText("");
+        }
       }
+
       setStenoStroke(stenoStroke.set(comparableTypedKeyNumber));
       setRightWrongColor(wrongColor);
     }

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -22,6 +22,10 @@ import { ReactComponent as MischievousRobot } from "../../../images/MischievousR
 import { choosePuzzleKey, prettyKey } from "./utilities";
 import * as stroke from "../../../utils/stroke";
 import { mapQWERTYKeysToStenoStroke } from "../../../utils/typey-type";
+import OutboundLink from "../../../components/OutboundLink";
+import { IconExternal } from "../../../components/IconExternal";
+import { Tooltip } from "react-tippy";
+import useAnnounceTooltip from "../../../components/Announcer/useAnnounceTooltip";
 
 const stenoTypedTextToKeysMapping = {
   "-Z": stroke.Z,
@@ -84,6 +88,8 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
   const canvasRef = useRef(null);
   const canvasWidth = Math.floor(window.innerWidth);
   const canvasHeight = Math.floor(window.innerHeight);
+
+  const announceTooltip = useAnnounceTooltip();
 
   const [previousCompletedPhraseAsTyped, setPreviousCompletedPhraseAsTyped] =
     useState("");
@@ -377,21 +383,62 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
                         </p>
                         <h4>Raw steno</h4>
                         <p>
-                          When the “Raw steno” setting is on, you can turn off
-                          all of your steno dictionaries to produce raw steno
-                          output. That way, when you press the{" "}
-                          <kbd className="steno-stroke steno-stroke--subtle">
-                            S
-                          </kbd>{" "}
-                          key, the steno engine will output “S” instead of “is”.
-                          Likewise, pressing the{" "}
-                          <kbd className="steno-stroke steno-stroke--subtle">
-                            -T
-                          </kbd>{" "}
-                          key will output “-T” instead of “the”. The dash is
+                          When the “Raw steno” setting is on, you need to type
+                          “-T” to prove that you know that key. The dash is
                           necessary for keys on the right-hand side of the
-                          board.
+                          board. There are 2 main options to type “raw steno”
+                          keys like that:
                         </p>
+                        <ol>
+                          <li>
+                            Download{" "}
+                            <OutboundLink
+                              className="no-underline"
+                              eventLabel="a raw steno dictionary (external link opens in new tab)"
+                              aria-label="a raw steno dictionary (external link opens in new tab)"
+                              to="https://github.com/didoesdigital/steno-dictionaries?tab=readme-ov-file#raw-steno-dictionary"
+                            >
+                              a raw steno dictionary
+                              {/* @ts-ignore */}
+                              <Tooltip
+                                title="(external link opens in new tab)"
+                                animation="shift"
+                                arrow="true"
+                                className=""
+                                duration="200"
+                                tabIndex="0"
+                                tag="span"
+                                theme="didoesdigital"
+                                trigger="mouseenter focus click"
+                                onShow={announceTooltip}
+                              >
+                                <IconExternal
+                                  ariaHidden="true"
+                                  role="presentation"
+                                  iconWidth="24"
+                                  iconHeight="24"
+                                  className="ml1 svg-icon-wrapper svg-baseline"
+                                  iconTitle=""
+                                />
+                              </Tooltip>
+                            </OutboundLink>{" "}
+                            and set it as the highest priority dictionary in
+                            Plover. When you're done playing the KAOES game,
+                            disable the raw steno dictionary.
+                          </li>
+                          <li>
+                            Turn off all of your steno dictionaries to produce
+                            raw steno output. That way, when you press the{" "}
+                            <kbd className="steno-stroke steno-stroke--subtle">
+                              -T
+                            </kbd>{" "}
+                            key, the steno engine will output “-T” instead of
+                            “the”. Because the “*” key in Plover does undo by
+                            default, you may still need to click the “*” key or
+                            otherwise find a way to write “*”.
+                          </li>
+                        </ol>
+
                         <h4>QWERTY steno</h4>
                         <p>
                           When the “QWERTY steno” setting is on, type regular

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -242,7 +242,8 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
               />
               <div id={"good-guess"} className="flex flex-grow">
                 <GameProgress
-                  round={state.roundIndex + 1}
+                  // NOTE: this is a hack to show "∞" when current round is higher than expected
+                  round={state.roundIndex + 1 > 9 ? -1 : state.roundIndex + 1}
                   roundToWin={roundToWin}
                 />
               </div>

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -410,7 +410,7 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
                               download={"raw-steno.json"}
                               onClick={trackDownloadDictionary}
                             >
-                              Download a raw steno dictionary
+                              Download a dictionary to type raw steno
                             </a>{" "}
                             and set it as the highest priority dictionary in
                             Plover. When you're done playing the KAOES game,

--- a/src/pages/games/KAOES/Game.jsx
+++ b/src/pages/games/KAOES/Game.jsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import GoogleAnalytics from "react-ga4";
 import ReactModal from "react-modal";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import * as Confetti from "../../../utils/confetti.js";
@@ -22,10 +23,6 @@ import { ReactComponent as MischievousRobot } from "../../../images/MischievousR
 import { choosePuzzleKey, prettyKey } from "./utilities";
 import * as stroke from "../../../utils/stroke";
 import { mapQWERTYKeysToStenoStroke } from "../../../utils/typey-type";
-import OutboundLink from "../../../components/OutboundLink";
-import { IconExternal } from "../../../components/IconExternal";
-import { Tooltip } from "react-tippy";
-import useAnnounceTooltip from "../../../components/Announcer/useAnnounceTooltip";
 
 const stenoTypedTextToKeysMapping = {
   "-Z": stroke.Z,
@@ -88,8 +85,6 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
   const canvasRef = useRef(null);
   const canvasWidth = Math.floor(window.innerWidth);
   const canvasHeight = Math.floor(window.innerHeight);
-
-  const announceTooltip = useAnnounceTooltip();
 
   const [previousCompletedPhraseAsTyped, setPreviousCompletedPhraseAsTyped] =
     useState("");
@@ -195,6 +190,14 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
     }
     setPreviousStenoStroke(tmpBoard.set(comparableTypedKeyNumber));
     dispatch({ type: actions.makeGuess });
+  };
+
+  const trackDownloadDictionary = () => {
+    GoogleAnalytics.event({
+      category: "Downloads",
+      action: "Click",
+      label: "Raw steno dictionary",
+    });
   };
 
   return (
@@ -391,37 +394,16 @@ export default function Game({ changeInputForKAOES, inputForKAOES }) {
                         </p>
                         <ol>
                           <li>
-                            Download{" "}
-                            <OutboundLink
-                              className="no-underline"
-                              eventLabel="a raw steno dictionary (external link opens in new tab)"
-                              aria-label="a raw steno dictionary (external link opens in new tab)"
-                              to="https://github.com/didoesdigital/steno-dictionaries?tab=readme-ov-file#raw-steno-dictionary"
+                            <a
+                              href={
+                                process.env.PUBLIC_URL +
+                                "/dictionaries/didoesdigital/raw-steno.json"
+                              }
+                              download={"raw-steno.json"}
+                              onClick={trackDownloadDictionary}
                             >
-                              a raw steno dictionary
-                              {/* @ts-ignore */}
-                              <Tooltip
-                                title="(external link opens in new tab)"
-                                animation="shift"
-                                arrow="true"
-                                className=""
-                                duration="200"
-                                tabIndex="0"
-                                tag="span"
-                                theme="didoesdigital"
-                                trigger="mouseenter focus click"
-                                onShow={announceTooltip}
-                              >
-                                <IconExternal
-                                  ariaHidden="true"
-                                  role="presentation"
-                                  iconWidth="24"
-                                  iconHeight="24"
-                                  className="ml1 svg-icon-wrapper svg-baseline"
-                                  iconTitle=""
-                                />
-                              </Tooltip>
-                            </OutboundLink>{" "}
+                              Download a raw steno dictionary
+                            </a>{" "}
                             and set it as the highest priority dictionary in
                             Plover. When you're done playing the KAOES game,
                             disable the raw steno dictionary.

--- a/src/pages/games/KAOES/gameReducer.js
+++ b/src/pages/games/KAOES/gameReducer.js
@@ -1,6 +1,9 @@
+import isNormalInteger from "../../../utils/isNormalInteger";
 import { actions } from "../utilities/gameActions";
 
 export const roundToWin = 8;
+
+const roundToWinStorageKey = "typey-KAOES-rounds";
 
 const defaultState = {
   firstGuess: true,
@@ -14,6 +17,22 @@ export const initConfig = (state) => ({
 });
 
 export const gameReducer = (state, action) => {
+  let experimentalRoundToWin = roundToWin;
+
+  try {
+    let storageRounds =
+      window.localStorage.getItem(roundToWinStorageKey) ?? "0";
+    if (
+      isNormalInteger(storageRounds) &&
+      +storageRounds > 1 &&
+      +storageRounds < 10000
+    ) {
+      experimentalRoundToWin = +storageRounds;
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
   switch (action?.type) {
     case actions.makeGuess:
       return {
@@ -21,7 +40,7 @@ export const gameReducer = (state, action) => {
         firstGuess: false,
       };
     case actions.roundCompleted:
-      return state.roundIndex + 1 === roundToWin
+      return state.roundIndex + 1 === experimentalRoundToWin
         ? {
             ...state,
             gameComplete: true,

--- a/src/pages/games/components/GameProgress.tsx
+++ b/src/pages/games/components/GameProgress.tsx
@@ -20,14 +20,14 @@ const Round: FC<RoundProps> = ({ round, roundToWin }) => (
 );
 
 type LevelProps = {
-  level: number;
-  levelToWin: number;
+  level?: number;
+  levelToWin?: number;
 };
 
 const Level: FC<LevelProps> = ({ level, levelToWin }) => {
   return level ? (
     <>
-      Level: <strong>{level || 1}</strong> of {levelToWin}
+      Level: <strong>{level || 1}</strong> of {levelToWin || 1}
     </>
   ) : null;
 };
@@ -35,8 +35,8 @@ const Level: FC<LevelProps> = ({ level, levelToWin }) => {
 type Props = {
   round: number;
   roundToWin: number;
-  level: number;
-  levelToWin: number;
+  level?: number;
+  levelToWin?: number;
 };
 
 const GameProgress: FC<Props> = ({ level, levelToWin, round, roundToWin }) => (

--- a/src/pages/games/components/GameProgress.tsx
+++ b/src/pages/games/components/GameProgress.tsx
@@ -11,7 +11,7 @@ const Round: FC<RoundProps> = ({ round, roundToWin }) => (
     Round:{" "}
     <TransitionGroup className={"dib"} component={"span"} key={round}>
       <CSSTransition timeout={500} classNames="bloop" appear={true}>
-        <strong className="dib">{round}</strong>
+        <strong className="dib">{round < 1 ? "∞" : round}</strong>
       </CSSTransition>
     </TransitionGroup>{" "}
     of {roundToWin}


### PR DESCRIPTION
This PR updates KAOES game.

- The help modal recommends downloading the `raw-steno.json` dictionary to use at the top of the Plover dictionary stack.
- KAOES now clears the input when ` *` is typed with a star in raw steno mode
- As an experiment, when local storage has a number between 1 and 10000 for the key `typey-KAOES-rounds`, the KAOES game uses that number for the number of rounds in order to win. Where there are over 10 rounds, it shows ∞. This is a hack. If we decide to make the number of KAOES rounds editable in the UI, we should properly handle displaying 10+ rounds without awkward wrapping and remove ∞.

<img width="1119" alt="The KAOES game with ∞ of 8 rounds" src="https://github.com/user-attachments/assets/78f5a4dc-02aa-40b7-9435-da0b21722ba1">
