### PR TITLE
Completes removal of callbacks from the setState calls in App.js - replaces PR 206

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,6 +99,30 @@ class App extends Component {
     this.setPersonalPreferences();
   }
 
+  /**
+   * calls setupLesson() if when the user settings change - 
+   * this should probably be moved inside the Lesson component
+   * when and if the lesson state is moved into the Lesson component
+   */
+  componentDidUpdate(prevProps) {
+    const curUserSettings = this.props.userSettings;
+    const prevUserSettings = prevProps.userSettings;
+    if (curUserSettings.sortOrder !== prevUserSettings.sortOrder ||
+        curUserSettings.spacePlacement !== prevUserSettings.spacePlacement ||
+        curUserSettings.stenoLayout !== prevUserSettings.stenoLayout ||
+        curUserSettings.study !== prevUserSettings.study ||
+        curUserSettings.limitNumberOfWords !== prevUserSettings.limitNumberOfWords ||
+        curUserSettings.repetitions !== prevUserSettings.repetitions ||
+        curUserSettings.startFromWord !== prevUserSettings.startFromWord ||
+        curUserSettings.upcomingWordsLayout !== prevUserSettings.upcomingWordsLayout ||
+        curUserSettings.newWords !== prevUserSettings.newWords ||
+        curUserSettings.seenWords !== prevUserSettings.seenWords ||
+        curUserSettings.retainedWords !== prevUserSettings.retainedWords ||
+        curUserSettings.simpleTypography !== prevUserSettings.simpleTypography) {
+      this.setupLesson();
+    }
+  }
+
   shouldUpdateLessonsProgress(state) {
     /*
      * Should this also check for /lessons/custom/setup?  - see setupLesson()

--- a/src/App.js
+++ b/src/App.js
@@ -107,26 +107,25 @@ class App extends Component {
   componentDidUpdate(prevProps) {
     const curUserSettings = this.props.userSettings;
     const prevUserSettings = prevProps.userSettings;
-    if (curUserSettings.sortOrder !== prevUserSettings.sortOrder ||
-        curUserSettings.spacePlacement !== prevUserSettings.spacePlacement ||
-        curUserSettings.stenoLayout !== prevUserSettings.stenoLayout ||
-        curUserSettings.study !== prevUserSettings.study ||
-        curUserSettings.limitNumberOfWords !== prevUserSettings.limitNumberOfWords ||
-        curUserSettings.repetitions !== prevUserSettings.repetitions ||
-        curUserSettings.startFromWord !== prevUserSettings.startFromWord ||
-        curUserSettings.upcomingWordsLayout !== prevUserSettings.upcomingWordsLayout ||
-        curUserSettings.newWords !== prevUserSettings.newWords ||
-        curUserSettings.seenWords !== prevUserSettings.seenWords ||
-        curUserSettings.retainedWords !== prevUserSettings.retainedWords ||
-        curUserSettings.simpleTypography !== prevUserSettings.simpleTypography) {
+    if (
+      curUserSettings.sortOrder !== prevUserSettings.sortOrder ||
+      curUserSettings.spacePlacement !== prevUserSettings.spacePlacement ||
+      curUserSettings.stenoLayout !== prevUserSettings.stenoLayout ||
+      curUserSettings.study !== prevUserSettings.study ||
+      curUserSettings.limitNumberOfWords !== prevUserSettings.limitNumberOfWords ||
+      curUserSettings.repetitions !== prevUserSettings.repetitions ||
+      curUserSettings.startFromWord !== prevUserSettings.startFromWord ||
+      curUserSettings.upcomingWordsLayout !== prevUserSettings.upcomingWordsLayout ||
+      curUserSettings.newWords !== prevUserSettings.newWords ||
+      curUserSettings.seenWords !== prevUserSettings.seenWords ||
+      curUserSettings.retainedWords !== prevUserSettings.retainedWords ||
+      curUserSettings.simpleTypography !== prevUserSettings.simpleTypography
+    ) {
       this.setupLesson();
     }
   }
 
   shouldUpdateLessonsProgress(state) {
-    /*
-     * Should this also check for /lessons/custom/setup?  - see setupLesson()
-     */
     return state.lesson.path && !state.lesson.path.endsWith("/lessons/custom");
   }
 
@@ -175,7 +174,7 @@ class App extends Component {
                                                             userSettings: this.props.userSettings,
                                                             prevLessonsProgress: prevState.lessonsProgress,
                                                             metWords: prevState.metWords});
-      prevState.lessonsProgress = lessonsProgress;
+      newState.lessonsProgress = lessonsProgress;
     }
 
     return newState;
@@ -659,9 +658,10 @@ class App extends Component {
    * @actualText param is not used - probably should be removed
    */
   processBuffer(actualText, buffer) {
+    const stateCopy = {...this.state};
     const [newState, sideEffects] = this.getNewStateAndSideEffectsForBuffer(actualText,
                                                                             buffer,
-                                                                            this.state,
+                                                                            stateCopy,
                                                                             []);
     sideEffects.forEach(effect => effect());
     this.setState(newState);

--- a/src/pages/lessons/components/UserSettings/UserSettings.tsx
+++ b/src/pages/lessons/components/UserSettings/UserSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import InfoIconAndTooltip from "../../../../components/InfoIconAndTooltip";
 import ErrorBoundary from "../../../../components/ErrorBoundary";
 import NumericInput from "react-numeric-input";
@@ -7,7 +7,6 @@ import SettingListItem from "../../../../components/SettingListItem";
 import SpeakWordsHelp from "../SpeakWordsHelp";
 import VoiceSetting from "../VoiceSetting";
 
-import { useAppMethods } from "../../../../states/legacy/AppMethodsContext";
 import { useAtomValue } from "jotai";
 import { userSettingsState } from "../../../../states/userSettingsState";
 import {
@@ -61,34 +60,6 @@ const UserSettings = ({
   const handleRepetitionsChange = useHandleRepetitionsChange();
   const handleStartFromWordChange = useHandleStartFromWordChange();
   const handleUpcomingWordsLayout = useHandleUpcomingWordsLayout();
-
-  const { setupLesson } = useAppMethods();
-  const mounted = useRef(false);
-  useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-      return;
-    }
-    // Call whenever settings change
-    setupLesson();
-
-    // TODO: add `setupLesson` to dependency array
-    // after reducing parent component re-renders:
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    userSettings.sortOrder,
-    userSettings.spacePlacement,
-    userSettings.stenoLayout,
-    userSettings.study,
-    userSettings.limitNumberOfWords,
-    userSettings.repetitions,
-    userSettings.startFromWord,
-    userSettings.upcomingWordsLayout,
-    userSettings.newWords,
-    userSettings.seenWords,
-    userSettings.retainedWords,
-    userSettings.simpleTypography,
-  ]);
 
   return (
     <div className="user-settings">

--- a/src/utils/calculateMemorisedWordCount.ts
+++ b/src/utils/calculateMemorisedWordCount.ts
@@ -3,7 +3,8 @@ import type { MetWords } from "../types";
 function calculateMemorisedWordCount(metWords: MetWords) {
   const yourMemorisedWordCount =
     Math.round(
-      Object.values(metWords).filter((timesSeen) => timesSeen > 29).length
+      // the 2 below should be restored to 29, 2 is to help debugging
+      Object.values(metWords).filter((timesSeen) => timesSeen > 2).length
     ) || 0;
 
   return yourMemorisedWordCount;

--- a/src/utils/calculateMemorisedWordCount.ts
+++ b/src/utils/calculateMemorisedWordCount.ts
@@ -3,8 +3,7 @@ import type { MetWords } from "../types";
 function calculateMemorisedWordCount(metWords: MetWords) {
   const yourMemorisedWordCount =
     Math.round(
-      // the 2 below should be restored to 29, 2 is to help debugging
-      Object.values(metWords).filter((timesSeen) => timesSeen > 2).length
+      Object.values(metWords).filter((timesSeen) => timesSeen > 29).length
     ) || 0;
 
   return yourMemorisedWordCount;


### PR DESCRIPTION
Replaces PR #206 

* adds App.shouldUpdateLessonsProgress(state)

* moves update of lessonsProgress from applyStopLessonSideEffects to getFutureStateToStopLesson

* stopLesson():
  - factored out applyStopLessonSideEffects()
  - factored out getFutureStateToStopLesson()

* isFinished takes state as an argument, instead of using this.state

* processBuffer():
  - consists of getNewStateAndSideEffectsForBuffer(), application of side-effects and a single setState() call

* getNewStateAndSideEffectsForBuffer():
  - contains the logic of the past processBuffer function, but does not use the global this.state, instead takes the previous value as an argument and returns the updated value, which is then applied in the setState() call
  - if the lesson is finished, applies the stop lesson side effects and returns the state for the stopped lesson
  - getNewStateAndSideEffectsForBuffer is intended to be a pure function
  - returns a tuple of [newState, sideEffects]