### PR TITLE
Upgrade various Typey Type dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "chromatic": "echo \"Chromatic is set up with a private token for use by Di. This script exists to stop Chromatic offering to add it for me.\""
   },
   "resolutions": {
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.2",
     "minimist": "^1.2.6",
     "loader-utils": "^2.0.4"
   },
@@ -73,9 +75,9 @@
     "@types/howler": "^2.2.7",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.0.0",
-    "@types/react": "16.8.6",
+    "@types/react": "^17.0.2",
     "@types/react-document-title": "^2.0.5",
-    "@types/react-dom": "^16.8.5",
+    "@types/react-dom": "^17.0.2",
     "@types/react-loadable": "^5.5.6",
     "@types/react-modal": "^3.13.1",
     "@types/react-numeric-input": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-ga4": "^2.1.0",
     "react-loadable": "^5.5.0",
     "react-modal": "^3.14.4",
-    "react-numeric-input": "^2.2.0",
+    "react-numeric-input": "^2.2.3",
     "react-router-dom": "5.1.2",
     "react-tooltip": "^5.28.0",
     "react-transition-group": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ]
   },
   "engines": {
-    "node": ">=18.8.0"
+    "node": ">=20.0.0"
   },
   "eslintConfig": {
     "overrides": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "d3-time-format": "^4.1.0",
     "howler": "^2.2.3",
     "jotai": "^2.8.0",
-    "npm-run-all": "^4.1.1",
     "pure-react-carousel": "https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback",
     "query-string": "^6.2.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chromatic": "echo \"Chromatic is set up with a private token for use by Di. This script exists to stop Chromatic offering to add it for me.\""
   },
   "resolutions": {
-    "loader-utils": "^2.0.1"
+    "loader-utils": "^2.0.4"
   },
   "dependencies": {
     "@sentry/browser": "^6.17.9",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chromatic": "echo \"Chromatic is set up with a private token for use by Di. This script exists to stop Chromatic offering to add it for me.\""
   },
   "resolutions": {
+    "minimist": "^1.2.6",
     "loader-utils": "^2.0.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,8 +86,7 @@
     "jest-mock-random": "^1.1.1",
     "react-scripts": "5.0.1",
     "storybook": "^7.5.1",
-    "webpack": "5",
-    "why-did-you-update": "^0.1.1"
+    "webpack": "5"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16588,48 +16588,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.every@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.every@npm:4.6.0"
-  checksum: 10c0/67dd78cf01e3a4dbeaf6095d766e6868a229bb71a9a438d4a0bf5425326fd8e8ceee97c0079961697dae984e1052db6c31d4e7c54da7899f36a88702ed13cee1
-  languageName: node
-  linkType: hard
-
-"lodash.filter@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.filter@npm:4.6.0"
-  checksum: 10c0/bb65002f3ee02b94400b9d8728a46d3ac9fc3eb7df387b3c642f36eff82d716714283ca674889a29edae3c28ea8a4048e6c7bb90598670ab9c97b5d125bffda2
-  languageName: node
-  linkType: hard
-
-"lodash.isequal@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: 10c0/dfdb2356db19631a4b445d5f37868a095e2402292d59539a987f134a8778c62a2810c2452d11ae9e6dcac71fc9de40a6fedcb20e2952a15b431ad8b29e50e28f
-  languageName: node
-  linkType: hard
-
-"lodash.isfunction@npm:^3.0.8":
-  version: 3.0.9
-  resolution: "lodash.isfunction@npm:3.0.9"
-  checksum: 10c0/e88620922f5f104819496884779ca85bfc542efb2946df661ab3e2cd38da5c8375434c6adbedfc76dd3c2b04075d2ba8ec215cfdedf08ddd2e3c3467e8a26ccd
-  languageName: node
-  linkType: hard
-
-"lodash.isstring@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "lodash.isstring@npm:4.0.1"
-  checksum: 10c0/09eaf980a283f9eef58ef95b30ec7fee61df4d6bf4aba3b5f096869cc58f24c9da17900febc8ffd67819b4e29de29793190e88dc96983db92d84c95fa85d1c92
-  languageName: node
-  linkType: hard
-
-"lodash.keys@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "lodash.keys@npm:4.2.0"
-  checksum: 10c0/e21565d5076f4afc99e517d2b3dc84f05bc83e036f532c6e691c318f9ffd7eca3006365e0dafae1c5f046e344aaa722b01fe102b9f68e7cc63b79d2f9196f667
-  languageName: node
-  linkType: hard
-
 "lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
@@ -16644,31 +16602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.pick@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.pick@npm:4.4.0"
-  checksum: 10c0/a04c460b95d1aaa44e9513d1dacf72ea74d838da843e45831de9de64c303f13cdde1859702a6f4dcef417816898ffd47c6ae0614c957ac70245bed2809b8d2e2
-  languageName: node
-  linkType: hard
-
-"lodash.some@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.some@npm:4.6.0"
-  checksum: 10c0/9d3cdb1c8a2ed3d19b02ce146d4962a7859016f752b40fc143d78d3e70985259d6bea71c2c31b8e78f492830f49d755f1be2cdbf85461c54a523089e0c8c0e75
-  languageName: node
-  linkType: hard
-
 "lodash.sortby@npm:^4.7.0":
   version: 4.7.0
   resolution: "lodash.sortby@npm:4.7.0"
   checksum: 10c0/fc48fb54ff7669f33bb32997cab9460757ee99fafaf72400b261c3e10fde21538e47d8cfcbe6a25a31bcb5b7b727c27d52626386fc2de24eb059a6d64a89cdf5
-  languageName: node
-  linkType: hard
-
-"lodash.union@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.union@npm:4.6.0"
-  checksum: 10c0/6da7f72d1facd472f6090b49eefff984c9f9179e13172039c0debca6851d21d37d83c7ad5c43af23bd220f184cd80e6897e8e3206509fae491f9068b02ae6319
   languageName: node
   linkType: hard
 
@@ -22769,7 +22706,6 @@ __metadata:
     typescript: "npm:^4.7.4"
     usehooks-ts: "npm:^2.9.1"
     webpack: "npm:5"
-    why-did-you-update: "npm:^0.1.1"
   languageName: unknown
   linkType: soft
 
@@ -23647,25 +23583,6 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/449fa5c44ed120ccecfe18c433296a4978a7583bf2391c50abce13f76878d2476defde04d0f79db8165bdf432853c1f8389d0485ca6e8ebce3bbcded513d5e6a
-  languageName: node
-  linkType: hard
-
-"why-did-you-update@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "why-did-you-update@npm:0.1.1"
-  dependencies:
-    lodash.every: "npm:^4.6.0"
-    lodash.filter: "npm:^4.6.0"
-    lodash.isequal: "npm:^4.5.0"
-    lodash.isfunction: "npm:^3.0.8"
-    lodash.isstring: "npm:^4.0.1"
-    lodash.keys: "npm:^4.2.0"
-    lodash.pick: "npm:^4.4.0"
-    lodash.some: "npm:^4.6.0"
-    lodash.union: "npm:^4.6.0"
-  peerDependencies:
-    react: ">=15.0 || 0.14.x"
-  checksum: 10c0/7e4e3c5c014da485b899a178ed2c371959f540b0dfeff1bb1d68b0d72b94d6d7586d42ae1785c9145701535394ffabb2003a7681056d088c9d938b00c94867d2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16533,7 +16533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^2.0.1":
+"loader-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "loader-utils@npm:2.0.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19759,7 +19759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-numeric-input@npm:^2.2.0":
+"react-numeric-input@npm:^2.2.3":
   version: 2.2.3
   resolution: "react-numeric-input@npm:2.2.3"
   peerDependencies:
@@ -22549,7 +22549,7 @@ __metadata:
     react-ga4: "npm:^2.1.0"
     react-loadable: "npm:^5.5.0"
     react-modal: "npm:^3.14.4"
-    react-numeric-input: "npm:^2.2.0"
+    react-numeric-input: "npm:^2.2.3"
     react-router-dom: "npm:5.1.2"
     react-scripts: "npm:5.0.1"
     react-tooltip: "npm:^5.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17043,13 +17043,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 10c0/c143b0c199af4df7a55c7a37b6465cdd438acdc6a3a345ba0fe9d94dfcc2042263f650879bc73be607c843deeaeaadf39c864e55bc6d80b36a025eca1a062ee7
-  languageName: node
-  linkType: hard
-
 "minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8477,9 +8477,9 @@ __metadata:
   linkType: hard
 
 "@types/prop-types@npm:*":
-  version: 15.7.4
-  resolution: "@types/prop-types@npm:15.7.4"
-  checksum: 10c0/014bb826592fab01499931259969aafc21d5a8ff4ece3e3fb8e2b5186bed17656f7dcdccf9a98c27fee74d7d0697aa3f53ea971a72679597f0ca0c3d5ca585d3
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
   languageName: node
   linkType: hard
 
@@ -8513,21 +8513,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:<18.0.0":
-  version: 17.0.18
-  resolution: "@types/react-dom@npm:17.0.18"
-  dependencies:
-    "@types/react": "npm:^17"
-  checksum: 10c0/a787471157d66e834ee2afa57d81171c8cae26d3b0def23709da8256433d0b3c5c9f35c03913c9c4137f79acf78af9e2483ee1578197f77298344f33b7186791
-  languageName: node
-  linkType: hard
-
-"@types/react-dom@npm:^16.8.5":
-  version: 16.8.5
-  resolution: "@types/react-dom@npm:16.8.5"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/68e3901045deff8beb0a90931c6092a4d1bb980f741533831e9f493761dea6513f746149895a110fe89f76e0be85f1efd35ada1581d2b72e711d0d16d92cf4d2
+"@types/react-dom@npm:^17.0.2":
+  version: 17.0.26
+  resolution: "@types/react-dom@npm:17.0.26"
+  peerDependencies:
+    "@types/react": ^17.0.0
+  checksum: 10c0/8363921f08afe3f2ef82fe293301a0809ec646975fe9f5bfeb2e823f7237b97e47d27e1c6c2ffff27d15c12ab3cad1de6c77a737e37499fcc52793b0fd674f3f
   languageName: node
   linkType: hard
 
@@ -8589,46 +8580,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 17.0.37
-  resolution: "@types/react@npm:17.0.37"
+"@types/react@npm:^17.0.2":
+  version: 17.0.87
+  resolution: "@types/react@npm:17.0.87"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
+    "@types/scheduler": "npm:^0.16"
     csstype: "npm:^3.0.2"
-  checksum: 10c0/af440f6281bd700a3b65146ff955f230243c8137a3c902e111d1e4ab5bf77724bf0e979cee286e51c7db76e6cdd505cd213c557f04831ca03a1767f7a7fcadba
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:16.8.6":
-  version: 16.8.6
-  resolution: "@types/react@npm:16.8.6"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^2.2.0"
-  checksum: 10c0/6d6d82dbf04e6c06dfce3464484c1d2f9122ffc2657e7268e845cbb6f1f42ca34b13cccb383e8b008f1980e6f8163cbb6cf4be46fee0779c010562a4c67e01c7
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:>=16":
-  version: 18.2.33
-  resolution: "@types/react@npm:18.2.33"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/d3392785660d78121541403a5d1da57dc79e8ce402769251a626aa06a6886a6aaead868a01ee473661380ddd4ac79743de78853d69f652544da191d435f78afb
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17":
-  version: 17.0.52
-  resolution: "@types/react@npm:17.0.52"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10c0/df8662375c71eab90f9832bf388e210b337514ff0cfd260547c498b5a010a8bba980fa704b0e828070e83363c8d20a0a03e3e2fcd27d50649c3811b1279ea9ed
+  checksum: 10c0/42efa9d1fa7c6c5422ef1add693c23e35dab0df68265fd403a1c13193acdd972ed03cd5f1cea8e6b378503abb70f25da04ff24f4ef0468d2b8e25db6bd394363
   languageName: node
   linkType: hard
 
@@ -8648,10 +8607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/scheduler@npm:*":
-  version: 0.16.2
-  resolution: "@types/scheduler@npm:0.16.2"
-  checksum: 10c0/89a3a922f03609b61c270d534226791edeedcb1b06f0225d5543ac17830254624ef9d8a97ad05418e4ce549dd545bddf1ff28cb90658ff10721ad14556ca68a5
+"@types/scheduler@npm:^0.16":
+  version: 0.16.8
+  resolution: "@types/scheduler@npm:0.16.8"
+  checksum: 10c0/f86de504945b8fc41b1f391f847444d542e2e4067cf7e5d9bfeb5d2d2393d3203b1161bc0ef3b1e104d828dabfb60baf06e8d2c27e27ff7e8258e6e618d8c4ec
   languageName: node
   linkType: hard
 
@@ -11514,13 +11473,6 @@ __metadata:
   dependencies:
     cssom: "npm:~0.3.6"
   checksum: 10c0/863400da2a458f73272b9a55ba7ff05de40d850f22eb4f37311abebd7eff801cf1cd2fb04c4c92b8c3daed83fe766e52e4112afb7bc88d86c63a9c2256a7d178
-  languageName: node
-  linkType: hard
-
-"csstype@npm:^2.2.0":
-  version: 2.6.20
-  resolution: "csstype@npm:2.6.20"
-  checksum: 10c0/335027b633e2075e7ae55c417a2ac125358e3b9ea51fea3f40fe436180dd5ce50f2914f94c03f410adbdf0f8d68c2380a3846224b596b67e3100f9b7104fe3a8
   languageName: node
   linkType: hard
 
@@ -22511,9 +22463,9 @@ __metadata:
     "@types/howler": "npm:^2.2.7"
     "@types/jest": "npm:^28.1.3"
     "@types/node": "npm:^18.0.0"
-    "@types/react": "npm:16.8.6"
+    "@types/react": "npm:^17.0.2"
     "@types/react-document-title": "npm:^2.0.5"
-    "@types/react-dom": "npm:^16.8.5"
+    "@types/react-dom": "npm:^17.0.2"
     "@types/react-loadable": "npm:^5.5.6"
     "@types/react-modal": "npm:^3.13.1"
     "@types/react-numeric-input": "npm:^2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11178,19 +11178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "cross-spawn@npm:6.0.5"
-  dependencies:
-    nice-try: "npm:^1.0.4"
-    path-key: "npm:^2.0.1"
-    semver: "npm:^5.5.0"
-    shebang-command: "npm:^1.2.0"
-    which: "npm:^1.2.9"
-  checksum: 10c0/e05544722e9d7189b4292c66e42b7abeb21db0d07c91b785f4ae5fefceb1f89e626da2703744657b287e86dcd4af57b54567cef75159957ff7a8a761d9055012
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -16514,18 +16501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-json-file@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "load-json-file@npm:4.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.2"
-    parse-json: "npm:^4.0.0"
-    pify: "npm:^3.0.0"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10c0/6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
-  languageName: node
-  linkType: hard
-
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -16854,13 +16829,6 @@ __metadata:
   dependencies:
     map-or-similar: "npm:^1.5.0"
   checksum: 10c0/661bf69b7afbfad57f0208f0c63324f4c96087b480708115b78ee3f0237d86c7f91347f6db31528740b2776c2e34c709bcb034e1e910edee2270c9603a0a469e
-  languageName: node
-  linkType: hard
-
-"memorystream@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "memorystream@npm:0.3.1"
-  checksum: 10c0/4bd164657711d9747ff5edb0508b2944414da3464b7fe21ac5c67cf35bba975c4b446a0124bd0f9a8be54cfc18faf92e92bd77563a20328b1ccf2ff04e9f39b9
   languageName: node
   linkType: hard
 
@@ -17297,13 +17265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nice-try@npm:^1.0.4":
-  version: 1.0.5
-  resolution: "nice-try@npm:1.0.5"
-  checksum: 10c0/95568c1b73e1d0d4069a3e3061a2102d854513d37bcfda73300015b7ba4868d3b27c198d1dbbd8ebdef4112fc2ed9e895d4a0f2e1cce0bd334f2a1346dc9205f
-  languageName: node
-  linkType: hard
-
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -17440,7 +17401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
+"normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -17470,27 +17431,6 @@ __metadata:
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 10c0/95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
-  languageName: node
-  linkType: hard
-
-"npm-run-all@npm:^4.1.1":
-  version: 4.1.5
-  resolution: "npm-run-all@npm:4.1.5"
-  dependencies:
-    ansi-styles: "npm:^3.2.1"
-    chalk: "npm:^2.4.1"
-    cross-spawn: "npm:^6.0.5"
-    memorystream: "npm:^0.3.1"
-    minimatch: "npm:^3.0.4"
-    pidtree: "npm:^0.3.0"
-    read-pkg: "npm:^3.0.0"
-    shell-quote: "npm:^1.6.1"
-    string.prototype.padend: "npm:^3.0.0"
-  bin:
-    npm-run-all: bin/npm-run-all/index.js
-    run-p: bin/run-p/index.js
-    run-s: bin/run-s/index.js
-  checksum: 10c0/736ee39bd35454d3efaa4a2e53eba6c523e2e17fba21a18edcce6b221f5cab62000bef16bb6ae8aff9e615831e6b0eb25ab51d52d60e6fa6f4ea880e4c6d31f4
   languageName: node
   linkType: hard
 
@@ -17956,16 +17896,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "parse-json@npm:4.0.0"
-  dependencies:
-    error-ex: "npm:^1.3.1"
-    json-parse-better-errors: "npm:^1.0.1"
-  checksum: 10c0/8d80790b772ccb1bcea4e09e2697555e519d83d04a77c2b4237389b813f82898943a93ffff7d0d2406203bdd0c30dcf95b1661e3a53f83d0e417f053957bef32
-  languageName: node
-  linkType: hard
-
 "parse-json@npm:^5.0.0":
   version: 5.0.0
   resolution: "parse-json@npm:5.0.0"
@@ -18049,13 +17979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "path-key@npm:2.0.1"
-  checksum: 10c0/dd2044f029a8e58ac31d2bf34c34b93c3095c1481942960e84dd2faa95bbb71b9b762a106aead0646695330936414b31ca0bd862bf488a937ad17c8c5d73b32b
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^3.0.0, path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -18093,15 +18016,6 @@ __metadata:
   dependencies:
     isarray: "npm:0.0.1"
   checksum: 10c0/7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
-  languageName: node
-  linkType: hard
-
-"path-type@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "path-type@npm:3.0.0"
-  dependencies:
-    pify: "npm:^3.0.0"
-  checksum: 10c0/1332c632f1cac15790ebab8dd729b67ba04fc96f81647496feb1c2975d862d046f41e4b975dbd893048999b2cc90721f72924ad820acc58c78507ba7141a8e56
   languageName: node
   linkType: hard
 
@@ -18179,26 +18093,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pidtree@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "pidtree@npm:0.3.0"
-  bin:
-    pidtree: ./bin/pidtree.js
-  checksum: 10c0/8ba7f84f95270b980060a9c176e3fc9eaaf8255c7942b694ac60a27f52dda80f2001aefef951fae42b06f520f1abe784aa94678e04ae8fcd83cacd3c4e3931d6
-  languageName: node
-  linkType: hard
-
 "pify@npm:^2.3.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 10c0/551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
-  languageName: node
-  linkType: hard
-
-"pify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pify@npm:3.0.0"
-  checksum: 10c0/fead19ed9d801f1b1fcd0638a1ac53eabbb0945bf615f2f8806a8b646565a04a1b0e7ef115c951d225f042cca388fdc1cd3add46d10d1ed6951c20bd2998af10
   languageName: node
   linkType: hard
 
@@ -20114,17 +20012,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg@npm:3.0.0"
-  dependencies:
-    load-json-file: "npm:^4.0.0"
-    normalize-package-data: "npm:^2.3.2"
-    path-type: "npm:^3.0.0"
-  checksum: 10c0/65acf2df89fbcd506b48b7ced56a255ba00adf7ecaa2db759c86cc58212f6fd80f1f0b7a85c848551a5d0685232e9b64f45c1fd5b48d85df2761a160767eeb93
-  languageName: node
-  linkType: hard
-
 "read-pkg@npm:^5.2.0":
   version: 5.2.0
   resolution: "read-pkg@npm:5.2.0"
@@ -20980,7 +20867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.5.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -21204,15 +21091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-command@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "shebang-command@npm:1.2.0"
-  dependencies:
-    shebang-regex: "npm:^1.0.0"
-  checksum: 10c0/7b20dbf04112c456b7fc258622dafd566553184ac9b6938dd30b943b065b21dabd3776460df534cc02480db5e1b6aec44700d985153a3da46e7db7f9bd21326d
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -21222,24 +21100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shebang-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "shebang-regex@npm:1.0.0"
-  checksum: 10c0/9abc45dee35f554ae9453098a13fdc2f1730e525a5eb33c51f096cc31f6f10a4b38074c1ebf354ae7bffa7229506083844008dfc3bb7818228568c0b2dc1fff2
-  languageName: node
-  linkType: hard
-
 "shebang-regex@npm:^3.0.0":
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.6.1":
-  version: 1.7.2
-  resolution: "shell-quote@npm:1.7.2"
-  checksum: 10c0/656aefdcdc394560ca091140a58b95e97f43d5e14bb60ff4a92556ca48841e49af6e837441e887c7890c7a86ae8542960c90e460a86799b68c53271784909edb
   languageName: node
   linkType: hard
 
@@ -21703,16 +21567,6 @@ __metadata:
     regexp.prototype.flags: "npm:^1.4.1"
     side-channel: "npm:^1.0.4"
   checksum: 10c0/85bfc0c18b73b90b4a10771bd1afa4c6e42fc78885196dee680b45d023afc81cec6a9944f2f0e25d81f8e5643d5412df5a4649ea624ab375598c6dba0864c9a2
-  languageName: node
-  linkType: hard
-
-"string.prototype.padend@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "string.prototype.padend@npm:3.1.0"
-  dependencies:
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.17.0-next.1"
-  checksum: 10c0/d8ddb7dbffdc27294f7f2e4dd78d6e70e303fb66e3c856c3f233f55cb2df20d433ff45defe37def68f95dddd2f1b1053699e9bb454e8ea5231f08fa2ebef821b
   languageName: node
   linkType: hard
 
@@ -22685,7 +22539,6 @@ __metadata:
     howler: "npm:^2.2.3"
     jest-mock-random: "npm:^1.1.1"
     jotai: "npm:^2.8.0"
-    npm-run-all: "npm:^4.1.1"
     pure-react-carousel: "https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback"
     query-string: "npm:^6.2.0"
     react: "npm:^17.0.2"
@@ -23553,7 +23406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:


### PR DESCRIPTION
This PR:

- Updates minimum node to a maintained version
- Removes `why-did-you-update`
- Upgrades `loader-utils`
- Removes unused `npm-run-all` from dependencies, which should have been in `devDependencies` anyway
- Bumps `react-numeric-input` to `^2.2.3`
- Upgrades `minimist` to `^1.2.6` using `resolutions`
- Upgrades `@types/react` and `@types/react-dom` using `resolutions`