### PR TITLE
Improve emoji results in lookup

### DIFF
--- a/src/utils/lookupListOfStrokesAndDicts.ts
+++ b/src/utils/lookupListOfStrokesAndDicts.ts
@@ -10,6 +10,14 @@ import type {
   StrokeAndDictionaryAndNamespace,
 } from "../types";
 
+function hasEmojiVariantSelector(lookupText: string) {
+  const trimmedLookupText = lookupText.trim();
+
+  return (
+    trimmedLookupText.endsWith("\ufe0e") || trimmedLookupText.endsWith("\ufe0f")
+  );
+}
+
 function lookupListOfStrokesAndDicts(
   phrase: string,
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig,
@@ -138,6 +146,23 @@ function lookupListOfStrokesAndDicts(
     listOfStrokesAndDicts = listOfStrokesAndDicts.concat(
       listOfStrokesAndDictsWithSuppressedSpaces
     );
+  }
+
+  if (
+    listOfStrokesAndDicts.length === 0 &&
+    hasEmojiVariantSelector(lookupText)
+  ) {
+    modifiedWordOrPhrase = lookupText.trim().replace(/(\ufe0e|\ufe0f)$/, "");
+
+    if (modifiedWordOrPhrase !== lookupText) {
+      let listOfStrokesAndDictsWithSuppressedSpaces = createListOfStrokes(
+        modifiedWordOrPhrase,
+        globalLookupDictionary
+      );
+      listOfStrokesAndDicts = listOfStrokesAndDicts.concat(
+        listOfStrokesAndDictsWithSuppressedSpaces
+      );
+    }
   }
 
   listOfStrokesAndDicts = rankOutlines(


### PR DESCRIPTION
This PR improves the lookup search results when searching for emoji that use variant selectors.

Previously, when using a custom emoji dictionary containing an emoji without variant selectors, searching for that emoji *with* a variant selector in the Lookup would show "no results". For example, searching for [`☔️`](https://text.makeup/#%E2%98%94%EF%B8%8F) with only a dictionary entry of `"PHOEPBLG/UPL/PWREL/HRA": "☔",` would show no results:

TODO: add `typey-type-umbrella-with-variant-selector-no-results-found.png` when on stable Internet connection.

Now, it will show the modified lookup phrase text and the nearest matching dictionary entry:

TODO: add `typey-type-umbrella-with-variant-selector-with-modified-result.png` when on stable connection.

While searching for an emoji without the variant selector (both before and after this PR's change), such as [☔](https://text.makeup/#%E2%98%94), would show the direct dictionary entry match:

TODO: add `typey-type-umbrella-without-variant-selector-with-unmodified-result.png` when on stable connection.