### PR TITLE
Don't run CI checks if actor is dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Just because a lot of dependabot issues can't be resolved until we escape create-react-app's react-scripts so let's avoid wasting energy on CI checks for dependabot until then.