### PR TITLE
Pass 2 on flattening setState calls in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,9 +110,7 @@ class App extends Component {
   /* anything that needs to be done when stopping the lesson, excluding the state update */
   applyStopLessonSideEffects(state) {
     this.stopTimer();
-    if (synth) {
-      synth.cancel();
-    }
+    synth?.cancel();
     writePersonalPreferences('metWords', state.metWords);
     if (this.shouldUpdateLessonsProgress(state)) {
       writePersonalPreferences('lessonsProgress', state.lessonsProgress);

--- a/src/App.js
+++ b/src/App.js
@@ -564,7 +564,6 @@ class App extends Component {
       });
     }
     else { // for navigating straight to custom lesson page without setup
-      // debugger;
     // TODO: is this the place where I should set a default empty custom lesson?
       let lesson = Object.assign({}, this.state.customLesson);
       lesson.title = 'Custom'
@@ -779,7 +778,6 @@ class App extends Component {
         state.metWords[phraseText] = meetingsCount + 1;
       }
 
-      // TODO: this is a side-effect, move to a separate function
       if (this.props.userSettings.speakMaterial) {
         const remaining = state.lesson.newPresentedMaterial.getRemaining();
         if (remaining && remaining.length > 0 && remaining[0].hasOwnProperty('phrase')) {

--- a/src/App.js
+++ b/src/App.js
@@ -186,15 +186,13 @@ class App extends Component {
     let calculatedYourSeenWordCount = calculateSeenWordCount(this.state.metWords);
     let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
-    this.setState({
+    writePersonalPreferences('lessonsProgress', lessonsProgressState);
+    writePersonalPreferences('metWords', metWordsFromStateOrArg);
+    this.setupLesson({
       lessonsProgress: lessonsProgressState,
       metWords: metWordsFromStateOrArg,
       yourSeenWordCount: calculatedYourSeenWordCount,
       yourMemorisedWordCount: calculatedYourMemorisedWordCount,
-    }, () => {
-      writePersonalPreferences('lessonsProgress', this.state.lessonsProgress);
-      writePersonalPreferences('metWords', this.state.metWords);
-      this.setupLesson();
     });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -279,11 +279,8 @@ class App extends Component {
       numberOfWordsToDiscover: numberOfWordsToDiscover
     }
 
-    this.setState({
-      lessonsProgress: lessonsProgress,
-    }, () => {
-      writePersonalPreferences('lessonsProgress', lessonsProgress);
-    });
+    writePersonalPreferences('lessonsProgress', lessonsProgress);
+    this.setState({ lessonsProgress });
     return lessonsProgress;
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -187,7 +187,7 @@ class App extends Component {
     let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
     // these two writePersonalPreferences calls were in a callback of setState - so 
-    // these moy need to be moved to useEffect later
+    // these may need to be moved to useEffect later
     writePersonalPreferences('lessonsProgress', lessonsProgressState);
     writePersonalPreferences('metWords', metWordsFromStateOrArg);
     this.setupLesson({

--- a/src/App.js
+++ b/src/App.js
@@ -213,6 +213,7 @@ class App extends Component {
     // these two writePersonalPreferences calls were in a callback of setState - so 
     // these may need to be moved to useEffect later, for example, when
     // this component is converted to a functional component
+    // care should be taken to not over-fire these updates
     writePersonalPreferences('lessonsProgress', lessonsProgressState);
     writePersonalPreferences('metWords', metWordsFromStateOrArg);
     this.setupLesson({

--- a/src/App.js
+++ b/src/App.js
@@ -186,6 +186,8 @@ class App extends Component {
     let calculatedYourSeenWordCount = calculateSeenWordCount(this.state.metWords);
     let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
+    // these two writePersonalPreferences calls were in a callback of setState - so 
+    // these moy need to be moved to useEffect later
     writePersonalPreferences('lessonsProgress', lessonsProgressState);
     writePersonalPreferences('metWords', metWordsFromStateOrArg);
     this.setupLesson({
@@ -279,6 +281,8 @@ class App extends Component {
       numberOfWordsToDiscover: numberOfWordsToDiscover
     }
 
+    // this writePersonalPreferences call was in a callback of setState - so
+    // this may need to be moved to useEffect later
     writePersonalPreferences('lessonsProgress', lessonsProgress);
     this.setState({ lessonsProgress });
     return lessonsProgress;

--- a/src/App.js
+++ b/src/App.js
@@ -520,11 +520,9 @@ class App extends Component {
   startCustomLesson() {
     let lesson = Object.assign({}, this.state.customLesson);
     lesson.title = 'Custom'
-    this.setState({
+    this.setupLesson({
       currentPhraseID: 0,
       lesson: lesson
-    }, () => {
-      this.setupLesson();
     });
   }
 
@@ -534,15 +532,13 @@ class App extends Component {
       let [lesson, validationState, validationMessages] = parseCustomMaterial(providedText);
       let customLesson = Object.assign({}, this.state.customLesson);
       if (validationMessages && validationMessages.length < 1) { customLesson = lesson; }
-      this.setState({
-        lesson: lesson,
+      this.setupLesson({
+        lesson,
         currentPhraseID: 0,
-        customLesson: customLesson,
+        customLesson,
         customLessonMaterial: providedText,
         customLessonMaterialValidationState: validationState,
         customLessonMaterialValidationMessages: validationMessages
-      }, () => {
-        this.setupLesson();
       });
     }
     else { // for navigating straight to custom lesson page without setup
@@ -550,12 +546,10 @@ class App extends Component {
     // TODO: is this the place where I should set a default empty custom lesson?
       let lesson = Object.assign({}, this.state.customLesson);
       lesson.title = 'Custom'
-      this.setState({
+      this.setupLesson({
         customLesson: lesson,
-        lesson: lesson,
+        lesson,
         currentPhraseID: 0
-      }, () => {
-        this.setupLesson();
       });
     }
     return event;
@@ -563,15 +557,11 @@ class App extends Component {
 
   reviseLesson(event, newRevisionMaterial) {
     event.preventDefault();
-    this.setState({
+    this.stopLesson();
+    this.setupLesson({
       revisionMaterial: newRevisionMaterial,
-    }, () => {
-      this.stopLesson();
-      this.setupLesson({
-        focusTriggerInt: this.state.focusTriggerInt + 1,
-        // revisionMaterial: newRevisionMaterial,
-        revisionMode: true,
-      });
+      focusTriggerInt: this.state.focusTriggerInt + 1,
+      revisionMode: true,
     });
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -187,7 +187,8 @@ class App extends Component {
     let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
     // these two writePersonalPreferences calls were in a callback of setState - so 
-    // these may need to be moved to useEffect later
+    // these may need to be moved to useEffect later, for example, when
+    // this component is converted to a functional component
     writePersonalPreferences('lessonsProgress', lessonsProgressState);
     writePersonalPreferences('metWords', metWordsFromStateOrArg);
     this.setupLesson({
@@ -282,7 +283,8 @@ class App extends Component {
     }
 
     // this writePersonalPreferences call was in a callback of setState - so
-    // this may need to be moved to useEffect later
+    // this may need to be moved to useEffect later, for example, when
+    // this component is converted to a functional component
     writePersonalPreferences('lessonsProgress', lessonsProgress);
     this.setState({ lessonsProgress });
     return lessonsProgress;

--- a/src/App.js
+++ b/src/App.js
@@ -643,17 +643,20 @@ class App extends Component {
    */
   processBuffer(actualText, buffer) {
     const [newState, sideEffects] = this.getNewStateAndSideEffectsForBuffer(actualText,
-                                                                              buffer,
-                                                                              this.state,
-                                                                              []);
+                                                                            buffer,
+                                                                            this.state,
+                                                                            []);
     sideEffects.forEach(effect => effect());
     this.setState(newState);
   }
 
   /*
-   * Takes buffer of inputs and returns the new state corresponding to the strokes
-   * in the buffer and the corresponding side effects to be applied - such as
-   * starting/stopping the timer, uttering the phrases, etc.
+   * Takes the buffer of inputs and returns the new state and the side effects
+   * corresponding to the strokes in the buffer.
+   * The side effects are actions, such as starting/stopping the timer,
+   * uttering the phrases, etc.
+   * This function may be executed recursively, until all the strokes in the buffer
+   * are processed.
    */
   getNewStateAndSideEffectsForBuffer(actualText, buffer, state, sideEffects) {
     let time = Date.now();

--- a/the.diff
+++ b/the.diff
@@ -1,3 +1,0 @@
-src/App.js: 
-
-* flattening setState calls in the most obvious places

--- a/the.diff
+++ b/the.diff
@@ -1,0 +1,4 @@
+Flattening the setState calls in App.js
+
+* adds App.shouldUpdateLessonsProgress(state)
+* moves update of lessonsProgress from applyStopLessonSideEffects to getFutureStateToStopLesson

--- a/the.diff
+++ b/the.diff
@@ -1,0 +1,3 @@
+src/App.js: 
+
+* flattening setState calls in the most obvious places

--- a/the.diff
+++ b/the.diff
@@ -1,4 +1,0 @@
-Flattening the setState calls in App.js
-
-* adds App.shouldUpdateLessonsProgress(state)
-* moves update of lessonsProgress from applyStopLessonSideEffects to getFutureStateToStopLesson


### PR DESCRIPTION
Here I've removed callbacks from setState() calls that seem to be obvious to me.

The only remaining use case is in the method `updateBufferSingle` which I found to be more difficult. I think I will make a fake PR where I request comments first to become better acquainted with the purpose of the method.

Test cases pass, and I went through the manual testing list from the previous PR and didn't see any issues, to the best of my ability.

Also it seems that I've rolled back the state of the submodule to an older commit, hopefully you could rectify that, @didoesdigital.