### PR TITLE
stenohintsonthefly prop is not necessary as it is now now in a jotai state defined in globalUserSettingsState

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -964,8 +964,6 @@ class App extends Component {
       };
     }
 
-    let stenohintsonthefly = this.props.globalUserSettings?.experiments && !!this.props.globalUserSettings?.experiments?.stenohintsonthefly;
-
     let presentedMaterialCurrentItem = (stateLesson.presentedMaterial && stateLesson.presentedMaterial[this.state.currentPhraseID]) ? stateLesson.presentedMaterial[this.state.currentPhraseID] : { phrase: '', stroke: '' };
     return (
       <div id="js-app" className="app">
@@ -1003,7 +1001,6 @@ class App extends Component {
                 completedMaterial,
                 presentedMaterialCurrentItem,
                 stateLesson,
-                stenohintsonthefly,
                 upcomingMaterial
               }}
               appState={this.state}

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -10,7 +10,6 @@ import Footer from "./components/Footer";
 import AnnouncerController from "./components/Announcer/AnnouncerController";
 import Announcer from "./components/Announcer/Announcer";
 import {
-  Experiments,
   MaterialItem,
   MaterialText,
   Lesson,

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -157,7 +157,6 @@ type AppProps = {
   completedMaterial: MaterialText[];
   presentedMaterialCurrentItem: MaterialItem;
   stateLesson: Lesson;
-  stenohintsonthefly: Pick<Experiments, "stenohintsonthefly">;
   upcomingMaterial: unknown;
 };
 
@@ -291,7 +290,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
                     lessonpath="flashcards"
                     locationpathname={appProps.location.pathname}
                     personalDictionaries={appState.personalDictionaries}
-                    stenoHintsOnTheFly={appProps.stenohintsonthefly}
                   />
                 </DocumentTitle>
               </div>
@@ -330,7 +328,6 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
                         appState.globalLookupDictionaryLoaded
                       }
                       personalDictionaries={appState.personalDictionaries}
-                      stenohintsonthefly={appProps.stenohintsonthefly}
                       {...props}
                     />
                   </ErrorBoundary>


### PR DESCRIPTION
AppRoutes.tsx
   - removes own prop stenohintsonthefly
   - removes unused import
   
App.js, AppRoutes.tsx 
   - does not pass down prop stenohintsonthefly


tests are passing.