### PR TITLE
Fix "Start from word" and lesson length, and props

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -358,6 +358,7 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
                       lessonNotFound={appState.lessonNotFound}
                       lessonSubTitle={appState.lesson.subtitle}
                       lessonTitle={appState.lesson.title}
+                      lessonLength={appProps.stateLesson.presentedMaterial.length}
                       lesson={appState.lesson}
                       actualText={appState.actualText}
                       completedPhrases={appProps.completedMaterial}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -8,15 +8,10 @@ import CustomLessonSetup from "./custom/CustomLessonSetup";
 import Loadable from "react-loadable";
 import PageLoading from "../../components/PageLoading";
 
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
-type LessonsRoutingProps = Optional<
-  RouteComponentProps &
-    ComponentPropsWithoutRef<typeof Lesson> &
-    ComponentPropsWithoutRef<typeof CustomLessonSetup> &
-    ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator>,
-  // TODO: check this. it's not passed from parent
-  "lessonLength"
->;
+type LessonsRoutingProps = RouteComponentProps &
+  ComponentPropsWithoutRef<typeof Lesson> &
+  ComponentPropsWithoutRef<typeof CustomLessonSetup> &
+  ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator>;
 
 const AsyncCustomLessonGenerator = Loadable({
   loader: () => import("./custom/CustomLessonGenerator"),
@@ -81,7 +76,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -122,7 +116,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -163,7 +156,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -204,7 +196,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -245,7 +236,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -286,7 +276,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -328,7 +317,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -370,7 +358,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -412,7 +399,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -491,7 +477,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -533,7 +518,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}
@@ -575,7 +559,6 @@ const Lessons = ({
               globalLookupDictionary={globalLookupDictionary}
               globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               lesson={lesson}
-              // @ts-expect-error
               lessonLength={lessonLength}
               lessonNotFound={lessonNotFound}
               lessonSubTitle={lessonSubTitle}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -62,7 +62,7 @@ const Lessons = ({
   totalNumberOfRetainedWords,
   totalWordCount,
   upcomingPhrases,
-  focusTriggerInt
+  focusTriggerInt,
 }: LessonsRoutingProps) => {
   return (
     <Suspense fallback={<PageLoading />}>
@@ -185,6 +185,7 @@ const Lessons = ({
               totalNumberOfRetainedWords={totalNumberOfRetainedWords}
               totalWordCount={totalWordCount}
               upcomingPhrases={upcomingPhrases}
+              focusTriggerInt={focusTriggerInt}
               {...props}
             />
           )}
@@ -391,7 +392,7 @@ const Lessons = ({
               totalNumberOfRetainedWords={totalNumberOfRetainedWords}
               totalWordCount={totalWordCount}
               upcomingPhrases={upcomingPhrases}
-              focusTiggerInt={focusTriggerInt}
+              focusTriggerInt={focusTriggerInt}
               {...props}
             />
           )}


### PR DESCRIPTION
In https://github.com/didoesdigital/typey-type/commit/2339150dc561a8f0668391ee433f88aea4808a90 as shown in https://github.com/didoesdigital/typey-type/pull/216, I "fixed" an error that made the Finished "Start from word" setting input work properly but the parent component did not actually set the prop correctly so it turned off the behaviour to show "There are no words to write" and the "Start from word 1" button. 

This PR's change correctly sets the prop in the parent component and removes related optional type and expect-error directives.

This also fixes the `focusTriggerInt` prop for the Seen lesson, but that inadvertently worked anyway so this fix makes no difference to actual behaviour, just makes intent clearer.