### PR TITLE
Add support for multiple Typey Type dictionaries

### DIFF
--- a/src/pages/writer/Writer.tsx
+++ b/src/pages/writer/Writer.tsx
@@ -24,10 +24,9 @@ import mapBriefToItalianMichelaStenoKeys from '../../utils/stenoLayouts/mapBrief
 import mapBriefToJapaneseStenoKeys from '../../utils/stenoLayouts/mapBriefToJapaneseStenoKeys';
 import mapBriefToKoreanModernCStenoKeys from '../../utils/stenoLayouts/mapBriefToKoreanModernCStenoKeys';
 import mapBriefToPalantypeKeys from '../../utils/stenoLayouts/mapBriefToPalantypeKeys';
-import { fetchResource } from '../../utils/getData';
+import fetchResource from 'utils/getData/fetchResource';
 import Subheader from "../../components/Subheader";
 
-import type { GlobalUserSettings, Outline, UserSettings } from "../../types";
 import { WithAppMethods, withAppMethods } from "../../states/legacy/AppMethodsContext";
 import { userSettingsState } from "../../states/userSettingsState";
 import { withAtomsCompat } from "../../states/atomUtils";
@@ -35,6 +34,8 @@ import { useChangeStenoLayout } from "../lessons/components/UserSettings/updateU
 import { globalUserSettingsState } from "../../states/globalUserSettingsState";
 import { useChangeWriterInput } from "../lessons/components/UserSettings/updateGlobalUserSetting";
 import LATEST_TYPEY_TYPE_DICT_NAME from 'constant/latestTypeyTypeDictName';
+
+import type { StenoDictionary, GlobalUserSettings, Outline, UserSettings } from "../../types";
 
 type Props = {
   userSettings: UserSettings,
@@ -122,7 +123,7 @@ class Writer extends Component<WithAppMethods<Props & {changeStenoLayout: Return
 
   componentDidMount() {
     let dict:string = '' + (process.env.PUBLIC_URL || '') + `/dictionaries/typey-type/${LATEST_TYPEY_TYPE_DICT_NAME}`;
-    fetchResource(dict)
+    fetchResource<StenoDictionary>(dict)
       .then((json) => {
         this.setState({
           stenoDictionary: json

--- a/src/pages/writer/Writer.tsx
+++ b/src/pages/writer/Writer.tsx
@@ -34,6 +34,7 @@ import { withAtomsCompat } from "../../states/atomUtils";
 import { useChangeStenoLayout } from "../lessons/components/UserSettings/updateUserSetting";
 import { globalUserSettingsState } from "../../states/globalUserSettingsState";
 import { useChangeWriterInput } from "../lessons/components/UserSettings/updateGlobalUserSetting";
+import LATEST_TYPEY_TYPE_DICT_NAME from 'constant/latestTypeyTypeDictName';
 
 type Props = {
   userSettings: UserSettings,
@@ -120,7 +121,7 @@ class Writer extends Component<WithAppMethods<Props & {changeStenoLayout: Return
   }
 
   componentDidMount() {
-    let dict:string = '' + (process.env.PUBLIC_URL || '') + '/dictionaries/typey-type/typey-type.json';
+    let dict:string = '' + (process.env.PUBLIC_URL || '') + `/dictionaries/typey-type/${LATEST_TYPEY_TYPE_DICT_NAME}`;
     fetchResource(dict)
       .then((json) => {
         this.setState({

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,20 @@ export type StenoDictionary = {
   [outline: Outline]: Translation;
 };
 
+/** e.g. [{"KR-S": "css", "KR*S": "CSS"}, "css.json"] */
+export type ReadDictionaryData = [StenoDictionary, DictName];
+
+/**
+ * The data read from files for multiple dictionaries including their
+ * StenoDictionary content and DictName:
+ *
+ * e.g. [
+ *   [{"A": "{&A}", "KR-S": "C"}, "letters.json"],
+ *   [{"KR-S": "css", "KR*S": "CSS"}, "css.json"]
+ * ]
+ **/
+export type ReadDictionariesData = ReadDictionaryData[];
+
 /**
  * Examples:
  * ["typey:typey-type.json", "user:nouns.json", "user:personal.json"]

--- a/src/utils/app/fetchAndSetupGlobalDict.ts
+++ b/src/utils/app/fetchAndSetupGlobalDict.ts
@@ -1,8 +1,9 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
 import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
-import { getLatestPloverDict, getTypeyTypeDict } from "../getData";
-import createAGlobalLookupDictionary from "../transformingDictionaries/createAGlobalLookupDictionary";
+import { getLatestPloverDict } from "../getData";
+import getTypeyTypeDict from "../getData/getTypeyTypeDicts";
+import { createGlobalLookupDictionary } from "../transformingDictionaries/createAGlobalLookupDictionary";
 import { AffixList } from "../affixList";
 import { loadPersonalDictionariesFromLocalStorage } from "../typey-type";
 
@@ -96,15 +97,16 @@ function fetchAndSetupGlobalDict(
       getTypeyTypeDict(),
       withPlover ? getLatestPloverDict() : {},
     ]).then((data) => {
-      let [typeyDict, latestPloverDict] = data;
+      let [typeyDictionaries, latestPloverDict] = data;
+
       // let t0 = performance.now();
       // if (this.state.globalUserSettings && this.state.globalUserSettings.showMisstrokesInLookup) {
       //   dictAndMisstrokes[1] = {};
       // }
 
-      let sortedAndCombinedLookupDictionary = createAGlobalLookupDictionary(
+      let sortedAndCombinedLookupDictionary = createGlobalLookupDictionary(
         personalDictionaries,
-        typeyDict,
+        typeyDictionaries,
         withPlover ? latestPloverDict : null
       );
       // let t1 = performance.now();

--- a/src/utils/app/fetchAndSetupGlobalDict.ts
+++ b/src/utils/app/fetchAndSetupGlobalDict.ts
@@ -1,4 +1,5 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
+import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
 import { getLatestPloverDict, getTypeyTypeDict } from "../getData";
 import createAGlobalLookupDictionary from "../transformingDictionaries/createAGlobalLookupDictionary";
@@ -37,7 +38,7 @@ function fetchAndSetupGlobalDict(
   // personal dictionary usage…
   let localConfigPlusTypeyType = localConfig.slice(0);
   localConfigPlusTypeyType.unshift(
-    `${SOURCE_NAMESPACES.get("typey")}:typey-type.json`
+    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`
   );
   const previouslyAppliedConfig =
     // @ts-ignore TODO

--- a/src/utils/app/fetchAndSetupGlobalDict.ts
+++ b/src/utils/app/fetchAndSetupGlobalDict.ts
@@ -1,8 +1,9 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
-import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
 import { getLatestPloverDict } from "../getData";
-import getTypeyTypeDict from "../getData/getTypeyTypeDicts";
+import getTypeyTypeDict, {
+  allTypeyTypeDictNames,
+} from "../getData/getTypeyTypeDicts";
 import { createGlobalLookupDictionary } from "../transformingDictionaries/createAGlobalLookupDictionary";
 import { AffixList } from "../affixList";
 import { loadPersonalDictionariesFromLocalStorage } from "../typey-type";
@@ -39,7 +40,9 @@ function fetchAndSetupGlobalDict(
   // personal dictionary usage…
   let localConfigPlusTypeyType = localConfig.slice(0);
   localConfigPlusTypeyType.unshift(
-    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`
+    ...allTypeyTypeDictNames.map(
+      (typeyDict) => `${SOURCE_NAMESPACES.get("typey")}:${typeyDict}`
+    )
   );
   const previouslyAppliedConfig =
     // @ts-ignore TODO

--- a/src/utils/getData.js
+++ b/src/utils/getData.js
@@ -1,3 +1,5 @@
+import fetchResource from "utils/getData/fetchResource";
+
 let latestPloverDict = null;
 
 function fetchLatestPloverDict() {
@@ -71,7 +73,7 @@ function fetchDictionaryIndex() {
 }
 
 // for custom lesson setup
-function fetchResource(resource = process.env.PUBLIC_URL + '/dictionaries/typey-type/typey-type.json') {
+function DEPRECATED_fetchResource(resource = process.env.PUBLIC_URL + '/dictionaries/typey-type/typey-type.json') {
   return fetch(resource, {
     method: "GET",
     credentials: "same-origin"
@@ -84,7 +86,7 @@ function fetchResource(resource = process.env.PUBLIC_URL + '/dictionaries/typey-
 
 export {
   fetchDictionaryIndex,
-  fetchResource, // for custom lesson setup and more
+  DEPRECATED_fetchResource, // for custom lesson setup and more
   getLesson,
   getLatestPloverDict,
 };

--- a/src/utils/getData.js
+++ b/src/utils/getData.js
@@ -1,4 +1,3 @@
-let dictTypeyType = null;
 let latestPloverDict = null;
 
 function fetchLatestPloverDict() {
@@ -6,57 +5,6 @@ function fetchLatestPloverDict() {
     return json;
   }).catch(function(e) {
     return {};
-  });
-}
-
-function fetchDictTypeyType() {
-  return fetchResource(process.env.PUBLIC_URL + '/dictionaries/typey-type/typey-type.json').then((json) => {
-    return json;
-  }).catch(function(e) {
-    return {
-      "-T": "The",
-      "PROEUS": "process",
-      "-F": "of",
-      "WREUG": "writing",
-      "SHORT/HA*PBD": "shorthand",
-      "S": "is",
-      "KAULD": "called",
-      "STEPB/TKPWRAEF TP-PL": "stenography.",
-      "T-S": "It's",
-      "TAOEUPD": "typed",
-      "WA*EU": "with a",
-      "STEPB/TAOEUP": "stenotype",
-      "OR": "or",
-      "TPAPB/SEU": "fancy",
-      "KAOEBD TP-PL": "keyboard.",
-      "KU": "You can",
-      "TREUB KW-BG": "transcribe,",
-      "KAPGS KW-BG": "caption,",
-      "TKEUBG/TAEUT KW-BG": "dictate,",
-      "KOED KW-BG": "code,",
-      "KHAT KW-BG": "chat,",
-      "WREU": "write",
-      "PROES": "prose",
-      "AT": "at",
-      "OEFR": "over",
-      "#T-Z": "200",
-      "WORDZ": "words",
-      "PER": "per",
-      "PHEUPB TP-PL": "minute.",
-      "TAOEUP/KWREU TAOEUP": "Typey type",
-      "AOUFS": "uses",
-      "SPAEUFD": "spaced",
-      "REP/TEUGS/-S": "repetitions",
-      "SKP": "and",
-      "HUPBS": "hundreds",
-      "HROEFPBS": "lessons",
-      "TO": "to",
-      "HEP": "help",
-      "U": "you",
-      "PHAFRT": "master",
-      "TAOEUPG": "typing",
-      "W": "with",
-    };
   });
 }
 
@@ -71,22 +19,6 @@ function getLatestPloverDict() {
   }
   else {
     dict = Promise.resolve(latestPloverDict);
-  }
-
-  return dict;
-}
-
-function getTypeyTypeDict() {
-  let dict;
-
-  if (dictTypeyType === null) {
-    dict = fetchDictTypeyType().then(data => {
-      dictTypeyType = data;
-      return data;
-    });
-  }
-  else {
-    dict = Promise.resolve(dictTypeyType);
   }
 
   return dict;
@@ -155,5 +87,4 @@ export {
   fetchResource, // for custom lesson setup and more
   getLesson,
   getLatestPloverDict,
-  getTypeyTypeDict
 };

--- a/src/utils/getData.js
+++ b/src/utils/getData.js
@@ -72,21 +72,8 @@ function fetchDictionaryIndex() {
   });
 }
 
-// for custom lesson setup
-function DEPRECATED_fetchResource(resource = process.env.PUBLIC_URL + '/dictionaries/typey-type/typey-type.json') {
-  return fetch(resource, {
-    method: "GET",
-    credentials: "same-origin"
-  }).then((response) => {
-    return response.json()
-  }).then(json => {
-    return(json);
-  });
-}
-
 export {
   fetchDictionaryIndex,
-  DEPRECATED_fetchResource, // for custom lesson setup and more
   getLesson,
   getLatestPloverDict,
 };

--- a/src/utils/getData/fetchDictionaries.ts
+++ b/src/utils/getData/fetchDictionaries.ts
@@ -1,0 +1,60 @@
+import fetchResource from "./fetchResource";
+
+import type { StenoDictionary } from "types";
+
+const fallbackDictionary: StenoDictionary = {
+  "-T": "The",
+  "PROEUS": "process",
+  "-F": "of",
+  "WREUG": "writing",
+  "SHORT/HA*PBD": "shorthand",
+  "S": "is",
+  "KAULD": "called",
+  "STEPB/TKPWRAEF TP-PL": "stenography.",
+  "T-S": "It's",
+  "TAOEUPD": "typed",
+  "WA*EU": "with a",
+  "STEPB/TAOEUP": "stenotype",
+  "OR": "or",
+  "TPAPB/SEU": "fancy",
+  "KAOEBD TP-PL": "keyboard.",
+  "KU": "You can",
+  "TREUB KW-BG": "transcribe,",
+  "KAPGS KW-BG": "caption,",
+  "TKEUBG/TAEUT KW-BG": "dictate,",
+  "KOED KW-BG": "code,",
+  "KHAT KW-BG": "chat,",
+  "WREU": "write",
+  "PROES": "prose",
+  "AT": "at",
+  "OEFR": "over",
+  "#T-Z": "200",
+  "WORDZ": "words",
+  "PER": "per",
+  "PHEUPB TP-PL": "minute.",
+  "TAOEUP/KWREU TAOEUP": "Typey type",
+  "AOUFS": "uses",
+  "SPAEUFD": "spaced",
+  "REP/TEUGS/-S": "repetitions",
+  "SKP": "and",
+  "HUPBS": "hundreds",
+  "HROEFPBS": "lessons",
+  "TO": "to",
+  "HEP": "help",
+  "U": "you",
+  "PHAFRT": "master",
+  "TAOEUPG": "typing",
+  "W": "with",
+};
+
+function fetchDictionaries(urls: string[]): Promise<StenoDictionary[]> {
+  const promises = urls.map((url) => fetchResource<StenoDictionary>(url));
+  const result = Promise.all(promises).catch((error) => {
+    console.error("Error fetching dictionaries:", error);
+    return [fallbackDictionary];
+  });
+
+  return result;
+}
+
+export default fetchDictionaries;

--- a/src/utils/getData/fetchResource.ts
+++ b/src/utils/getData/fetchResource.ts
@@ -1,0 +1,19 @@
+function fetchResource<T>(url: string): Promise<T> {
+  return fetch(url, {
+    method: "GET",
+    credentials: "same-origin",
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP status: ${response.status}`);
+      }
+
+      return response.json() as Promise<T>;
+    })
+    .catch((error) => {
+      console.error(`Error fetching resource from ${url}:`, error);
+      throw error;
+    });
+}
+
+export default fetchResource;

--- a/src/utils/getData/getTypeyTypeDicts.ts
+++ b/src/utils/getData/getTypeyTypeDicts.ts
@@ -5,7 +5,7 @@ import type { ReadDictionariesData, ReadDictionaryData } from "types";
 
 let allDicts: null | ReadDictionariesData = null;
 
-const allTypeyTypeDictNames = [LATEST_TYPEY_TYPE_DICT_NAME];
+export const allTypeyTypeDictNames = [LATEST_TYPEY_TYPE_DICT_NAME];
 const typeyDictionariesSubDir = "dictionaries/typey-type";
 
 const allTypeyTypeDictURLs = allTypeyTypeDictNames.map(

--- a/src/utils/getData/getTypeyTypeDicts.ts
+++ b/src/utils/getData/getTypeyTypeDicts.ts
@@ -1,0 +1,36 @@
+import LATEST_TYPEY_TYPE_DICT_NAME from "constant/latestTypeyTypeDictName";
+import fetchDictionaries from "./fetchDictionaries";
+
+import type { ReadDictionariesData, ReadDictionaryData } from "types";
+
+let allDicts: null | ReadDictionariesData = null;
+
+const allTypeyTypeDictNames = [LATEST_TYPEY_TYPE_DICT_NAME];
+const typeyDictionariesSubDir = "dictionaries/typey-type";
+
+const allTypeyTypeDictURLs = allTypeyTypeDictNames.map(
+  (filename) =>
+    `${process.env.PUBLIC_URL}/${typeyDictionariesSubDir}/${filename}`
+);
+
+function getTypeyTypeDicts() {
+  let dict;
+
+  if (allDicts === null) {
+    dict = fetchDictionaries(allTypeyTypeDictURLs).then((data) => {
+      const zippedData = data.map((dict, i) => {
+        const result: ReadDictionaryData = [dict, allTypeyTypeDictNames[i]];
+        return result;
+      });
+
+      allDicts = zippedData;
+      return zippedData;
+    });
+  } else {
+    dict = Promise.resolve(allDicts);
+  }
+
+  return dict;
+}
+
+export default getTypeyTypeDicts;

--- a/src/utils/transformingDictionaries/combineValidDictionaries.test.ts
+++ b/src/utils/transformingDictionaries/combineValidDictionaries.test.ts
@@ -160,7 +160,7 @@ describe("combining valid dictionaries without sorting", () => {
     expect(
       combineValidDictionaries(
         personalDictionaries,
-        testTypeyTypeDict,
+        [[testTypeyTypeDict, "typey-type.json"]],
         testPloverDict
       )
     ).toEqual(expectedCombinedDict);
@@ -217,7 +217,9 @@ describe("combining valid dictionaries without sorting", () => {
     ]);
 
     expect(
-      combineValidDictionaries(personalDictionaries, testTypeyTypeDict)
+      combineValidDictionaries(personalDictionaries, [
+        [testTypeyTypeDict, "typey-type.json"],
+      ])
     ).toEqual(expectedCombinedDict);
   });
 });

--- a/src/utils/transformingDictionaries/combineValidDictionaries.ts
+++ b/src/utils/transformingDictionaries/combineValidDictionaries.ts
@@ -1,4 +1,5 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
+import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
 import { addOutlinesToWordsInCombinedDict } from "./transformingDictionaries";
 import {
@@ -35,7 +36,7 @@ const combineValidDictionaries = (
   [combinedLookupDictionary, _] = addOutlinesToWordsInCombinedDict(
     dictTypeyType,
     combinedLookupDictionary,
-    `${SOURCE_NAMESPACES.get("typey")}:typey-type.json`,
+    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`,
     new Set()
   );
 

--- a/src/utils/transformingDictionaries/combineValidDictionaries.ts
+++ b/src/utils/transformingDictionaries/combineValidDictionaries.ts
@@ -1,15 +1,14 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
-import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
 import { addOutlinesToWordsInCombinedDict } from "./transformingDictionaries";
 import {
   PersonalDictionaryNameAndContents,
-  StenoDictionary,
+  ReadDictionariesData,
 } from "../../types";
 
 const combineValidDictionaries = (
   personalDictionariesNamesAndContents: PersonalDictionaryNameAndContents[],
-  dictTypeyType: StenoDictionary,
+  typeyDicts: ReadDictionariesData,
   ploverDict: any = null
 ) => {
   let combinedLookupDictionary = new Map();
@@ -33,12 +32,14 @@ const combineValidDictionaries = (
   }
 
   // 2. Add Typey Type entries
-  [combinedLookupDictionary, _] = addOutlinesToWordsInCombinedDict(
-    dictTypeyType,
-    combinedLookupDictionary,
-    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`,
-    new Set()
-  );
+  typeyDicts.forEach((readDictData) => {
+    [combinedLookupDictionary, _] = addOutlinesToWordsInCombinedDict(
+      readDictData[0],
+      combinedLookupDictionary,
+      `${SOURCE_NAMESPACES.get("typey")}:${readDictData[1]}`,
+      new Set()
+    );
+  });
 
   // 3. Add Plover dictionary entries
   if (!!ploverDict) {

--- a/src/utils/transformingDictionaries/createAGlobalLookupDictionary.ts
+++ b/src/utils/transformingDictionaries/createAGlobalLookupDictionary.ts
@@ -1,4 +1,5 @@
 import LATEST_PLOVER_DICT_NAME from "../../constant/latestPloverDictName";
+import LATEST_TYPEY_TYPE_DICT_NAME from "../../constant/latestTypeyTypeDictName";
 import SOURCE_NAMESPACES from "../../constant/sourceNamespaces";
 
 import combineValidDictionaries from "./combineValidDictionaries";
@@ -34,7 +35,7 @@ const createAGlobalLookupDictionary = (
 
   // let sortedAndCombinedLookupDictionary = rankAllOutlinesInCombinedLookupDictionary(combinedLookupDictionary); // has a bug; instead of sorted entire dict, we sort per entry used within chooseOutlineForPhrase function
   let configuration = [
-    `${SOURCE_NAMESPACES.get("typey")}:typey-type.json`,
+    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`,
     ...personalDictionariesNamesAndContents.map(
       (d) => `${SOURCE_NAMESPACES.get("user")}:${d[0]}`
     ),

--- a/src/utils/transformingDictionaries/createAGlobalLookupDictionary.ts
+++ b/src/utils/transformingDictionaries/createAGlobalLookupDictionary.ts
@@ -8,6 +8,7 @@ import {
   LookupDictWithNamespacedDictsAndConfig,
   PersonalDictionaryNameAndContents,
   DictionaryConfigurationList,
+  ReadDictionariesData,
   StenoDictionary,
 } from "../../types";
 
@@ -19,9 +20,10 @@ const addConfig = (
   return dict as LookupDictWithNamespacedDictsAndConfig;
 };
 
-const createAGlobalLookupDictionary = (
+// Note: This is the new preferred method to create a global lookup dictionary
+export const createGlobalLookupDictionary = (
   personalDictionariesNamesAndContents: PersonalDictionaryNameAndContents[],
-  dictTypeyType: StenoDictionary,
+  typeyDicts: ReadDictionariesData,
   ploverDict: any = null
 ): LookupDictWithNamespacedDictsAndConfig => {
   // TODO: one day, this could be the place we check for whether Typey Type dictionaries or the Plover dictionary are enabled and if so combineValidDictionaries with them and add to 'configuration'
@@ -29,13 +31,17 @@ const createAGlobalLookupDictionary = (
   let combinedLookupDictionary: LookupDictWithNamespacedDicts =
     combineValidDictionaries(
       personalDictionariesNamesAndContents,
-      dictTypeyType,
+      typeyDicts,
       ploverDict
     );
 
+  const typeyDictsConfigEntries = typeyDicts.map(
+    (readDictData) => `${SOURCE_NAMESPACES.get("typey")}:${readDictData[1]}`
+  );
+
   // let sortedAndCombinedLookupDictionary = rankAllOutlinesInCombinedLookupDictionary(combinedLookupDictionary); // has a bug; instead of sorted entire dict, we sort per entry used within chooseOutlineForPhrase function
   let configuration = [
-    `${SOURCE_NAMESPACES.get("typey")}:${LATEST_TYPEY_TYPE_DICT_NAME}`,
+    ...typeyDictsConfigEntries,
     ...personalDictionariesNamesAndContents.map(
       (d) => `${SOURCE_NAMESPACES.get("user")}:${d[0]}`
     ),
@@ -48,6 +54,25 @@ const createAGlobalLookupDictionary = (
   }
 
   return addConfig(combinedLookupDictionary, configuration);
+};
+
+/**
+ * @deprecated This function is deprecated. Use `createGlobalLookupDictionary`
+ * without "A" instead.
+ *
+ * This deprecated function only exists so we don't have to change the
+ * structure of a hundred existing tests.
+ */
+const createAGlobalLookupDictionary = (
+  personalDictionariesNamesAndContents: PersonalDictionaryNameAndContents[],
+  typeyDicts: StenoDictionary,
+  ploverDict: any = null
+): LookupDictWithNamespacedDictsAndConfig => {
+  return createGlobalLookupDictionary(
+    personalDictionariesNamesAndContents,
+    [[typeyDicts, LATEST_TYPEY_TYPE_DICT_NAME]],
+    ploverDict
+  );
 };
 
 export default createAGlobalLookupDictionary;


### PR DESCRIPTION
This PR starts to add support for multiple Typey Type dictionaries, starting with just using the existing `typey-type.json` but in a way that could be more than 1 Typey Type dictionary. It also:

- extracts functions out of `getData.js` into separate TypeScript files
- reuses variables instead of hard-coding `typey-type.json`

This is a step towards making it possible for the Typey Type web app to directly use the dictionaries that make up `typey-type.json`, such as `dict.json`, `briefs.json`, and `top-10000-project-gutenberg-words.json`.