### PR TITLE
Preserve user setting sort order on custom lessons

### DIFF
--- a/src/pages/lessons/LessonsIndex.tsx
+++ b/src/pages/lessons/LessonsIndex.tsx
@@ -37,7 +37,7 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
         <div className="flex flex-wrap mxn2">
           {customLesson.title !== "Steno" ? (
             <Link
-              to={`${url}/custom?study=discover&newWords=1&seenWords=1&retainedWords=1&sortOrder=sortOff&startFromWord=1`.replace(
+              to={`${url}/custom?study=discover&newWords=1&seenWords=1&retainedWords=1&startFromWord=1`.replace(
                 /\/{2,}/g,
                 "/"
               )}

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -299,7 +299,7 @@ const CustomLessonGenerator = ({
                         Build lesson
                       </button>
                       <Link
-                        to="/lessons/custom?study=practice&newWords=1&seenWords=1&retainedWords=1&sortOrder=sortOff&startFromWord=1"
+                        to="/lessons/custom?study=practice&newWords=1&seenWords=1&retainedWords=1&startFromWord=1"
                         className="link-button dib button button--secondary"
                         style={{ lineHeight: 2 }}
                       >

--- a/src/pages/lessons/custom/components/CustomLessonIntro.tsx
+++ b/src/pages/lessons/custom/components/CustomLessonIntro.tsx
@@ -112,7 +112,7 @@ examples.	KP-PLS TP-PL"
                 </button>
               ) : (
                 <Link
-                  to="/lessons/custom?study=practice&newWords=1&seenWords=1&retainedWords=1&sortOrder=sortOff&startFromWord=1"
+                  to="/lessons/custom?study=practice&newWords=1&seenWords=1&retainedWords=1&startFromWord=1"
                   className="link-button dib text-right"
                   style={{ lineHeight: 2 }}
                 >


### PR DESCRIPTION
Someone shared feedback through a Google form that they want their custom lessons to always use the "Random" sort order. Previously, all of the link buttons that started a new custom lesson included a parameter to set the sort order to "Lesson default". This PR removes that parameter in order to respect the user setting.

Previously, the intent of using a parameter for "lesson default" sort order on custom lessons was so that custom lesson material was always precisely what the student provided. This has been particularly useful to prevent people being surprised by the order when creating a custom lesson. Unfortunately, that meant if a student *wanted* a specific order setting, they would have to reset it *every* time they created a custom lesson.

There's a chance this PR's change will cause some people to be annoyed that they created a custom lesson and then the material is "not in the correct order". In that scenario, they can change the sort order to "Lesson default" just *once* and it will be remembered for so long as they don't change their settings or follow a recommended lesson that comes with specific settings. If it turns out many people are bothered by this change, we can explore other options then.