### PR TITLE
Add "⌨️ Typey Type" and update misstroke styling

### DIFF
--- a/src/components/LookupResultsOutlinesAndDicts.tsx
+++ b/src/components/LookupResultsOutlinesAndDicts.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 import SOURCE_NAMESPACES from "../constant/sourceNamespaces";
+import TypeyTypeIcon from "components/Icons/icon-images/TypeyTypeIcon.svg";
+import Icon from "components/Icons/Icon";
 
-import type { StrokeAndDictionaryAndNamespace, StenoLayout } from "../types";
+import type { StenoLayout } from "../types";
+import type { StrokeDictNamespaceAndMisstrokeStatus } from "components/StrokesForWords";
+import LATEST_TYPEY_TYPE_DICT_NAME from "constant/latestTypeyTypeDictName";
 
 type Props = {
-  listOfStrokesAndDicts: StrokeAndDictionaryAndNamespace[];
+  listOfStrokeDictNamespaceMisstroke: StrokeDictNamespaceAndMisstrokeStatus[];
   stenoLayout: StenoLayout;
 };
 
 const LookupResultsOutlinesAndDicts = ({
-  listOfStrokesAndDicts,
+  listOfStrokeDictNamespaceMisstroke,
   stenoLayout,
 }: Props) => {
   let layoutTypeStyle = "";
@@ -20,7 +24,7 @@ const LookupResultsOutlinesAndDicts = ({
     layoutTypeStyle = " type-face--japanese";
   }
 
-  const strokeListItems = listOfStrokesAndDicts.map(
+  const strokeListItems = listOfStrokeDictNamespaceMisstroke.map(
     (strokeAndDict, indexInListOfStrokesAndDicts) => {
       const briefWithSpacesBetweenLetters = [...strokeAndDict[0]]
         .join(" ")
@@ -51,12 +55,22 @@ const LookupResultsOutlinesAndDicts = ({
 
       return (
         <li
-          className="unstyled-list-item mb1 flex flex-wrap items-baseline"
+          className="unstyled-list-item mb1 flex flex-wrap items-baseline gap-y-1"
           key={indexInListOfStrokesAndDicts}
         >
           <div className={"overflow-auto di mw-408 mr1" + layoutTypeStyle}>
             {stenoBriefKeysWithOrWithoutStrongTag}
           </div>
+          {strokeAndDict[2] === SOURCE_NAMESPACES.get("typey") ? (
+            <Icon
+              iconSVGImport={TypeyTypeIcon}
+              color="currentColor"
+              width="1.5em"
+              height="1.5em"
+              className="icon mr1"
+              style={{ alignSelf: "center" }}
+            />
+          ) : null}
           <span
             className={
               strokeAndDict[2] === SOURCE_NAMESPACES.get("typey")
@@ -64,13 +78,22 @@ const LookupResultsOutlinesAndDicts = ({
                 : "de-emphasized"
             }
           >
-            {strokeAndDict[1]}
-          </span>
+            {strokeAndDict[1] === LATEST_TYPEY_TYPE_DICT_NAME &&
+            strokeAndDict[2] === SOURCE_NAMESPACES.get("typey")
+              ? "Typey Type"
+              : strokeAndDict[1]}
+          </span>{" "}
+          {strokeAndDict[3] === true ? (
+            <span className="ml1 px1 bg-magenta-300 dark:bg-coolgrey-800 dark:text-magenta-400">
+              Possible misstroke
+            </span>
+          ) : null}
         </li>
       );
     }
   );
-  return listOfStrokesAndDicts && listOfStrokesAndDicts.length > 0 ? (
+  return listOfStrokeDictNamespaceMisstroke &&
+    listOfStrokeDictNamespaceMisstroke.length > 0 ? (
     <ul className="unstyled-list wrap">{strokeListItems}</ul>
   ) : null;
 };

--- a/src/components/MatchedModifiedTranslation.tsx
+++ b/src/components/MatchedModifiedTranslation.tsx
@@ -1,23 +1,24 @@
 import React from "react";
 
-import type { MaterialText, StrokeAndDictionaryAndNamespace } from "../types";
+import type { MaterialText } from "../types";
+import type { StrokeDictNamespaceAndMisstrokeStatus } from "components/StrokesForWords";
 
 type Props = {
   modifiedWordOrPhrase: MaterialText;
   phrase: MaterialText;
-  listOfStrokesAndDicts: StrokeAndDictionaryAndNamespace[];
+  listOfStrokeDictNamespaceMisstroke: StrokeDictNamespaceAndMisstrokeStatus[];
 };
 
 const MatchedModifiedTranslation = ({
   modifiedWordOrPhrase,
   phrase,
-  listOfStrokesAndDicts,
+  listOfStrokeDictNamespaceMisstroke,
 }: Props) => {
   let classes =
     "dark:text-coolgrey-900 wrap mr1 order-1 fw4 py05 bg-slat bw-1 b--solid";
   classes += modifiedWordOrPhrase === phrase ? " b-info" : " b-danger";
-  return listOfStrokesAndDicts &&
-    listOfStrokesAndDicts.length > 0 &&
+  return listOfStrokeDictNamespaceMisstroke &&
+    listOfStrokeDictNamespaceMisstroke.length > 0 &&
     modifiedWordOrPhrase ? (
     <p className="de-emphasized flex flex-wrap items-center">
       <span className="de-emphasized order-2">(text shown in dictionary)</span>

--- a/src/components/StrokesAsDiagrams.tsx
+++ b/src/components/StrokesAsDiagrams.tsx
@@ -2,22 +2,18 @@ import React from "react";
 import getStenoDiagram from "../pages/lessons/utilities/getStenoDiagram";
 import getMapBriefsFn from "../pages/lessons/utilities/getMapBriefsFn";
 
-import type {
-  SingleStroke,
-  StenoLayout,
-  StrokeAndDictionaryAndNamespace,
-  UserSettings,
-} from "../types";
+import type { SingleStroke, StenoLayout, UserSettings } from "../types";
+import type { StrokeDictNamespaceAndMisstrokeStatus } from "components/StrokesForWords";
 
 type Props = {
-  listOfStrokesAndDicts: StrokeAndDictionaryAndNamespace[];
+  listOfStrokeDictNamespaceMisstroke: StrokeDictNamespaceAndMisstrokeStatus[];
   stenoLayout: StenoLayout;
   strokes: SingleStroke[];
   userSettings: UserSettings;
 };
 
 const StrokesAsDiagrams = ({
-  listOfStrokesAndDicts,
+  listOfStrokeDictNamespaceMisstroke,
   stenoLayout,
   strokes,
   userSettings,
@@ -27,7 +23,7 @@ const StrokesAsDiagrams = ({
   return (
     <div className="flex flex-wrap mr05 overflow-y-auto max-h-240">
       {userSettings?.showStrokesAsDiagrams &&
-        listOfStrokesAndDicts.length > 0 &&
+        listOfStrokeDictNamespaceMisstroke.length > 0 &&
         strokes.map((strokeToDraw, index) => (
           <React.Fragment key={index}>
             {Object.values(mapBriefsFunction(strokeToDraw)).some(
@@ -46,7 +42,7 @@ const StrokesAsDiagrams = ({
           </React.Fragment>
         ))}
       {userSettings?.showStrokesAsDiagrams &&
-      listOfStrokesAndDicts.length === 0 ? (
+      listOfStrokeDictNamespaceMisstroke.length === 0 ? (
         <React.Fragment>
           <div className="mt1 mr2 mb2">
             <StenoLayoutDiagram

--- a/src/components/StrokesForWords.tsx
+++ b/src/components/StrokesForWords.tsx
@@ -9,11 +9,13 @@ import PloverMisstrokesDetail from "./PloverMisstrokesDetail";
 import StrokesAsDiagrams from "./StrokesAsDiagrams";
 
 import type {
+  DictName,
   FetchAndSetupGlobalDict,
   ImportedPersonalDictionaries,
   LookupDictWithNamespacedDictsAndConfig,
+  Namespace,
+  Outline,
   StenoDictionary,
-  StrokeAndDictionaryAndNamespace,
   UserSettings,
 } from "../types";
 import { useAtomValue } from "jotai";
@@ -30,6 +32,13 @@ type Props = {
   userSettings: UserSettings;
 };
 
+export type StrokeDictNamespaceAndMisstrokeStatus = [
+  Outline,
+  DictName,
+  Namespace,
+  boolean
+];
+
 const StrokesForWords = ({
   fetchAndSetupGlobalDict,
   lookupTerm,
@@ -44,9 +53,10 @@ const StrokesForWords = ({
   const [modifiedWordOrPhraseState, setModifiedWordOrPhraseState] =
     useState("");
   const [phraseState, setPhraseState] = useState("");
-  const [listOfStrokesAndDictsState, setListOfStrokesAndDictsState] = useState<
-    StrokeAndDictionaryAndNamespace[]
-  >([]);
+  const [
+    listOfStrokeDictNamespaceMisstroke,
+    setListOfStrokeDictNamespaceMisstroke,
+  ] = useState<StrokeDictNamespaceAndMisstrokeStatus[]>([]);
 
   const misstrokesJSON = misstrokes as StenoDictionary;
 
@@ -107,22 +117,36 @@ const StrokesForWords = ({
       );
     }
 
+    const listOfStrokesDictsNamespaceMisstroke: StrokeDictNamespaceAndMisstrokeStatus[] =
+      listOfStrokesAndDicts.map((row) => {
+        const misstrokeStatus =
+          !!misstrokesJSON[row[0]] &&
+          modifiedWordOrPhrase === misstrokesJSON[row[0]];
+
+        const result: StrokeDictNamespaceAndMisstrokeStatus = [
+          ...row,
+          misstrokeStatus,
+        ];
+
+        return result;
+      });
+
     if (trackPhrase) {
       trackPhrase(phrase);
     }
 
     setModifiedWordOrPhraseState(modifiedWordOrPhrase);
     setPhraseState(phrase);
-    setListOfStrokesAndDictsState(listOfStrokesAndDicts);
+    setListOfStrokeDictNamespaceMisstroke(listOfStrokesDictsNamespaceMisstroke);
   }
 
   const stenoLayout = userSettings?.stenoLayout ?? "stenoLayoutAmericanSteno";
 
   const brief =
-    listOfStrokesAndDictsState &&
-    listOfStrokesAndDictsState[0] &&
-    listOfStrokesAndDictsState[0][0]
-      ? listOfStrokesAndDictsState[0][0]
+    listOfStrokeDictNamespaceMisstroke &&
+    listOfStrokeDictNamespaceMisstroke[0] &&
+    listOfStrokeDictNamespaceMisstroke[0][0]
+      ? listOfStrokeDictNamespaceMisstroke[0][0]
       : "";
 
   const strokes = splitBriefsIntoStrokes(brief);
@@ -151,20 +175,22 @@ const StrokesForWords = ({
         wrap="off"
       ></textarea>
       <MatchedModifiedTranslation
-        listOfStrokesAndDicts={listOfStrokesAndDictsState}
+        listOfStrokeDictNamespaceMisstroke={listOfStrokeDictNamespaceMisstroke}
         modifiedWordOrPhrase={modifiedWordOrPhraseState}
         phrase={phraseState}
       />
       <div className="mb1">
         <StrokesAsDiagrams
-          listOfStrokesAndDicts={listOfStrokesAndDictsState}
+          listOfStrokeDictNamespaceMisstroke={
+            listOfStrokeDictNamespaceMisstroke
+          }
           stenoLayout={stenoLayout}
           strokes={strokes}
           userSettings={userSettings}
         />
       </div>
       <LookupResultsOutlinesAndDicts
-        listOfStrokesAndDicts={listOfStrokesAndDictsState}
+        listOfStrokeDictNamespaceMisstroke={listOfStrokeDictNamespaceMisstroke}
         stenoLayout={stenoLayout}
       />
       <PloverMisstrokesDetail

--- a/src/index.scss
+++ b/src/index.scss
@@ -48,7 +48,7 @@
   --magenta-100: #FCF8FA; //#FCF8FA;
   // --magenta-200: #; //#FAEBF0;
   --magenta-300: #ead6de; //#F5D6E1;
-  // --magenta-400: #F2C5D6; //#F2C5D6;
+  --magenta-400: #F2C5D6; //#F2C5D6;
   // --magenta-500: #; //#E89BB7;
   // --magenta-600: #; //#E26F99;
   --magenta-700: #d64e84; //#CC2E68;
@@ -126,6 +126,7 @@
     --green-600: #09A573;
     --green-700: #067551;
     --magenta-300: #F5D6E1;
+    --magenta-400: #F0BCD0;
     --type-color: var(--coolgrey-400);
   }
 }
@@ -146,6 +147,14 @@
   .dark\:text-violet-900 {
     color: var(--violet-900);
   }
+
+  .dark\:text-magenta-400 {
+    color: var(--magenta-400);
+  }
+}
+
+.bg-magenta-300 {
+  background-color: var(--magenta-300);
 }
 
 .bg-violet-200 {
@@ -1832,6 +1841,10 @@ $textarea-padding-x: 8px;
 .gap-4 {
   gap: 1rem; /* 16px */
 }
+.gap-y-1 {
+  row-gap: 0.25rem; /* 4px */
+}
+
 .columns-xs {
   column-width: 20rem; /* 320px */
 }

--- a/src/pages/lessons/components/StrokeTipList.tsx
+++ b/src/pages/lessons/components/StrokeTipList.tsx
@@ -75,10 +75,9 @@ const StrokeTipList = ({
           </p>
         ) : (
           <LookupResultsOutlinesAndDicts
-            listOfStrokesAndDicts={currentPhraseOutlines.slice(
-              0,
-              maxOutlinesShown
-            )}
+            listOfStrokeDictNamespaceMisstroke={currentPhraseOutlines
+              .slice(0, maxOutlinesShown)
+              .map((row) => [...row, false])}
             stenoLayout={userSettings.stenoLayout}
           />
         )}

--- a/src/pages/lookup/Lookup.stories.jsx
+++ b/src/pages/lookup/Lookup.stories.jsx
@@ -75,7 +75,7 @@ LookupSearchStory.play = async ({ canvasElement }) => {
   ).not.toHaveTextContent("No results found");
 
   await expect(canvas.getByTestId("lookup-page-contents")).toHaveTextContent(
-    "typey-type.json"
+    "Typey Type"
   );
 };
 


### PR DESCRIPTION
This PR updates the way outlines and dictionaries are shown on the Lookup page, Dictionaries index page, and Flashcards pages. It adds a Typey Type logo icon to the `typey:` namespaced dictionaries and replaces `typey-type.json` with "Typey Type".

![image](https://github.com/user-attachments/assets/5f3cc092-a6fa-40e7-b473-8ef9f80e1886)

![image](https://github.com/user-attachments/assets/afb93065-e5dc-4c70-b52a-98869d8503b3)

![image](https://github.com/user-attachments/assets/14533d0a-f5c7-4bba-b10f-e355aa114fbf)

When the `showMisstrokesInLookup` experiment is true in local storage, it shows "Possible misstroke" next to outlines that are in the `misstrokes.json` file (regardless of `user:` or `plover:` namespace):

![image](https://github.com/user-attachments/assets/fb6c9251-7ebf-419a-8a01-9fc1620c60cc)
