### PR TITLE
Update Chromatic workflow on master/main branch

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -1,5 +1,7 @@
 name: Visual Regression Testing
 on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -31,5 +33,6 @@ jobs:
         uses: chromaui/action@v12.2.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          exitZeroOnChanges: false
+          exitZeroOnChanges: ${{ github.ref == 'refs/heads/master' && true || false }}
           skip: "dependabot/**"
+          dryRun: true

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -1,7 +1,7 @@
 name: Visual Regression Testing
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+  # pull_request:
+  #   types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -35,4 +35,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: ${{ github.ref == 'refs/heads/master' && true || false }}
           skip: "dependabot/**"
-          dryRun: true
+          # dryRun: true


### PR DESCRIPTION
If the branch is master/main and there are changes, then let the build pass anyway so it doesn't look broken. I want to do this instead of `--auto-accept-changes` so I can still see that it has a bad Chromatic snapshot in Chromatic on the master branch.