### PR TITLE
Fix incorrectly set Finished props

### DIFF
--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -382,7 +382,7 @@ const Lesson = ({
               toggleHideOtherSettings={toggleHideOtherSettings}
               metadata={metadata}
               lesson={lesson}
-              lessonLength={propsLesson.presentedMaterial.length}
+              lessonLength={lessonLength}
               lessonTitle={lessonTitle}
               metWords={metWords}
               path={lesson?.path}
@@ -400,7 +400,7 @@ const Lesson = ({
               totalNumberOfRetainedWords={totalNumberOfRetainedWords}
               totalNumberOfMistypedWords={totalNumberOfMistypedWords}
               totalNumberOfHintedWords={totalNumberOfHintedWords}
-              totalWordCount={propsLesson.presentedMaterial.length}
+              totalWordCount={totalWordCount}
             />
           </main>
         </DocumentTitle>


### PR DESCRIPTION
This fixes a bug where on the Finished view, it was impossible to increase the "Start from word" setting greater than the original length of the lesson