### PR TITLE
Removes redundant handleStopLesson method from App.js.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,11 +110,6 @@ class App extends Component {
     this.setPersonalPreferences();
   }
 
-  handleStopLesson(event) {
-    event.preventDefault();
-    this.stopLesson();
-  }
-
   stopLesson() {
     this.stopTimer();
 
@@ -980,7 +975,6 @@ class App extends Component {
               changeShowStrokesInLesson: changeShowStrokesInLesson.bind(this),
               createCustomLesson: this.createCustomLesson.bind(this),
               handleLesson: this.handleLesson.bind(this),
-              handleStopLesson: this.handleStopLesson.bind(this),
               restartLesson: this.restartLesson.bind(this),
               reviseLesson: this.reviseLesson.bind(this),
               sayCurrentPhraseAgain: this.sayCurrentPhraseAgain.bind(this),

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -85,7 +85,6 @@ const Lesson = ({
     appFetchAndSetupGlobalDict,
     customiseLesson,
     handleLesson,
-    handleStopLesson,
     changeShowStrokesInLesson,
     restartLesson,
     reviseLesson,
@@ -370,7 +369,7 @@ const Lesson = ({
           <main id="main">
             <LessonSubheader
               createNewCustomLesson={createNewCustomLesson}
-              handleStopLesson={handleStopLesson}
+              stopLesson={stopLesson}
               lessonSubTitle={lessonSubTitle}
               lessonTitle={lessonTitle}
               overviewLink={overviewLink}
@@ -476,7 +475,7 @@ const Lesson = ({
                 disableUserSettings={disableUserSettings}
                 globalLookupDictionary={globalLookupDictionary}
                 globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-                handleStopLesson={handleStopLesson}
+                stopLesson={stopLesson}
                 toggleHideOtherSettings={toggleHideOtherSettings}
                 lesson={lesson}
                 lessonLength={lessonLength}

--- a/src/pages/lessons/MainLessonView.stories.tsx
+++ b/src/pages/lessons/MainLessonView.stories.tsx
@@ -103,7 +103,7 @@ const Template = (args: any) => {
               totalNumberOfMistypedWords={0}
               totalNumberOfHintedWords={0}
               restartLesson={() => undefined}
-              handleStopLesson={() => undefined}
+              stopLesson={() => undefined}
               changeShowStrokesAsList={() => undefined}
               changeShowStrokesInLesson={() => undefined}
               changeShowStrokesOnMisstroke={() => undefined}

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -51,7 +51,7 @@ type Props = {
   disableUserSettings: boolean;
   globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
   globalLookupDictionaryLoaded: boolean;
-  handleStopLesson: () => void;
+  stopLesson: () => void;
   toggleHideOtherSettings: () => void;
   lesson: Lesson;
   lessonLength: number;
@@ -93,7 +93,7 @@ const MainLessonView = ({
   disableUserSettings,
   globalLookupDictionary,
   globalLookupDictionaryLoaded,
-  handleStopLesson,
+  stopLesson,
   toggleHideOtherSettings,
   lesson,
   lessonLength,
@@ -150,7 +150,7 @@ const MainLessonView = ({
       <main id="main">
         <LessonSubheader
           createNewCustomLesson={createNewCustomLesson}
-          handleStopLesson={handleStopLesson}
+          stopLesson={stopLesson}
           lessonSubTitle={lessonSubTitle}
           lessonTitle={lessonTitle}
           overviewLink={overviewLink}

--- a/src/pages/lessons/components/LessonSubheader.tsx
+++ b/src/pages/lessons/components/LessonSubheader.tsx
@@ -4,7 +4,7 @@ import Subheader from "../../../components/Subheader";
 
 type LessonSubheaderProps = {
   createNewCustomLesson: JSX.Element | undefined;
-  handleStopLesson: () => void;
+  stopLesson: () => void;
   lessonSubTitle: any;
   lessonTitle: any;
   overviewLink: JSX.Element | undefined;
@@ -16,7 +16,7 @@ const LessonSubheader = React.forwardRef(
   (
     {
       createNewCustomLesson,
-      handleStopLesson,
+      stopLesson,
       lessonSubTitle,
       lessonTitle,
       overviewLink,
@@ -66,7 +66,10 @@ const LessonSubheader = React.forwardRef(
           </a>
           <a
             href={path}
-            onClick={handleStopLesson}
+            onClick={(evt) => {
+              evt.preventDefault();
+              stopLesson()
+            }}
             className="button button--secondary table-cell mr2"
             style={{ lineHeight: 2 }}
             role="button"

--- a/src/states/legacy/AppMethodsContext.tsx
+++ b/src/states/legacy/AppMethodsContext.tsx
@@ -19,7 +19,6 @@ export type AppMethods = {
   changeShowStrokesInLesson: typeof changeShowStrokesInLesson,
   createCustomLesson: typeof App.prototype.createCustomLesson,
   handleLesson: typeof App.prototype.handleLesson,
-  handleStopLesson: typeof App.prototype.handleStopLesson,
   restartLesson: typeof App.prototype.restartLesson,
   reviseLesson: typeof App.prototype.reviseLesson,
   sayCurrentPhraseAgain: typeof App.prototype.sayCurrentPhraseAgain,

--- a/src/stories/fixtures/appMethods.ts
+++ b/src/stories/fixtures/appMethods.ts
@@ -7,7 +7,6 @@ const appMethods: AppMethods = {
   customiseLesson: () => undefined,
   generateCustomLesson: () => console.log("generate custom lesson"),
   handleLesson: () => undefined,
-  handleStopLesson: () => undefined,
   restartLesson: () => undefined,
   reviseLesson: () => undefined,
   sayCurrentPhraseAgain: () => undefined,


### PR DESCRIPTION
A small change towards resolving #168 

* src/App.js:
  - removes the handleStopLesson method
  - removes it from the context
* src/pages/lessons/Lesson.tsx:
   - removes handleStopLesson from props
   - passes stopLesson to LessonSubheader and MainLessonView instead of handleStopLesson
* src/pages/lessons/{Lesson,LessonSubheader,MainLessonView + stories}.tsx:
   - replaces prop handleStopLesson with stopLesson
* src/pages/lessons/components/LessonSubheader.tsx:
  - button onClick handler calls stopLesson after event.preventDefault()