### PR TITLE
Convert `App.js` to `App.tsx`

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,6 +79,7 @@ describe(App, () => {
     const [userSettings, setUserSettings] = useAtom(userSettingsState)
     const [globalUserSettings, setGlobalUserSettings] = useAtom(globalUserSettingsState)
     const lessonIndex = useLessonIndexWithFallback()
+    // @ts-ignore
     return <StateLoggingApp {...{
       location,
       history,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,9 +215,7 @@ class App extends Component {
         : this.props.userSettings.spacePlacement === "spaceAfterOutput"
         ? newMetWord + " "
         : newMetWord;
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const meetingsCount = newMetWordsState[phraseText] || 0;
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     newMetWordsState[phraseText] = meetingsCount + 1;
     this.setState({ metWords: newMetWordsState });
     writePersonalPreferences("metWords", newMetWordsState);
@@ -668,7 +666,6 @@ class App extends Component {
   }
 
 
-  // @ts-expect-error TS(7008) FIXME: Member 'markupBuffer' implicitly has an 'any[]' ty... Remove this comment to see the full error message
   markupBuffer = [];
   updateBufferTimer = null;
 
@@ -983,7 +980,6 @@ class App extends Component {
                 location: this.props.location,
                 completedMaterial,
                 presentedMaterialCurrentItem,
-                // @ts-expect-error TS(2322) FIXME: Type '{ sourceMaterial: { phrase: string; stroke: ... Remove this comment to see the full error message
                 stateLesson,
                 upcomingMaterial
               }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,11 +45,13 @@ class App extends Component {
   // @ts-expect-error TS(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
   constructor(props) {
     super(props);
+    // @ts-ignore
     this.charsPerWord = 5;
     // When updating default state for anything stored in local storage,
     // add the same default to load/set personal preferences code and test.
     let metWordsFromStorage = loadPersonalPreferences()[0];
     let startingMetWordsToday = loadPersonalPreferences()[0];
+    // @ts-ignore
     this.appFetchAndSetupGlobalDict = fetchAndSetupGlobalDict.bind(this);
 
     this.state = {
@@ -99,6 +101,7 @@ class App extends Component {
   }
 
   componentDidMount() {
+    // @ts-ignore
     this.setPersonalPreferences();
   }
 
@@ -109,6 +112,7 @@ class App extends Component {
    */
   // @ts-expect-error TS(7006) FIXME: Parameter 'prevProps' implicitly has an 'any' type... Remove this comment to see the full error message
   componentDidUpdate(prevProps) {
+    // @ts-ignore
     const curUserSettings = this.props.userSettings;
     const prevUserSettings = prevProps.userSettings;
     if (
@@ -125,6 +129,7 @@ class App extends Component {
       curUserSettings.retainedWords !== prevUserSettings.retainedWords ||
       curUserSettings.simpleTypography !== prevUserSettings.simpleTypography
     ) {
+      // @ts-ignore
       this.setupLesson();
     }
   }
@@ -165,6 +170,7 @@ class App extends Component {
       ...prevState,
       actualText: '',
       currentLessonStrokes: currentLessonStrokes,
+      // @ts-ignore
       currentPhraseID: this.state.lesson.presentedMaterial.length,
       previousCompletedPhraseAsTyped: '',
       currentPhraseAttempts: [],
@@ -179,6 +185,7 @@ class App extends Component {
     if (this.shouldUpdateLessonsProgress(newState)) {
       let lessonsProgress = this.getUpdatedLessonsProgress({lessonPath: prevState.lesson.path,
                                                             lesson: prevState.lesson,
+      // @ts-ignore
                                                             userSettings: this.props.userSettings,
                                                             prevLessonsProgress: prevState.lessonsProgress,
                                                             metWords: prevState.metWords});
@@ -189,12 +196,16 @@ class App extends Component {
   }
 
   startTimer() {
+    // @ts-ignore
     this.intervalID = window.setInterval(this.updateWPM.bind(this), 1000);
   }
 
   stopTimer() {
+    // @ts-ignore
     if (this.intervalID) {
+      // @ts-ignore
       clearInterval(this.intervalID);
+      // @ts-ignore
       this.intervalID = null;
     }
   }
@@ -208,10 +219,13 @@ class App extends Component {
 
   // @ts-expect-error TS(7006) FIXME: Parameter 'newMetWord' implicitly has an 'any' typ... Remove this comment to see the full error message
   updateMetWords(newMetWord) {
+    // @ts-ignore
     const newMetWordsState = Object.assign({}, this.state.metWords);
     const phraseText =
+      // @ts-ignore
       this.props.userSettings.spacePlacement === "spaceBeforeOutput"
         ? " " + newMetWord
+        // @ts-ignore
         : this.props.userSettings.spacePlacement === "spaceAfterOutput"
         ? newMetWord + " "
         : newMetWord;
@@ -223,7 +237,9 @@ class App extends Component {
 
   // @ts-expect-error TS(7006) FIXME: Parameter 'source' implicitly has an 'any' type.
   setPersonalPreferences(source) {
+    // @ts-ignore
     let metWordsFromStateOrArg = this.state.metWords;
+    // @ts-ignore
     let lessonsProgressState = this.state.lessonsProgress;
     if (source && source !== '') {
       try {
@@ -364,6 +380,7 @@ class App extends Component {
     // let stenoLayout = "stenoLayoutAmericanSteno";
     // if (this.props.userSettings) { stenoLayout = this.props.userSettings.stenoLayout; }
 
+    // @ts-ignore
     this.appFetchAndSetupGlobalDict(null).then(() => {
       // grab metWords, trim spaces, and sort by times seen
       let myWords = createWordListFromMetWords(metWordsFromStorage).join("\n");
@@ -374,6 +391,7 @@ class App extends Component {
         // let result = parseWordList(myWords);
       if (result && result.length > 0) {
         // look up strokes for each word
+        // @ts-ignore
         let lessonWordsAndStrokes = generateListOfWordsAndStrokes(result, this.state.globalLookupDictionary);
         if (lessonWordsAndStrokes && lessonWordsAndStrokes.length > 0) {
           // @ts-expect-error TS(2339) FIXME: Property 'sourceMaterial' does not exist on type '... Remove this comment to see the full error message
@@ -409,9 +427,11 @@ class App extends Component {
       this.setupLesson({
         currentPhraseID: 0,
         lesson: lesson,
+        // @ts-ignore
         focusTriggerInt: this.state.focusTriggerInt + 1
       });
     })
+    // @ts-ignore
     .catch(error => {
       console.error(error);
       // this.showDictionaryErrorNotification();
@@ -421,8 +441,10 @@ class App extends Component {
   // @ts-expect-error TS(7006) FIXME: Parameter 'lessonProps' implicitly has an 'any' ty... Remove this comment to see the full error message
   setupLesson(lessonProps) {
     const newState = {...this.state, ...lessonProps};
+    // @ts-ignore
     const revisionMode = lessonProps?.revisionMode ?? this.props.revisionMode;
     const revisionMaterial = newState.revisionMaterial;
+    // @ts-ignore
     const userSettings = this.props.userSettings;
     const lessonPath = newState.lesson.path;
     let newLesson = Object.assign({}, newState.lesson);
@@ -540,6 +562,7 @@ class App extends Component {
         this.setState({lessonNotFound: false});
         let lesson = parseLesson(lessonText, path);
         if (
+          // @ts-ignore
           this.props.globalUserSettings.experiments && !!this.props.globalUserSettings.experiments.stenohintsonthefly &&
           !path.includes("phrasing") &&
           !path.includes("prefixes") &&
@@ -548,7 +571,9 @@ class App extends Component {
           !path.includes("collections/tech")
         ) {
 
+          // @ts-ignore
           this.appFetchAndSetupGlobalDict(null).then(() => {
+            // @ts-ignore
             let lessonWordsAndStrokes = generateListOfWordsAndStrokes(lesson['sourceMaterial'].map(i => i.phrase), this.state.globalLookupDictionary);
               lesson.sourceMaterial = lessonWordsAndStrokes;
               lesson.presentedMaterial = lessonWordsAndStrokes;
@@ -557,15 +582,21 @@ class App extends Component {
             this.setupLesson({
               lesson: lesson,
               currentPhraseID: 0,
+              // @ts-ignore
               focusTriggerInt: this.state.focusTriggerInt + 1
             });
           });
         }
+        // @ts-ignore
         else if (this.props.userSettings.showStrokesAsList) {
+          // @ts-ignore
           const shouldUsePersonalDictionaries = this.state.personalDictionaries
+          // @ts-ignore
             && Object.entries(this.state.personalDictionaries).length > 0
+            // @ts-ignore
             && !!this.state.personalDictionaries.dictionariesNamesAndContents;
 
+            // @ts-ignore
           this.appFetchAndSetupGlobalDict(
             // @ts-expect-error TS(2345) FIXME: Argument of type '{ dictionariesNamesAndContents: ... Remove this comment to see the full error message
             shouldUsePersonalDictionaries ? this.state.personalDictionaries : null
@@ -574,8 +605,10 @@ class App extends Component {
               this.setupLesson({
                 lesson: lesson,
                 currentPhraseID: 0,
+                // @ts-ignore
                 focusTriggerInt: this.state.focusTriggerInt + 1
               });
+              // @ts-ignore
             }).catch((error) =>
               console.error("failed to fetch and setup global dictionary", error)
             );
@@ -584,6 +617,7 @@ class App extends Component {
           this.setupLesson({
             lesson: lesson,
             currentPhraseID: 0,
+            // @ts-ignore
             focusTriggerInt: this.state.focusTriggerInt + 1
           });
         }
@@ -596,6 +630,7 @@ class App extends Component {
   }
 
   startCustomLesson() {
+    // @ts-ignore
     let lesson = Object.assign({}, this.state.customLesson);
     lesson.title = 'Custom'
     this.setupLesson({
@@ -609,6 +644,7 @@ class App extends Component {
     if (event && event.target) {
       let providedText = event.target.value || '';
       let [lesson, validationState, validationMessages] = parseCustomMaterial(providedText);
+      // @ts-ignore
       let customLesson = Object.assign({}, this.state.customLesson);
       // @ts-expect-error TS(2339) FIXME: Property 'length' does not exist on type 'string |... Remove this comment to see the full error message
       if (validationMessages && validationMessages.length < 1) { customLesson = lesson; }
@@ -623,6 +659,7 @@ class App extends Component {
     }
     else { // for navigating straight to custom lesson page without setup
     // TODO: is this the place where I should set a default empty custom lesson?
+    // @ts-ignore
       let lesson = Object.assign({}, this.state.customLesson);
       lesson.title = 'Custom'
       this.setupLesson({
@@ -640,6 +677,7 @@ class App extends Component {
     this.stopLesson();
     this.setupLesson({
       revisionMaterial: newRevisionMaterial,
+      // @ts-ignore
       focusTriggerInt: this.state.focusTriggerInt + 1,
       revisionMode: true,
     });
@@ -650,6 +688,7 @@ class App extends Component {
     event.preventDefault();
     this.stopLesson();
     this.setupLesson({
+      // @ts-ignore
       focusTriggerInt: this.state.focusTriggerInt + 1,
       revisionMode: false
     });
@@ -676,11 +715,13 @@ class App extends Component {
     // const batchUpdate = document.cookie.indexOf("batchUpdate=1")>=0;
     const batchUpdate = true;
     if(!batchUpdate) {
+      // @ts-ignore
       this.processBuffer(actualText);
       return;
     }
     // Immediately update the text in the input field
     this.setState({ actualText });
+    // @ts-ignore
     this.markupBuffer.push({text: actualText, time: Date.now()});
 
     if (this.updateBufferTimer) {
@@ -747,6 +788,7 @@ class App extends Component {
       matchSplitText(state.lesson.presentedMaterial[state.currentPhraseID].phrase,
                      actualText,
                      state.lesson.settings,
+                     // @ts-ignore
                      this.props.userSettings);
 
     if (state.lesson.settings.ignoredChars) {
@@ -767,10 +809,13 @@ class App extends Component {
     currentPhraseAttempts.push({
       text: actualText,
       time: time,
+      // @ts-ignore
       numberOfMatchedWordsSoFar: (state.totalNumberOfMatchedChars + numberOfMatchedChars) / this.charsPerWord,
       hintWasShown: shouldShowStroke(state.showStrokesInLesson,
+                                     // @ts-ignore
                                      this.props.userSettings.showStrokes,
                                      state.repetitionsRemaining,
+                                     // @ts-ignore
                                      this.props.userSettings.hideStrokesOnLastRepetition)
     });
 
@@ -778,6 +823,7 @@ class App extends Component {
       ...state,
       currentPhraseAttempts: currentPhraseAttempts,
       numberOfMatchedChars: numberOfMatchedChars,
+      // @ts-ignore
       totalNumberOfMatchedWords: (state.totalNumberOfMatchedChars + numberOfMatchedChars) / this.charsPerWord,
       actualText: actualText,
     };
@@ -791,6 +837,7 @@ class App extends Component {
     const accurateStroke = phraseMisstrokes.strokeAccuracy; // false
     const attempts = phraseMisstrokes.attempts; // [" sign", " ss"]
 
+    // @ts-ignore
     if (!accurateStroke && !state.showStrokesInLesson && this.props.userSettings.showStrokesOnMisstroke) {
       state.showStrokesInLesson = true;
     }
@@ -800,6 +847,7 @@ class App extends Component {
       // e.g. unmatchedActual is "es" if "Frenches" is typed for "French"
       // In case of spaceAfterOutput, unmatchedChars is not empty and don't care here.
       // In case of spaceExact, proceed without checking next actual chars.
+      // @ts-ignore
       const excessLookFine = this.props.userSettings.spacePlacement === "spaceAfterOutput" || this.props.userSettings.spacePlacement === "spaceExact" || unmatchedActual.length === 0 || unmatchedActual[0] === " ";
       proceedToNextWord = numberOfUnmatchedChars === 0 && excessLookFine;
     } else {
@@ -809,12 +857,15 @@ class App extends Component {
       state.currentPhraseAttempts = []; // reset for next word
 
       const strokeHintShown = shouldShowStroke(state.showStrokesInLesson,
+                                               // @ts-ignore
                                                this.props.userSettings.showStrokes,
                                                state.repetitionsRemaining,
+                                               // @ts-ignore
                                                this.props.userSettings.hideStrokesOnLastRepetition);
 
       // NOTE: here is where completed phrases are pushed
       state.currentLessonStrokes.push({
+        // @ts-ignore
         numberOfMatchedWordsSoFar: (state.totalNumberOfMatchedChars + numberOfMatchedChars) / this.charsPerWord,
         word: state.lesson.presentedMaterial[state.currentPhraseID].phrase,
         typedText: actualText,
@@ -833,8 +884,10 @@ class App extends Component {
 
       if (!strokeHintShown && accurateStroke) {
         // Use the original text when recording to preserve case and spacing
+        // @ts-ignore
         const phraseText = this.props.userSettings.spacePlacement === 'spaceBeforeOutput'
           ? ' ' + state.lesson.presentedMaterial[state.currentPhraseID].phrase
+          // @ts-ignore
           : this.props.userSettings.spacePlacement === 'spaceAfterOutput'
           ? state.lesson.presentedMaterial[state.currentPhraseID].phrase + ' '
           : state.lesson.presentedMaterial[state.currentPhraseID].phrase;
@@ -847,6 +900,7 @@ class App extends Component {
         state.metWords[phraseText] = meetingsCount + 1;
       }
 
+      // @ts-ignore
       if (this.props.userSettings.speakMaterial) {
         const remaining = state.lesson.newPresentedMaterial.getRemaining();
         if (remaining && remaining.length > 0 && remaining[0].hasOwnProperty('phrase')) {
@@ -866,6 +920,7 @@ class App extends Component {
       state.targetStrokeCount = getTargetStrokeCount(nextItem || { phrase: '', stroke: 'TK-LS' });
       state.lesson.newPresentedMaterial.visitNext();
 
+      // @ts-ignore
       state.repetitionsRemaining = repetitionsRemaining(this.props.userSettings,
                                                         state.lesson.presentedMaterial,
                                                         state.currentPhraseID + 1);
@@ -897,16 +952,23 @@ class App extends Component {
 
   say(utteranceText: string) {
     synthesizeSpeech(utteranceText, {
+      // @ts-ignore
       voiceURI: this.props.userSettings.voiceURI,
+      // @ts-ignore
       voiceName: this.props.userSettings.voiceName,
+      // @ts-ignore
       stenoLayout: this.props.userSettings?.stenoLayout,
+      // @ts-ignore
       timeElapsedMillis: this.state.timer,
+      // @ts-ignore
       totalNumberOfMatchedWords: this.state.totalNumberOfMatchedWords,
     });
   }
 
   sayCurrentPhraseAgain() {
+    // @ts-ignore
     if (this.props.userSettings.speakMaterial) {
+      // @ts-ignore
       let currentPhrase = this.state.lesson.presentedMaterial[this.state.currentPhraseID];
       if (currentPhrase && currentPhrase.hasOwnProperty('phrase')) {
         this.say(currentPhrase.phrase);
@@ -926,6 +988,7 @@ class App extends Component {
   }
 
   presentUpcomingMaterial() {
+    // @ts-ignore
     return this.state.lesson.newPresentedMaterial ? this.state.lesson.newPresentedMaterial.getRemaining().slice().map(item => item.phrase) : [];
   }
 
@@ -933,6 +996,7 @@ class App extends Component {
     let completedMaterial = this.presentCompletedMaterial();
     let upcomingMaterial = this.presentUpcomingMaterial();
 
+    // @ts-ignore
     let stateLesson = this.state.lesson;
     if ((Object.keys(stateLesson).length === 0 && stateLesson.constructor === Object) || !stateLesson) {
       stateLesson = {
@@ -945,12 +1009,14 @@ class App extends Component {
       };
     }
 
+    // @ts-ignore
     let presentedMaterialCurrentItem = (stateLesson.presentedMaterial && stateLesson.presentedMaterial[this.state.currentPhraseID]) ? stateLesson.presentedMaterial[this.state.currentPhraseID] : { phrase: '', stroke: '' };
     return (
       <div id="js-app" className="app">
         <div className="flex flex-column justify-between min-vh-100">
           <AppMethodsContext.Provider value={
             {
+              // @ts-ignore
               appFetchAndSetupGlobalDict: this.appFetchAndSetupGlobalDict,
               setCustomLessonContent: setCustomLessonContent.bind(this),
               customiseLesson: customiseLesson.bind(this),
@@ -977,6 +1043,7 @@ class App extends Component {
           }>
             <AppRoutes
               appProps={{
+                // @ts-ignore
                 location: this.props.location,
                 completedMaterial,
                 presentedMaterialCurrentItem,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import AppMethodsContext from "./states/legacy/AppMethodsContext";
 import { synth, synthesizeSpeech } from "./utils/speechSynthesis";
 
 class App extends Component {
+  // @ts-expect-error TS(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
   constructor(props) {
     super(props);
     this.charsPerWord = 5;
@@ -89,7 +90,9 @@ class App extends Component {
       revisionMaterial: [
       ],
       startingMetWordsToday: startingMetWordsToday,
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{}' is not assignable to paramet... Remove this comment to see the full error message
       yourSeenWordCount: calculateSeenWordCount(metWordsFromStorage),
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{}' is not assignable to paramet... Remove this comment to see the full error message
       yourMemorisedWordCount: calculateMemorisedWordCount(metWordsFromStorage),
       focusTriggerInt: 0
     };
@@ -104,6 +107,7 @@ class App extends Component {
    * this should probably be moved inside the Lesson component
    * when and if the lesson state is moved into the Lesson component
    */
+  // @ts-expect-error TS(7006) FIXME: Parameter 'prevProps' implicitly has an 'any' type... Remove this comment to see the full error message
   componentDidUpdate(prevProps) {
     const curUserSettings = this.props.userSettings;
     const prevUserSettings = prevProps.userSettings;
@@ -125,11 +129,13 @@ class App extends Component {
     }
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'state' implicitly has an 'any' type.
   shouldUpdateLessonsProgress(state) {
     return state.lesson.path && !state.lesson.path.endsWith("/lessons/custom");
   }
 
   /* anything that needs to be done when stopping the lesson, excluding the state update */
+  // @ts-expect-error TS(7006) FIXME: Parameter 'state' implicitly has an 'any' type.
   applyStopLessonSideEffects(state) {
     this.stopTimer();
     synth?.cancel();
@@ -145,7 +151,9 @@ class App extends Component {
     this.setState(newState);
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'prevState' implicitly has an 'any' type... Remove this comment to see the full error message
   getFutureStateToStopLesson(prevState) {
+    // @ts-expect-error TS(7006) FIXME: Parameter 'copy' implicitly has an 'any' type.
     const currentLessonStrokes = prevState.currentLessonStrokes.map(copy => ({...copy}));
     for (let i = 0; i < currentLessonStrokes.length; i++) {
       if (currentLessonStrokes[i].accuracy === true) {
@@ -193,10 +201,12 @@ class App extends Component {
 
   updateWPM() {
     this.setState({
+      // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
       timer: new Date().getTime() - this.state.startTime
     });
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'newMetWord' implicitly has an 'any' typ... Remove this comment to see the full error message
   updateMetWords(newMetWord) {
     const newMetWordsState = Object.assign({}, this.state.metWords);
     const phraseText =
@@ -205,12 +215,15 @@ class App extends Component {
         : this.props.userSettings.spacePlacement === "spaceAfterOutput"
         ? newMetWord + " "
         : newMetWord;
+    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const meetingsCount = newMetWordsState[phraseText] || 0;
+    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     newMetWordsState[phraseText] = meetingsCount + 1;
     this.setState({ metWords: newMetWordsState });
     writePersonalPreferences("metWords", newMetWordsState);
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'source' implicitly has an 'any' type.
   setPersonalPreferences(source) {
     let metWordsFromStateOrArg = this.state.metWords;
     let lessonsProgressState = this.state.lessonsProgress;
@@ -227,7 +240,9 @@ class App extends Component {
       [metWordsFromStateOrArg, lessonsProgressState] = loadPersonalPreferences();
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{}' is not assignable to paramet... Remove this comment to see the full error message
     let calculatedYourSeenWordCount = calculateSeenWordCount(this.state.metWords);
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{}' is not assignable to paramet... Remove this comment to see the full error message
     let calculatedYourMemorisedWordCount = calculateMemorisedWordCount(this.state.metWords);
 
     // these two writePersonalPreferences calls were in a callback of setState - so 
@@ -244,6 +259,7 @@ class App extends Component {
     });
   }
 
+  // @ts-expect-error TS(7031) FIXME: Binding element 'lessonPath' implicitly has an 'an... Remove this comment to see the full error message
   getUpdatedLessonsProgress({lessonPath, lesson, userSettings, prevLessonsProgress, metWords}) {
     const lessonsProgress = {...prevLessonsProgress};
     // This is actually UNIQUE numberOfWordsSeen.
@@ -258,6 +274,7 @@ class App extends Component {
       numberOfWordsSeen = lessonsProgress[lessonPath].numberOfWordsSeen;
     }
 
+    // @ts-expect-error TS(7006) FIXME: Parameter 'copy' implicitly has an 'any' type.
     let material = lesson?.sourceMaterial ? lesson.sourceMaterial.map(copy => ({...copy})) : [{phrase: "the", stroke: "-T"}];
     if (userSettings.simpleTypography) {
       material = replaceSmartTypographyInPresentedMaterial.call(this, material, userSettings);
@@ -269,10 +286,13 @@ class App extends Component {
 
     let normalisedMetWords = {};
     Object.keys(metWords).forEach(function(key) {
+      // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       if (normalisedMetWords[key.trim()]) {
+        // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         normalisedMetWords[key.trim()] = metWords[key] + normalisedMetWords[key.trim()];
       }
       else {
+        // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         normalisedMetWords[key.trim()] = metWords[key];
       }
     });
@@ -288,16 +308,19 @@ class App extends Component {
       sourceMaterialPhrase = sourceMaterialPhrase.trim();
 
       // have you seen this word?
+      // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       if (normalisedMetWords[sourceMaterialPhrase] && normalisedMetWords[sourceMaterialPhrase] > 0) {
 
         // console.log(sourceMaterialPhrase);
         // have you seen this word and seen it in this lesson already?
         if (!(alreadyChecked.indexOf(sourceMaterialPhrase) > -1)) {
           alreadyChecked.push(sourceMaterialPhrase);
+          // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           if (normalisedMetWords[sourceMaterialPhrase] < 30) {
             seenAccumulator = seenAccumulator + 1;
             // console.log("Seen: " + sourceMaterialPhrase);
           }
+          // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           if (normalisedMetWords[sourceMaterialPhrase] > 29) {
             memorisedAccumulator = memorisedAccumulator + 1;
             // console.log("Memorised: " + sourceMaterialPhrase);
@@ -327,6 +350,7 @@ class App extends Component {
     return lessonsProgress;
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'providedMetWords' implicitly has an 'an... Remove this comment to see the full error message
   updateStartingMetWordsAndCounts(providedMetWords) {
     this.setState({
       startingMetWordsToday: providedMetWords,
@@ -336,6 +360,7 @@ class App extends Component {
   }
 
   // set user settings
+  // @ts-expect-error TS(7006) FIXME: Parameter 'metWordsFromStorage' implicitly has an ... Remove this comment to see the full error message
   setUpProgressRevisionLesson(metWordsFromStorage, newSeenOrMemorised) {
     let lesson = {};
     // let stenoLayout = "stenoLayoutAmericanSteno";
@@ -353,19 +378,30 @@ class App extends Component {
         // look up strokes for each word
         let lessonWordsAndStrokes = generateListOfWordsAndStrokes(result, this.state.globalLookupDictionary);
         if (lessonWordsAndStrokes && lessonWordsAndStrokes.length > 0) {
+          // @ts-expect-error TS(2339) FIXME: Property 'sourceMaterial' does not exist on type '... Remove this comment to see the full error message
           lesson.sourceMaterial = lessonWordsAndStrokes;
+          // @ts-expect-error TS(2339) FIXME: Property 'presentedMaterial' does not exist on typ... Remove this comment to see the full error message
           lesson.presentedMaterial = lessonWordsAndStrokes;
+          // @ts-expect-error TS(2339) FIXME: Property 'newPresentedMaterial' does not exist on ... Remove this comment to see the full error message
           lesson.newPresentedMaterial = new Zipper(lessonWordsAndStrokes);
+          // @ts-expect-error TS(2339) FIXME: Property 'settings' does not exist on type '{}'.
           lesson.settings = {
             ignoredChars: '',
             customMessage: ''
           };
+          // @ts-expect-error TS(2339) FIXME: Property 'path' does not exist on type '{}'.
           lesson.path = process.env.PUBLIC_URL + '/lessons/progress/seen/'
+          // @ts-expect-error TS(2339) FIXME: Property 'title' does not exist on type '{}'.
           lesson.title = 'Your revision words'
+          // @ts-expect-error TS(2339) FIXME: Property 'path' does not exist on type '{}'.
           if (newSeenOrMemorised[2]) { lesson.path = process.env.PUBLIC_URL + '/lessons/progress/memorised/'; }
+          // @ts-expect-error TS(2339) FIXME: Property 'title' does not exist on type '{}'.
           if (newSeenOrMemorised[2]) { lesson.title = 'Your memorised words'; }
+          // @ts-expect-error TS(2339) FIXME: Property 'title' does not exist on type '{}'.
           if (newSeenOrMemorised[1] && newSeenOrMemorised[2]) { lesson.title = 'Your words'; }
+          // @ts-expect-error TS(2339) FIXME: Property 'path' does not exist on type '{}'.
           if (newSeenOrMemorised[1] && newSeenOrMemorised[2]) { lesson.path = process.env.PUBLIC_URL + '/lessons/progress/'; }
+          // @ts-expect-error TS(2339) FIXME: Property 'subtitle' does not exist on type '{}'.
           lesson.subtitle = ''
         }
       }
@@ -384,6 +420,7 @@ class App extends Component {
     });
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'lessonProps' implicitly has an 'any' ty... Remove this comment to see the full error message
   setupLesson(lessonProps) {
     const newState = {...this.state, ...lessonProps};
     const revisionMode = lessonProps?.revisionMode ?? this.props.revisionMode;
@@ -405,9 +442,11 @@ class App extends Component {
 
     // Copy source or revision material to presented material:
     if (revisionMode) {
+      // @ts-expect-error TS(7006) FIXME: Parameter 'line' implicitly has an 'any' type.
       newLesson.presentedMaterial = revisionMaterial.map(line => ({...line}));
     }
     else {
+      // @ts-expect-error TS(7006) FIXME: Parameter 'line' implicitly has an 'any' type.
       newLesson.presentedMaterial = newLesson.sourceMaterial.map(line => ({...line}));
     }
 
@@ -496,6 +535,7 @@ class App extends Component {
     this.setState(newState);
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'path' implicitly has an 'any' type.
   handleLesson(path) {
     getLesson(path).then((lessonText) => {
       if (isLessonTextValid(lessonText)) {
@@ -529,6 +569,7 @@ class App extends Component {
             && !!this.state.personalDictionaries.dictionariesNamesAndContents;
 
           this.appFetchAndSetupGlobalDict(
+            // @ts-expect-error TS(2345) FIXME: Argument of type '{ dictionariesNamesAndContents: ... Remove this comment to see the full error message
             shouldUsePersonalDictionaries ? this.state.personalDictionaries : null
           )
             .then(() => {
@@ -565,11 +606,13 @@ class App extends Component {
     });
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   createCustomLesson(event) {
     if (event && event.target) {
       let providedText = event.target.value || '';
       let [lesson, validationState, validationMessages] = parseCustomMaterial(providedText);
       let customLesson = Object.assign({}, this.state.customLesson);
+      // @ts-expect-error TS(2339) FIXME: Property 'length' does not exist on type 'string |... Remove this comment to see the full error message
       if (validationMessages && validationMessages.length < 1) { customLesson = lesson; }
       this.setupLesson({
         lesson,
@@ -593,6 +636,7 @@ class App extends Component {
     return event;
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   reviseLesson(event, newRevisionMaterial) {
     event.preventDefault();
     this.stopLesson();
@@ -603,6 +647,7 @@ class App extends Component {
     });
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   restartLesson(event) {
     event.preventDefault();
     this.stopLesson();
@@ -612,18 +657,22 @@ class App extends Component {
     });
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'personalDictionaries' implicitly has an... Remove this comment to see the full error message
   updatePersonalDictionaries(personalDictionaries) {
     this.setState({personalDictionaries: personalDictionaries});
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'combinedLookupDictionary' implicitly ha... Remove this comment to see the full error message
   updateGlobalLookupDictionary(combinedLookupDictionary) {
     this.setState({globalLookupDictionary: combinedLookupDictionary});
   }
 
 
+  // @ts-expect-error TS(7008) FIXME: Member 'markupBuffer' implicitly has an 'any[]' ty... Remove this comment to see the full error message
   markupBuffer = [];
   updateBufferTimer = null;
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   updateMarkup(event) {
     let actualText = event.target.value;
     // TODO: once we're happy that this will be the permanent new default behaviour, remove all the `batchUpdate`-specific branching code and tests:
@@ -640,6 +689,7 @@ class App extends Component {
     if (this.updateBufferTimer) {
       clearTimeout(this.updateBufferTimer);
     }
+    // @ts-expect-error TS(2322) FIXME: Type 'Timeout' is not assignable to type 'null'.
     this.updateBufferTimer = setTimeout(() => {
       const buffer = this.markupBuffer;
       this.markupBuffer = [];
@@ -657,12 +707,14 @@ class App extends Component {
    *
    * @actualText param is not used - probably should be removed
    */
+  // @ts-expect-error TS(7006) FIXME: Parameter 'actualText' implicitly has an 'any' typ... Remove this comment to see the full error message
   processBuffer(actualText, buffer) {
     const stateCopy = {...this.state};
     const [newState, sideEffects] = this.getNewStateAndSideEffectsForBuffer(actualText,
                                                                             buffer,
                                                                             stateCopy,
                                                                             []);
+    // @ts-expect-error TS(7006) FIXME: Parameter 'effect' implicitly has an 'any' type.
     sideEffects.forEach(effect => effect());
     this.setState(newState);
   }
@@ -675,6 +727,7 @@ class App extends Component {
    * This function may be executed recursively, until all the strokes in the buffer
    * are processed.
    */
+  // @ts-expect-error TS(7023) FIXME: 'getNewStateAndSideEffectsForBuffer' implicitly ha... Remove this comment to see the full error message
   getNewStateAndSideEffectsForBuffer(actualText, buffer, state, sideEffects) {
     let time = Date.now();
     if (buffer) {
@@ -707,6 +760,7 @@ class App extends Component {
     const [numberOfMatchedChars, numberOfUnmatchedChars] = [matchedChars, unmatchedChars].map(text => text.length);
 
     // @ts-ignore this should be ok when currentPhraseAttempts is typed correctly instead of never[]
+    // @ts-expect-error TS(7006) FIXME: Parameter 'copy' implicitly has an 'any' type.
     const currentPhraseAttempts = state.currentPhraseAttempts.map(copy => ({...copy}));
 
     if (buffer) {
@@ -835,7 +889,9 @@ class App extends Component {
     } else if (buffer && proceedToNextWord && unmatchedActual.length > 0) {
       // Repetitively apply buffer with already accepted phrases excluded
       const newBuffer = buffer
+        // @ts-expect-error TS(7006) FIXME: Parameter 'stroke' implicitly has an 'any' type.
         .filter(stroke => stroke.text.length > matchedActual.length && stroke.text.startsWith(matchedActual))
+        // @ts-expect-error TS(7006) FIXME: Parameter 'stroke' implicitly has an 'any' type.
         .map(stroke => ({ text: stroke.text.slice(matchedActual.length), time: stroke.time }));
       return this.getNewStateAndSideEffectsForBuffer(null, newBuffer, state, sideEffects);
     }
@@ -861,12 +917,14 @@ class App extends Component {
     }
   }
 
+  // @ts-expect-error TS(7006) FIXME: Parameter 'currentState' implicitly has an 'any' t... Remove this comment to see the full error message
   isFinished(currentState) {
     const presentedMaterialLength = currentState.lesson?.presentedMaterial?.length || 0;
     return currentState.currentPhraseID === presentedMaterialLength;
   }
 
   presentCompletedMaterial() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.state.lesson.newPresentedMaterial ? this.state.lesson.newPresentedMaterial.getCompleted().map(item => item.phrase) : [];
   }
 
@@ -925,9 +983,11 @@ class App extends Component {
                 location: this.props.location,
                 completedMaterial,
                 presentedMaterialCurrentItem,
+                // @ts-expect-error TS(2322) FIXME: Type '{ sourceMaterial: { phrase: string; stroke: ... Remove this comment to see the full error message
                 stateLesson,
                 upcomingMaterial
               }}
+              // @ts-expect-error TS(2322) FIXME: Type '{ currentPhraseAttempts: never[]; currentPhr... Remove this comment to see the full error message
               appState={this.state}
             />
           </AppMethodsContext.Provider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ if (process.env.NODE_ENV === "production" && !process.env.REACT_APP_QA) {
 
 function AppWrapper(props: object) {
   const lessonIndex = useLessonIndexWithFallback();
+  // @ts-ignore
   return <App {...props} {...{ lessonIndex }} />;
 }
 

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -194,6 +194,7 @@ const Lesson = ({
           parsedParams
         );
         setUserSettings(newUserSettings);
+        // @ts-ignore
         setupLesson();
       }
       const urlSearchParams = new URLSearchParams(location.search);


### PR DESCRIPTION
This PR converts `App.js` to `App.tsx`.

- used `ts-migrate` to automatically add `// @ts-expect-error` lines like `// @ts-expect-error TS(7006) FIXME: Parameter 'prevProps' implicitly has an 'any' type... Remove this comment to see the full error message`. Manually brought back 1 `@ts-ignore` line that would have been replaced by the expect error line: `// @ts-ignore this should be ok when currentPhraseAttempts is typed correctly instead of never[]`
- removed the newly added `// @ts-expect-error` lines that were showing "unused expect error directives"
- added remaining `@ts-ignore` to `App.tsx` to make it compile, and to related TSX files

Related to https://github.com/didoesdigital/typey-type/issues/168 and specifically https://github.com/didoesdigital/typey-type/issues/168#issuecomment-2286097280