### PR TITLE
Ranks and sorts affixes and updates fingerspelling entries

### DIFF
--- a/src/pages/lessons/custom/generator/rules/isOneSyllable.test.ts
+++ b/src/pages/lessons/custom/generator/rules/isOneSyllable.test.ts
@@ -67,7 +67,7 @@ describe("isOneSyllable", () => {
 
   it("returns false for phrases with punctuation", async () => {
     expect(
-      isOneSyllable("KHR-PB/STREUPBG/PREPB/#T-/#A/#A/PR*EPB", ":string(255)")
+      isOneSyllable("KHR-PB/STREUPBG/PREPB/#T/#A/#A/PR*EPB", ":string(255)")
     ).toEqual(false);
   });
 

--- a/src/utils/affixList.test.ts
+++ b/src/utils/affixList.test.ts
@@ -136,4 +136,77 @@ describe("AffixList", () => {
       });
     });
   });
+
+  describe("creates an affix list with sorted, ranked prefixes and suffixes", () => {
+    it("prioritises longer translations over shorter translations to select affixes so that the hint for suitors is SAOUT/O*RS not SAOU/TOR/-S", () => {
+      const emptyPersonalDictionaries: PersonalDictionaryNameAndContents[] = [];
+      const customGlobalLookupDictionary = createGlobalLookupDictionary(
+        emptyPersonalDictionaries,
+        [
+          [
+            {
+              "-S": "{^s}",
+              "O*R": "{^or}",
+              "O*RS": "{^ors}",
+              "SAOU/TOR": "suitor",
+              "SAOUT": "suit",
+              "SAOUT/TOR": "suitor",
+            },
+            LATEST_TYPEY_TYPE_FULL_DICT_NAME,
+          ],
+        ]
+      );
+      new AffixList(customGlobalLookupDictionary);
+
+      expect(new AffixList(customGlobalLookupDictionary)).toEqual({
+        "prefixes": [],
+        "suffixes": [
+          ["/O*RS", "ors"],
+          ["/O*R", "or"],
+          ["/-S", "s"],
+        ],
+      });
+    });
+
+    it("ranks available affix outlines and chooses the first outline to add to the affix list", () => {
+      const emptyPersonalDictionaries: PersonalDictionaryNameAndContents[] = [];
+      const customGlobalLookupDictionary = createGlobalLookupDictionary(
+        emptyPersonalDictionaries,
+        [
+          [
+            {
+              "STPA": "{^a}",
+              "STPO": "{^o}",
+              "STPE": "{^e}",
+              "STPEU": "{^i}",
+              "STPU": "{^u}",
+              "SKWRA": "{^a}",
+              "SKWRO": "{^o}",
+              "SKWR*E": "{^e}",
+              "SKWRE": "{^e}",
+              "SKWREU": "{^i}",
+              "SKWRU": "{^u}",
+              "KWRA": "{^a}",
+              "KWRO": "{^o}",
+              "KWREU": "{^y}",
+            },
+            LATEST_TYPEY_TYPE_FULL_DICT_NAME,
+          ],
+        ]
+      );
+      new AffixList(customGlobalLookupDictionary);
+
+      expect(new AffixList(customGlobalLookupDictionary)).toEqual({
+        "prefixes": [],
+        "suffixes": [
+          ["/SKWRA", "a"],
+          ["/SKWRO", "o"],
+          ["/SKWRE", "e"],
+          ["/SKWREU", "i"],
+          ["/SKWRU", "u"],
+          ["/KWREU", "y"],
+        ],
+      });
+    });
+  });
 });

--- a/src/utils/affixList.ts
+++ b/src/utils/affixList.ts
@@ -1,4 +1,7 @@
 import splitIntoStrokesDictsAndNamespaces from "utils/transformingDictionaries/splitIntoStrokesDictsAndNamespaces";
+import misstrokesJSON from "../json/misstrokes.json";
+import rankAffixes from "utils/rankAffixes";
+
 import type {
   LookupDictWithNamespacedDicts,
   AffixObject,
@@ -9,12 +12,7 @@ import type {
   SuffixOutlineWithLeadingSlash,
   SuffixTextWithNoTPRBGTS,
   StenoDictionary,
-  StrokeAndDictionaryAndNamespace,
 } from "../types";
-import penaliseStars from "utils/transformingDictionaries/rankOutlines/penaliseStars";
-import penaliseStretchKeys from "utils/transformingDictionaries/rankOutlines/penaliseStretchKeys";
-import misstrokesJSON from "../json/misstrokes.json";
-import penaliseSlashes from "utils/transformingDictionaries/rankOutlines/penaliseSlashes";
 
 let SHARED_INSTANCE: AffixObject = { suffixes: [], prefixes: [] };
 
@@ -29,102 +27,6 @@ const misstrokes = misstrokesJSON as StenoDictionary;
 const affixMisstrokes = Object.fromEntries(
   Object.entries(misstrokes).filter((dictEntry) => isAffix(dictEntry[1]))
 );
-
-const preferredVowelSet = [
-  "SKWRA",
-  "SKWRE",
-  "SKWREU",
-  "SKWRO",
-  "SKWRU",
-  "KWREU",
-];
-const secondPreferredVowelSet = [
-  "STPA",
-  "STPE",
-  "STPEU",
-  "STPO",
-  "STPU",
-  // no "y" suffix
-];
-const vowelSuffixTranslations = [
-  "{^a}",
-  "{^e}",
-  "{^i}",
-  "{^o}",
-  "{^u}",
-  "{^y}",
-];
-
-function getVowelSuffixPriority(outline: string) {
-  if (preferredVowelSet.includes(outline)) return 1;
-  if (secondPreferredVowelSet.includes(outline)) return 2;
-  return 3;
-}
-
-// This function shares a lot of code with rankOutlines but is modified to specifically handle *only* affixes
-function rankAffixes(
-  arrayOfStrokesAndTheirSourceDictNames: StrokeAndDictionaryAndNamespace[],
-  affixMisstrokes: StenoDictionary,
-  translation: string
-  // affixes: AffixObject = { suffixes: [], prefixes: [] }
-) {
-  arrayOfStrokesAndTheirSourceDictNames.sort((a, b) => {
-    if (a[2] === "user" && b[2] !== "user") return -1;
-    if (b[2] === "user" && a[2] !== "user") return 1;
-
-    // For now, there are no affixes in this dictionary. The only Plover
-    // formatting in it at the moment is for glue formatting e.g. {&er}, {&2}
-    // if (a[1] === "top-10000-project-gutenberg-words.json") return -1;
-    // if (b[1] === "top-10000-project-gutenberg-words.json") return 1;
-
-    if (
-      affixMisstrokes[a[0]] === translation &&
-      !(affixMisstrokes[b[0]] === translation)
-    ) {
-      return 1; // sort a after b
-    }
-    if (
-      affixMisstrokes[b[0]] === translation &&
-      !(affixMisstrokes[a[0]] === translation)
-    ) {
-      return -1; // sort a before b
-    }
-
-    let outlineA = a[0];
-    let outlineB = b[0];
-
-    if (vowelSuffixTranslations.includes(translation)) {
-      return (
-        getVowelSuffixPriority(outlineA) - getVowelSuffixPriority(outlineB)
-      );
-    }
-
-    let outlineALengthWithAllPenalties = outlineA.length;
-    let outlineBLengthWithAllPenalties = outlineB.length;
-
-    outlineALengthWithAllPenalties += penaliseStars(outlineA, translation);
-    outlineBLengthWithAllPenalties += penaliseStars(outlineB, translation);
-
-    outlineALengthWithAllPenalties += penaliseSlashes(outlineA, translation);
-    outlineBLengthWithAllPenalties += penaliseSlashes(outlineB, translation);
-
-    if (outlineALengthWithAllPenalties === outlineBLengthWithAllPenalties) {
-      outlineALengthWithAllPenalties += penaliseStretchKeys(
-        outlineA,
-        outlineB,
-        translation
-      );
-      outlineBLengthWithAllPenalties += penaliseStretchKeys(
-        outlineB,
-        outlineA,
-        translation
-      );
-    }
-
-    return outlineALengthWithAllPenalties - outlineBLengthWithAllPenalties;
-  });
-  return arrayOfStrokesAndTheirSourceDictNames;
-}
 
 export class AffixList {
   suffixes: SuffixEntry[];

--- a/src/utils/affixList.ts
+++ b/src/utils/affixList.ts
@@ -1,3 +1,4 @@
+import splitIntoStrokesDictsAndNamespaces from "utils/transformingDictionaries/splitIntoStrokesDictsAndNamespaces";
 import type {
   LookupDictWithNamespacedDicts,
   AffixObject,
@@ -7,12 +8,123 @@ import type {
   SuffixEntry,
   SuffixOutlineWithLeadingSlash,
   SuffixTextWithNoTPRBGTS,
+  StenoDictionary,
+  StrokeAndDictionaryAndNamespace,
 } from "../types";
+import penaliseStars from "utils/transformingDictionaries/rankOutlines/penaliseStars";
+import penaliseStretchKeys from "utils/transformingDictionaries/rankOutlines/penaliseStretchKeys";
+import misstrokesJSON from "../json/misstrokes.json";
+import penaliseSlashes from "utils/transformingDictionaries/rankOutlines/penaliseSlashes";
 
 let SHARED_INSTANCE: AffixObject = { suffixes: [], prefixes: [] };
 
 const prefixRegex = /^\{([A-Za-z0-9.=<>\\:'"#-])+\^\}$/;
 const suffixRegex = /^\{\^([A-Za-z0-9.=<>\\:'"#-])+\}$/;
+
+const isAffix = (translation: string) => {
+  return translation.match(suffixRegex) || translation.match(prefixRegex);
+};
+
+const misstrokes = misstrokesJSON as StenoDictionary;
+const affixMisstrokes = Object.fromEntries(
+  Object.entries(misstrokes).filter((dictEntry) => isAffix(dictEntry[1]))
+);
+
+const preferredVowelSet = [
+  "SKWRA",
+  "SKWRE",
+  "SKWREU",
+  "SKWRO",
+  "SKWRU",
+  "KWREU",
+];
+const secondPreferredVowelSet = [
+  "STPA",
+  "STPE",
+  "STPEU",
+  "STPO",
+  "STPU",
+  // no "y" suffix
+];
+const vowelSuffixTranslations = [
+  "{^a}",
+  "{^e}",
+  "{^i}",
+  "{^o}",
+  "{^u}",
+  "{^y}",
+];
+
+function getVowelSuffixPriority(outline: string) {
+  if (preferredVowelSet.includes(outline)) return 1;
+  if (secondPreferredVowelSet.includes(outline)) return 2;
+  return 3;
+}
+
+// This function shares a lot of code with rankOutlines but is modified to specifically handle *only* affixes
+function rankAffixes(
+  arrayOfStrokesAndTheirSourceDictNames: StrokeAndDictionaryAndNamespace[],
+  affixMisstrokes: StenoDictionary,
+  translation: string
+  // affixes: AffixObject = { suffixes: [], prefixes: [] }
+) {
+  arrayOfStrokesAndTheirSourceDictNames.sort((a, b) => {
+    if (a[2] === "user" && b[2] !== "user") return -1;
+    if (b[2] === "user" && a[2] !== "user") return 1;
+
+    // For now, there are no affixes in this dictionary. The only Plover
+    // formatting in it at the moment is for glue formatting e.g. {&er}, {&2}
+    // if (a[1] === "top-10000-project-gutenberg-words.json") return -1;
+    // if (b[1] === "top-10000-project-gutenberg-words.json") return 1;
+
+    if (
+      affixMisstrokes[a[0]] === translation &&
+      !(affixMisstrokes[b[0]] === translation)
+    ) {
+      return 1; // sort a after b
+    }
+    if (
+      affixMisstrokes[b[0]] === translation &&
+      !(affixMisstrokes[a[0]] === translation)
+    ) {
+      return -1; // sort a before b
+    }
+
+    let outlineA = a[0];
+    let outlineB = b[0];
+
+    if (vowelSuffixTranslations.includes(translation)) {
+      return (
+        getVowelSuffixPriority(outlineA) - getVowelSuffixPriority(outlineB)
+      );
+    }
+
+    let outlineALengthWithAllPenalties = outlineA.length;
+    let outlineBLengthWithAllPenalties = outlineB.length;
+
+    outlineALengthWithAllPenalties += penaliseStars(outlineA, translation);
+    outlineBLengthWithAllPenalties += penaliseStars(outlineB, translation);
+
+    outlineALengthWithAllPenalties += penaliseSlashes(outlineA, translation);
+    outlineBLengthWithAllPenalties += penaliseSlashes(outlineB, translation);
+
+    if (outlineALengthWithAllPenalties === outlineBLengthWithAllPenalties) {
+      outlineALengthWithAllPenalties += penaliseStretchKeys(
+        outlineA,
+        outlineB,
+        translation
+      );
+      outlineBLengthWithAllPenalties += penaliseStretchKeys(
+        outlineB,
+        outlineA,
+        translation
+      );
+    }
+
+    return outlineALengthWithAllPenalties - outlineBLengthWithAllPenalties;
+  });
+  return arrayOfStrokesAndTheirSourceDictNames;
+}
 
 export class AffixList {
   suffixes: SuffixEntry[];
@@ -31,7 +143,12 @@ export class AffixList {
     const prefixes = [];
     for (const [phrase, outlinesAndSourceDicts] of dict) {
       if (phrase.match(suffixRegex)) {
-        const suffixOutlineWithLeadingSlash: SuffixOutlineWithLeadingSlash = `/${outlinesAndSourceDicts[0][0]}`;
+        const bestSuffixOutline = rankAffixes(
+          splitIntoStrokesDictsAndNamespaces(outlinesAndSourceDicts),
+          affixMisstrokes,
+          phrase
+        )[0][0];
+        const suffixOutlineWithLeadingSlash: SuffixOutlineWithLeadingSlash = `/${bestSuffixOutline}`;
         const suffixTextWithNoTPRBGTS: SuffixTextWithNoTPRBGTS = phrase
           .replace("{^", "")
           .replace("}", "");

--- a/src/utils/affixList.ts
+++ b/src/utils/affixList.ts
@@ -11,6 +11,9 @@ import type {
 
 let SHARED_INSTANCE: AffixObject = { suffixes: [], prefixes: [] };
 
+const prefixRegex = /^\{([A-Za-z0-9.=<>\\:'"#-])+\^\}$/;
+const suffixRegex = /^\{\^([A-Za-z0-9.=<>\\:'"#-])+\}$/;
+
 export class AffixList {
   suffixes: SuffixEntry[];
   prefixes: PrefixEntry[];
@@ -26,8 +29,6 @@ export class AffixList {
   constructor(dict: LookupDictWithNamespacedDicts) {
     const suffixes = [];
     const prefixes = [];
-    const prefixRegex = /^\{([A-Za-z0-9.=<>\\:'"#-])+\^\}$/;
-    const suffixRegex = /^\{\^([A-Za-z0-9.=<>\\:'"#-])+\}$/;
     for (const [phrase, outlinesAndSourceDicts] of dict) {
       if (phrase.match(suffixRegex)) {
         const suffixOutlineWithLeadingSlash: SuffixOutlineWithLeadingSlash = `/${outlinesAndSourceDicts[0][0]}`;

--- a/src/utils/affixList.ts
+++ b/src/utils/affixList.ts
@@ -62,7 +62,12 @@ export class AffixList {
       }
 
       if (phrase.match(prefixRegex)) {
-        const prefixOutlineWithSlash: PrefixOutlineWithSlash = `${outlinesAndSourceDicts[0][0]}/`;
+        const bestPrefixOutline = rankAffixes(
+          splitIntoStrokesDictsAndNamespaces(outlinesAndSourceDicts),
+          affixMisstrokes,
+          phrase
+        )[0][0];
+        const prefixOutlineWithSlash: PrefixOutlineWithSlash = `${bestPrefixOutline}/`;
         const prefixTextWithNoTPRBGTS: PrefixTextWithNoTPRBGTS = phrase
           .replace("{", "")
           .replace("^}", "");

--- a/src/utils/affixList.ts
+++ b/src/utils/affixList.ts
@@ -54,6 +54,10 @@ export class AffixList {
       }
     }
 
+    // Sort by translation length so that longer affixes are selected first
+    suffixes.sort((a, b) => b[1].length - a[1].length);
+    prefixes.sort((a, b) => b[1].length - a[1].length);
+
     this.suffixes = suffixes;
     this.prefixes = prefixes;
   }

--- a/src/utils/rankAffixes.ts
+++ b/src/utils/rankAffixes.ts
@@ -43,7 +43,6 @@ function rankAffixes(
   arrayOfStrokesAndTheirSourceDictNames: StrokeAndDictionaryAndNamespace[],
   affixMisstrokes: StenoDictionary,
   translation: string
-  // affixes: AffixObject = { suffixes: [], prefixes: [] }
 ) {
   arrayOfStrokesAndTheirSourceDictNames.sort((a, b) => {
     if (a[2] === "user" && b[2] !== "user") return -1;

--- a/src/utils/rankAffixes.ts
+++ b/src/utils/rankAffixes.ts
@@ -1,0 +1,106 @@
+import penaliseStars from "utils/transformingDictionaries/rankOutlines/penaliseStars";
+import penaliseStretchKeys from "utils/transformingDictionaries/rankOutlines/penaliseStretchKeys";
+import penaliseSlashes from "utils/transformingDictionaries/rankOutlines/penaliseSlashes";
+
+import type {
+  StenoDictionary,
+  StrokeAndDictionaryAndNamespace,
+} from "../types";
+
+const preferredVowelSet = [
+  "SKWRA",
+  "SKWRE",
+  "SKWREU",
+  "SKWRO",
+  "SKWRU",
+  "KWREU",
+];
+const secondPreferredVowelSet = [
+  "STPA",
+  "STPE",
+  "STPEU",
+  "STPO",
+  "STPU",
+  // no "y" suffix
+];
+const vowelSuffixTranslations = [
+  "{^a}",
+  "{^e}",
+  "{^i}",
+  "{^o}",
+  "{^u}",
+  "{^y}",
+];
+
+function getVowelSuffixPriority(outline: string) {
+  if (preferredVowelSet.includes(outline)) return 1;
+  if (secondPreferredVowelSet.includes(outline)) return 2;
+  return 3;
+}
+
+// This function shares a lot of code with rankOutlines but is modified to specifically handle *only* affixes
+function rankAffixes(
+  arrayOfStrokesAndTheirSourceDictNames: StrokeAndDictionaryAndNamespace[],
+  affixMisstrokes: StenoDictionary,
+  translation: string
+  // affixes: AffixObject = { suffixes: [], prefixes: [] }
+) {
+  arrayOfStrokesAndTheirSourceDictNames.sort((a, b) => {
+    if (a[2] === "user" && b[2] !== "user") return -1;
+    if (b[2] === "user" && a[2] !== "user") return 1;
+
+    // For now, there are no affixes in this dictionary. The only Plover
+    // formatting in it at the moment is for glue formatting e.g. {&er}, {&2}
+    // if (a[1] === "top-10000-project-gutenberg-words.json") return -1;
+    // if (b[1] === "top-10000-project-gutenberg-words.json") return 1;
+
+    if (
+      affixMisstrokes[a[0]] === translation &&
+      !(affixMisstrokes[b[0]] === translation)
+    ) {
+      return 1; // sort a after b
+    }
+    if (
+      affixMisstrokes[b[0]] === translation &&
+      !(affixMisstrokes[a[0]] === translation)
+    ) {
+      return -1; // sort a before b
+    }
+
+    let outlineA = a[0];
+    let outlineB = b[0];
+
+    if (vowelSuffixTranslations.includes(translation)) {
+      return (
+        getVowelSuffixPriority(outlineA) - getVowelSuffixPriority(outlineB)
+      );
+    }
+
+    let outlineALengthWithAllPenalties = outlineA.length;
+    let outlineBLengthWithAllPenalties = outlineB.length;
+
+    outlineALengthWithAllPenalties += penaliseStars(outlineA, translation);
+    outlineBLengthWithAllPenalties += penaliseStars(outlineB, translation);
+
+    outlineALengthWithAllPenalties += penaliseSlashes(outlineA, translation);
+    outlineBLengthWithAllPenalties += penaliseSlashes(outlineB, translation);
+
+    if (outlineALengthWithAllPenalties === outlineBLengthWithAllPenalties) {
+      outlineALengthWithAllPenalties += penaliseStretchKeys(
+        outlineA,
+        outlineB,
+        translation
+      );
+      outlineBLengthWithAllPenalties += penaliseStretchKeys(
+        outlineB,
+        outlineA,
+        translation
+      );
+    }
+
+    return outlineALengthWithAllPenalties - outlineBLengthWithAllPenalties;
+  });
+  return arrayOfStrokesAndTheirSourceDictNames;
+}
+
+export default rankAffixes;

--- a/src/utils/transformingDictionaries/chooseOutlineForPhrase.test.ts
+++ b/src/utils/transformingDictionaries/chooseOutlineForPhrase.test.ts
@@ -309,7 +309,7 @@ describe("choose outline for phrase", () => {
           strokeLookupAttempts,
           precedingChar
         )
-      ).toEqual(["A*UT/SKROL", 1]);
+      ).toEqual(["O*EUT/SKROL", 1]);
     });
 
     it("with long", () => {

--- a/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
+++ b/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
@@ -296,7 +296,7 @@ describe("create stroke hint for phrase", () => {
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
         // ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
-      ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U");
+      ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD");
     });
 
     it("with prefix that is not a word that has trailing hyphen and a word", () => {
@@ -312,7 +312,7 @@ describe("create stroke hint for phrase", () => {
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
         // ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
-      ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U");
+      ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD");
     });
 
     it("with hyphenated compound word and suffix", () => {

--- a/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
+++ b/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
@@ -1815,6 +1815,30 @@ describe("create stroke hint for phrase", () => {
         );
         expect(result).toEqual("PWE/KET/*L");
       });
+
+      it("returns hints using the affix strokes with the longest translation available such as SAOUT/O*RS instead of SAOU/TOR/-S for 'suitors'", () => {
+        const emptyPersonalDictionaries: PersonalDictionaryNameAndContents[] =
+          [];
+        const wordOrPhraseMaterial = "suitors";
+        const result = createStrokeHintForPhrase(
+          wordOrPhraseMaterial,
+          createGlobalLookupDictionary(emptyPersonalDictionaries, [
+            [
+              {
+                "-S": "{^s}",
+                "O*R": "{^or}",
+                "O*RS": "{^ors}",
+                "SAOU/TOR": "suitor",
+                "SAOUT": "suit",
+                "SAOUT/TOR": "suitor",
+              },
+              LATEST_TYPEY_TYPE_FULL_DICT_NAME,
+            ],
+          ]),
+          AffixList.getSharedInstance()
+        );
+        expect(result).toEqual("SAOUT/O*RS");
+      });
     });
   });
 

--- a/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
+++ b/src/utils/transformingDictionaries/createStrokeHintForPhrase.test.ts
@@ -216,7 +216,8 @@ describe("create stroke hint for phrase", () => {
       // expect(createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)).toEqual("SKHRAPL/TP*/O*/O*");
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("SKHRAPL/TP*/KWRO/KWRO");
+        // ).toEqual("SKHRAPL/TP*/KWRO/KWRO");
+      ).toEqual("SKHRAPL/TP*/SKWRAO");
     });
 
     it("with and unknown word and trailing exclamation mark", () => {
@@ -225,7 +226,8 @@ describe("create stroke hint for phrase", () => {
       // expect(createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)).toEqual("TP*/O*/O*/SKHRAPL");
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("TP*/KWRO/KWRO/SKHRAPL");
+        // ).toEqual("TP*/KWRO/KWRO/SKHRAPL");
+      ).toEqual("TP*/SKWRAO/SKHRAPL");
     });
 
     it("with preceding double quotes and capital letter", () => {
@@ -293,7 +295,8 @@ describe("create stroke hint for phrase", () => {
       // expect(createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)).toEqual("KWAS/KWREU/KR*/O*/TPH*/TP*/*U/STKPW*/STKPW*/HR*/*E/TK*");
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
+        // ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
+      ).toEqual("KWAS/KWREU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U");
     });
 
     it("with prefix that is not a word that has trailing hyphen and a word", () => {
@@ -308,7 +311,8 @@ describe("create stroke hint for phrase", () => {
       // expect(createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)).toEqual("TKPWHRAOEU/KR*/O*/TPH*/TP*/*U/STKPW*/STKPW*/HR*/*E/TK*");
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
+        // ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D");
+      ).toEqual("TKPWHRAOEU/KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U");
     });
 
     it("with hyphenated compound word and suffix", () => {
@@ -759,7 +763,8 @@ describe("create stroke hint for phrase", () => {
       // expect(createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)).toEqual("1-Z -9Z 1/THOUZ TPHOUZ 1-Z/HUPB/HUPB #SO/W-B/THUZ");
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("1-Z/-9Z/1/THOUZ/TPHOUZ/1-Z/HUPB/HUPB/#SO/W-B/THUZ");
+        // ).toEqual("1-Z/-9Z/1/THOUZ/TPHOUZ/1-Z/HUPB/HUPB/#SO/W-B/THUZ");
+      ).toEqual("1-Z/-9Z/1/THOUZ/TPHOUZ/1/0/THO*EUPB/#SO/W-B/THUZ");
     });
 
     it("returns string with double numbers", () => {
@@ -825,7 +830,8 @@ describe("create stroke hint for phrase", () => {
       let wordOrPhraseMaterial = "kettle:10";
       expect(
         createStrokeHintForPhrase(wordOrPhraseMaterial, globalLookupDictionary)
-      ).toEqual("KET/*L/10*BG");
+        // ).toEqual("KET/*L/10*BG");
+      ).toEqual("KET/*L/10BG");
     });
 
     xit("showing good stroke hint for gibberish word and suffix with one hyphen", () => {
@@ -1636,7 +1642,8 @@ describe("create stroke hint for phrase", () => {
       );
       // expect(result).toEqual("A*/TK*/STKPW*/*E");
       // expect(result).toEqual("A/TK*/STKPW*/*E");
-      expect(result).toEqual("A*/TK*/STKPW*/SKWR*E");
+      // expect(result).toEqual("A*/TK*/STKPW*/SKWR*E");
+      expect(result).toEqual("A*ED/STKPW*/SKWRE");
     });
   });
 
@@ -1656,7 +1663,8 @@ describe("create stroke hint for phrase", () => {
         ])
       );
       // expect(result).toEqual("*URP/A*RB/*T/*EU/O*/P*/*EU/A*/TPH*");
-      expect(result).toEqual("*URP/A*RB/*T/SKWREU/KWRO/*P/SKWREU/KWRA/*PB");
+      // expect(result).toEqual("*URP/A*RB/*T/SKWREU/KWRO/*P/SKWREU/KWRA/*PB");
+      expect(result).toEqual("*URP/A*RB/*T/KWRO*E/*P/KWRAPB");
     });
   });
 
@@ -1681,7 +1689,8 @@ describe("create stroke hint for phrase", () => {
           ],
         ])
       );
-      expect(result).toEqual("PH-BG/KEPB/*PB/KWRA");
+      // expect(result).toEqual("PH-BG/KEPB/*PB/KWRA");
+      expect(result).toEqual("PH-BG/KEPB/*PB/SKWRA");
     });
   });
 
@@ -2258,7 +2267,8 @@ describe("create stroke hint for phrase", () => {
         AffixList.getSharedInstance()
       );
       // expect(result).toEqual("SEF/TPH*/O*/T*/A*/R*/*E/A*/HR*/W*/O*/R*/TK*");
-      expect(result).toEqual("SEF/TPH*/O*/T*/A*/R*/*E/A*/HR*/W*/KWRO/R*D");
+      // expect(result).toEqual("SEF/TPH*/O*/T*/A*/R*/*E/A*/HR*/W*/KWRO/R*D");
+      expect(result).toEqual("SEF/TPH*/O*/T*/A*R/SKWRE/A*L/WO*RD");
     });
 
     it('returns strokes, stroke, and number of attempts for “"Lady-bird,”', () => {

--- a/src/utils/transformingDictionaries/rankOutlines/rankOutlines.ts
+++ b/src/utils/transformingDictionaries/rankOutlines/rankOutlines.ts
@@ -10,6 +10,7 @@ import type {
   StrokeAndDictionaryAndNamespace,
 } from "../../../types";
 
+// This function shares a lot of code with rankAffixes but handles all dictionary entries
 function rankOutlines(
   arrayOfStrokesAndTheirSourceDictNames: StrokeAndDictionaryAndNamespace[],
   misstrokesJSON: StenoDictionary,

--- a/src/utils/transformingDictionaries/transformingDictionaries.fixtures.ts
+++ b/src/utils/transformingDictionaries/transformingDictionaries.fixtures.ts
@@ -1533,6 +1533,7 @@ const testSuffixesDict = {
   "*FP": "{^ch}",
   "*FPL": "{^sm}",
   "*L": "{^le}",
+  "*LD": "{^led}",
   "*P": "{^p}",
   "*PB": "{^n}",
   "*PBD": "{^nd}",

--- a/src/utils/transformingDictionaries/transformingDictionaries.fixtures.ts
+++ b/src/utils/transformingDictionaries/transformingDictionaries.fixtures.ts
@@ -599,7 +599,7 @@ const testPrefixesDict = {
   "A*RT/RO": "{arthro^}",
   "A*T/RO": "{athero^}",
   "A*T/ROE": "{athero^}",
-  "A*UT": "{auto^}",
+  // "A*UT": "{auto^}", // misstroke
   "A/PHAOEB": "{ameb^}",
   "A/PHEUG/TKA/HRO": "{amygdalo^}",
   "A/PHO*EUPB": "{amino^}",

--- a/src/utils/transformingDictionaries/transformingDictionaries.test.ts
+++ b/src/utils/transformingDictionaries/transformingDictionaries.test.ts
@@ -291,7 +291,7 @@ describe("generate dictionary entries", () => {
         { phrase: "'sinatra'", stroke: "AE HRO*ER/STPHAT/RA AE" },
         {
           phrase: "'confuzzled'",
-          stroke: "AE KAUPB/TP*/*U/STKPW*/STKPW*/HR*/-D AE",
+          stroke: "AE KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U AE",
         },
         { phrase: "and! and", stroke: "SKP SKHRAPL SKP" },
         { phrase: "andx and", stroke: "A*/TPH*/TK*/KP* SKP" },

--- a/src/utils/transformingDictionaries/transformingDictionaries.test.ts
+++ b/src/utils/transformingDictionaries/transformingDictionaries.test.ts
@@ -291,7 +291,7 @@ describe("generate dictionary entries", () => {
         { phrase: "'sinatra'", stroke: "AE HRO*ER/STPHAT/RA AE" },
         {
           phrase: "'confuzzled'",
-          stroke: "AE KAUPB/TP*/*U/STKPW*/STKPW*/*LD/A*U AE",
+          stroke: "AE KAUPB/TP*/*U/STKPW*/STKPW*/*LD AE",
         },
         { phrase: "and! and", stroke: "SKP SKHRAPL SKP" },
         { phrase: "andx and", stroke: "A*/TPH*/TK*/KP* SKP" },


### PR DESCRIPTION
This PR contributes to addressing: https://github.com/didoesdigital/steno-dictionaries/issues/174

Related PRs:

- https://github.com/didoesdigital/typey-type-cli/pull/16
- https://github.com/didoesdigital/steno-dictionaries/pull/626

In particular, it updates how Typey Type ranks affixes for adding to the shared `affixList` used by stroke hints and custom lesson generation to try select only the "best" outline for each affix in the global lookup dictionary (which may be based on Typey Type or imported personal dictionaries). It also selects longer affix translations when attempting to split up words to create stroke hints. Overall, this should improve the quality of stroke hints across the board. There are some exceptions where the hint might be slightly worse depending on how you like to split up words. For example, the hint for `repented` changed from `RE/PEPBT/-D` to `REP/EPBT/-D`, which is not how I'd naturally stroked that word. 