### PR TITLE
Add links to zero-setup demos

### DIFF
--- a/src/pages/games/KHAERT/ActionProvider.js
+++ b/src/pages/games/KHAERT/ActionProvider.js
@@ -56,7 +56,10 @@ class ActionProvider {
   handleLearningQuestions(userMessage) {
     const [linkText, linkUrl] =
       userMessage.includes("learn") || userMessage.includes("theory")
-        ? ["Learn Plover", "https://www.openstenoproject.org/learn-plover/home.html"]
+        ? [
+            "Learn Plover",
+            "https://www.openstenoproject.org/learn-plover/home.html",
+          ]
         : userMessage.includes("practice") || userMessage.includes("drill")
         ? ["Stenojig", "https://joshuagrams.github.io/steno-jig/"]
         : ["Plover Discord", "https://discord.gg/0lQde43a6dGmAMp2"];
@@ -92,6 +95,31 @@ class ActionProvider {
     this.setState((prevState) => ({
       ...prevState,
       phraseToLookup: strippedUserMessage,
+      messages: [...prevState.messages, botMessage],
+    }));
+  }
+
+  handleTrySteno() {
+    const options = [
+      ["Ploverpad", "https://stenopad.stenokeyboards.com/"],
+      [
+        "StenoKnight's Interactive Steno Demo",
+        "https://stenoknight.com/plover/ploverdemo/ploverdemo.html",
+      ],
+    ];
+    const selectedOption = Math.random() >= 0.5 ? options[0] : options[1];
+    const [linkText, linkUrl] = selectedOption;
+    const botMessage = this.createChatBotMessage(
+      `To try steno in the browser with zero setup, you could visit:`,
+      {
+        widget: "externalLink",
+      }
+    );
+
+    this.setState((prevState) => ({
+      ...prevState,
+      linkText,
+      linkUrl,
       messages: [...prevState.messages, botMessage],
     }));
   }

--- a/src/pages/games/KHAERT/ExternalLink.jsx
+++ b/src/pages/games/KHAERT/ExternalLink.jsx
@@ -17,6 +17,7 @@ const ExternalLink = ({ linkText, linkUrl }) => {
       <OutboundLink
         className="no-underline"
         eventLabel={`${text} (external link opens in new tab)`}
+        newTabAndIUnderstandTheAccessibilityImplications={true}
         to={url}
       >
         <strong>{text}</strong> (external link opens in new tab)

--- a/src/pages/games/KHAERT/MessageParser.js
+++ b/src/pages/games/KHAERT/MessageParser.js
@@ -14,6 +14,7 @@ import {
   locationQuestions,
   lookupKeywords,
   nameQuestions,
+  tryStenoKeywords,
   whatQuestions,
   whoQuestions,
 } from "./constants.js";
@@ -72,6 +73,11 @@ class MessageParser {
       messageMatchesAKeyword(lowerCaseMessage, keyboardFunctions)
     ) {
       this.actionProvider.handleHowToKeyboard(lowerCaseMessage);
+      foundSomething = true;
+    }
+
+    if (messageMatchesAKeyword(lowerCaseMessage, tryStenoKeywords)) {
+      this.actionProvider.handleTrySteno(lowerCaseMessage);
       foundSomething = true;
     }
 

--- a/src/pages/games/KHAERT/constants.js
+++ b/src/pages/games/KHAERT/constants.js
@@ -57,6 +57,22 @@ export const keyboardFunctions = [
   "undo",
 ];
 
+export const tryStenoKeywords = [
+  "try steno",
+  "test steno",
+  "give steno a", // … go/try
+  "steno demo",
+  "steno trial",
+  "steno example",
+  "zero setup",
+  "without installing",
+  "without software",
+  "without technology",
+  "without hardware",
+  "without a keyboard",
+  "without a steno machine",
+];
+
 export const lessonKeywords = [
   "lesson",
   "lessons",

--- a/src/pages/support/Support.tsx
+++ b/src/pages/support/Support.tsx
@@ -143,6 +143,55 @@ const Support = () => {
             </OutboundLink>
           </p>
 
+          <h3 id="try-steno">Try steno in the browser with zero setup</h3>
+          <p>
+            There are demos to help you try steno in the browser without
+            installing software and without a proper keyboard or steno machine.
+            Without guidance, they might still be a little confusing. When you
+            visit them, try something like pressing the keys “a” and “p” at the
+            same time on a QWERTY keyboard then let go and maybe you can enjoy
+            the magic of seeing “is the” appear! Then for a longer word word,
+            try pressing the keys “e”, “f”, and “j” together then let go to
+            watch “prerequisite” pop out!
+          </p>
+          <ul>
+            <li>
+              You can try the{" "}
+              <OutboundLink
+                eventLabel="interactive steno demo on StenoKnight Cart Services"
+                to="https://stenoknight.com/kws.html"
+              >
+                interactive steno demo on StenoKnight's site
+              </OutboundLink>
+              . This site is Mirabai Knight's, the founder of the founder of The
+              Open Steno Project and Plover. You can also go directly to the{" "}
+              <OutboundLink
+                eventLabel="standalone steno demo on StenoKnight Cart Services"
+                to="https://stenoknight.com/plover/ploverdemo/ploverdemo.html"
+              >
+                standalone steno demo
+              </OutboundLink>
+              .
+            </li>
+            <li>
+              You can read about{" "}
+              <OutboundLink
+                eventLabel="Stenopad on the StenoKeyboards blog"
+                to="https://stenokeyboards.com/blogs/posts/stenopad"
+              >
+                Stenopad on the StenoKeyboards blog
+              </OutboundLink>
+              . You can also go directly to the{" "}
+              <OutboundLink
+                eventLabel="Stenopad"
+                to="https://stenopad.stenokeyboards.com/"
+              >
+                Stenopad
+              </OutboundLink>{" "}
+              demo to try out steno.
+            </li>
+          </ul>
+
           <h3 id="steno-terms">Steno terms</h3>
           <DescriptionList>
             <DescriptionTerm>Briefs</DescriptionTerm>
@@ -462,7 +511,9 @@ const Support = () => {
           </p>
 
           <h3 id="learn-steno">Learning stenography</h3>
-          <h4 id="try-steno">How can you try out steno?</h4>
+          <h4 id="try-steno-on-a-computer">
+            How can you try steno on your computer?
+          </h4>
           <p>
             For an idea of how steno feels and works, you can{" "}
             <OutboundLink


### PR DESCRIPTION
This PR adds links in the KHAERT game and About page to:

- the [interactive steno demo on StenoKnight's site](https://stenoknight.com/kws.html).
- the [standalone steno demo](https://stenoknight.com/plover/ploverdemo/ploverdemo.html).
- [Stenopad on the StenoKeyboards blog](https://stenokeyboards.com/blogs/posts/stenopad). 
- [Stenopad](https://stenopad.stenokeyboards.com/) demo.

The context is in this issue: https://github.com/didoesdigital/typey-type/issues/190#issuecomment-2456226024

This PR also (unrelated) updates `typey-type-data` to [use glued fingerspelled alphabet in top X dicts](https://github.com/didoesdigital/steno-dictionaries/pull/610)