### PR TITLE
Upgrade to React Router v6

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import type { Preview } from "@storybook/react";
 
 import "../src/index.scss";
@@ -39,13 +39,13 @@ const preview: Preview = {
   decorators: [
     (Story) => (
       <Router basename="/typey-type">
-        <Switch>
+        <Routes>
           <Route>
             <div id="js-app" className="app">
               <Story />
             </div>
           </Route>
-        </Switch>
+        </Routes>
       </Router>
     ),
   ],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { MemoryRouter as Router, Route, Routes } from "react-router-dom";
 import type { Preview } from "@storybook/react";
 
 import "../src/index.scss";
@@ -38,13 +38,16 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <Router basename="/typey-type">
+      <Router basename="/typey-type" initialEntries={["/typey-type"]}>
         <Routes>
-          <Route>
-            <div id="js-app" className="app">
-              <Story />
-            </div>
-          </Route>
+          <Route
+            path="/"
+            element={
+              <div id="js-app" className="app">
+                <Story />
+              </div>
+            }
+          />
         </Routes>
       </Router>
     ),

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,7 +38,14 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <Router basename="/typey-type" initialEntries={["/typey-type"]}>
+      <Router
+        basename="/typey-type"
+        initialEntries={["/typey-type"]}
+        future={{
+          v7_relativeSplatPath: false,
+          v7_startTransition: false,
+        }}
+      >
         <Routes>
           <Route
             path="/"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@types/react-loadable": "^5.5.6",
     "@types/react-modal": "^3.13.1",
     "@types/react-numeric-input": "^2.2.4",
-    "@types/react-router-dom": "^5.3.3",
     "@types/react-transition-group": "^4.4.5",
     "chromatic": "^12.2.0",
     "eslint-plugin-storybook": "^0.6.15",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-loadable": "^5.5.0",
     "react-modal": "^3.14.4",
     "react-numeric-input": "^2.2.3",
-    "react-router-dom": "5.3.4",
+    "react-router-dom": "^6.30.1",
     "react-tooltip": "^5.28.0",
     "react-transition-group": "^2.4.0",
     "sass": "^1.49.8",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -128,7 +128,13 @@ describe(App, () => {
       );
     const loadPage = async ({ path, expectedFirstPhrase, settings }: Page) => {
       render(
-        <MemoryRouter initialEntries={[path]}>
+        <MemoryRouter
+          initialEntries={[path]}
+          future={{
+            v7_relativeSplatPath: false,
+            v7_startTransition: false,
+          }}
+        >
           <AppWithRouterInfo />
         </MemoryRouter>
       );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import App from "./App";
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useHistory, useLocation } from "react-router-dom";
+import { MemoryRouter, useNavigate, useLocation } from "react-router-dom";
 import React from "react";
 import fs from "node:fs/promises";
 import userEvent from "@testing-library/user-event";
@@ -75,14 +75,14 @@ describe(App, () => {
 
   function AppWithRouterInfo() {
     const location = useLocation();
-    const history = useHistory();
+    const navigate = useNavigate();
     const [userSettings, setUserSettings] = useAtom(userSettingsState)
     const [globalUserSettings, setGlobalUserSettings] = useAtom(globalUserSettingsState)
     const lessonIndex = useLessonIndexWithFallback()
-    // @ts-expect-error TS(2739) FIXME: Type '{ location: Location<unknown>; history: Hist... Remove this comment to see the full error message
+    // @ts-expect-error TS(2739) FIXME: Type '{ location: Location<unknown>; navigate: Hist... Remove this comment to see the full error message
     return <StateLoggingApp {...{
       location,
-      history,
+      navigate,
       userSettings,
       setUserSettings,
       globalUserSettings,

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -165,213 +165,259 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
       <Announcer />
       <div>
         <Routes>
-          <Route exact={true} path="/">
-            <div>
-              <Header />
+          <Route
+            path="/"
+            element={
+              <div>
+                <Header />
 
-              <DocumentTitle title="Typey Type for Stenographers">
-                <AsyncHome />
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/support">
-            <div>
-              <Header />
+                <DocumentTitle title="Typey Type for Stenographers">
+                  <AsyncHome />
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="support"
+            element={
+              <div>
+                <Header />
 
-              <DocumentTitle title={"Typey Type | About"}>
-                <ErrorBoundary>
-                  <AsyncSupport />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/writer">
-            <div>
-              <Header />
+                <DocumentTitle title={"Typey Type | About"}>
+                  <ErrorBoundary>
+                    <AsyncSupport />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="writer"
+            element={
+              <div>
+                <Header />
 
-              <DocumentTitle title={"Typey Type | Writer"}>
-                <ErrorBoundary>
-                  <AsyncWriter />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/games">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Games"}>
-                <ErrorBoundary>
-                  <AsyncGames
-                    globalLookupDictionary={appState.globalLookupDictionary}
-                    globalLookupDictionaryLoaded={
-                      appState.globalLookupDictionaryLoaded
-                    }
-                    metWords={appState.metWords}
-                    personalDictionaries={appState.personalDictionaries}
-                    startingMetWordsToday={appState.startingMetWordsToday}
-                  />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/break">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Take a break"}>
-                <ErrorBoundary>
-                  <AsyncBreak />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/contribute">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Contribute"}>
-                <ErrorBoundary>
-                  <AsyncContribute />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/progress">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Progress"}>
-                <ErrorBoundary>
-                  <Suspense fallback={<PageLoading pastDelay={true} />}>
-                    <AsyncProgress
+                <DocumentTitle title={"Typey Type | Writer"}>
+                  <ErrorBoundary>
+                    <AsyncWriter />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="games/*"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Games"}>
+                  <ErrorBoundary>
+                    <AsyncGames
+                      globalLookupDictionary={appState.globalLookupDictionary}
+                      globalLookupDictionaryLoaded={
+                        appState.globalLookupDictionaryLoaded
+                      }
                       metWords={appState.metWords}
-                      lessonsProgress={appState.lessonsProgress}
+                      personalDictionaries={appState.personalDictionaries}
                       startingMetWordsToday={appState.startingMetWordsToday}
-                      yourSeenWordCount={appState.yourSeenWordCount}
-                      yourMemorisedWordCount={appState.yourMemorisedWordCount}
                     />
-                  </Suspense>
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/flashcards">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Flashcards"}>
-                <AsyncFlashcards
-                  globalLookupDictionary={appState.globalLookupDictionary}
-                  globalLookupDictionaryLoaded={
-                    appState.globalLookupDictionaryLoaded
-                  }
-                  lessonpath="flashcards"
-                  locationpathname={location.pathname}
-                  personalDictionaries={appState.personalDictionaries}
-                />
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/lookup">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Lookup"}>
-                <ErrorBoundary>
-                  <AsyncLookup
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="break"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Take a break"}>
+                  <ErrorBoundary>
+                    <AsyncBreak />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="contribute"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Contribute"}>
+                  <ErrorBoundary>
+                    <AsyncContribute />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="progress"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Progress"}>
+                  <ErrorBoundary>
+                    <Suspense fallback={<PageLoading pastDelay={true} />}>
+                      <AsyncProgress
+                        metWords={appState.metWords}
+                        lessonsProgress={appState.lessonsProgress}
+                        startingMetWordsToday={appState.startingMetWordsToday}
+                        yourSeenWordCount={appState.yourSeenWordCount}
+                        yourMemorisedWordCount={appState.yourMemorisedWordCount}
+                      />
+                    </Suspense>
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="flashcards"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Flashcards"}>
+                  <AsyncFlashcards
                     globalLookupDictionary={appState.globalLookupDictionary}
                     globalLookupDictionaryLoaded={
                       appState.globalLookupDictionaryLoaded
                     }
+                    lessonpath="flashcards"
+                    locationpathname={location.pathname}
                     personalDictionaries={appState.personalDictionaries}
                   />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/dictionaries">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Dictionaries"}>
-                <ErrorBoundary>
-                  <AsyncDictionaries
-                    globalLookupDictionary={appState.globalLookupDictionary}
-                    globalLookupDictionaryLoaded={
-                      appState.globalLookupDictionaryLoaded
-                    }
-                    personalDictionaries={appState.personalDictionaries}
-                  />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route path="/lessons">
-            <div>
-              <Header />
-              <DocumentTitle title={"Typey Type | Lessons"}>
-                <ErrorBoundary>
-                  <Lessons
-                    customLesson={appState.customLesson}
-                    customLessonMaterial={appState.customLessonMaterial}
-                    customLessonMaterialValidationState={
-                      appState.customLessonMaterialValidationState
-                    }
-                    customLessonMaterialValidationMessages={
-                      appState.customLessonMaterialValidationMessages
-                    }
-                    globalLookupDictionary={appState.globalLookupDictionary}
-                    globalLookupDictionaryLoaded={
-                      appState.globalLookupDictionaryLoaded
-                    }
-                    personalDictionaries={appState.personalDictionaries}
-                    lessonNotFound={appState.lessonNotFound}
-                    lessonSubTitle={appState.lesson.subtitle}
-                    lessonTitle={appState.lesson.title}
-                    lessonLength={appProps.stateLesson.presentedMaterial.length}
-                    lesson={appState.lesson}
-                    actualText={appState.actualText}
-                    completedPhrases={appProps.completedMaterial}
-                    currentLessonStrokes={appState.currentLessonStrokes}
-                    currentPhraseID={appState.currentPhraseID}
-                    currentPhrase={appProps.presentedMaterialCurrentItem.phrase}
-                    currentStroke={appProps.presentedMaterialCurrentItem.stroke}
-                    disableUserSettings={appState.disableUserSettings}
-                    metWords={appState.metWords}
-                    previousCompletedPhraseAsTyped={
-                      appState.previousCompletedPhraseAsTyped
-                    }
-                    repetitionsRemaining={appState.repetitionsRemaining}
-                    startTime={appState.startTime}
-                    settings={appState.lesson.settings}
-                    showStrokesInLesson={appState.showStrokesInLesson}
-                    targetStrokeCount={appState.targetStrokeCount}
-                    timer={appState.timer}
-                    totalNumberOfMatchedWords={
-                      appState.totalNumberOfMatchedWords
-                    }
-                    totalNumberOfNewWordsMet={appState.totalNumberOfNewWordsMet}
-                    totalNumberOfLowExposuresSeen={
-                      appState.totalNumberOfLowExposuresSeen
-                    }
-                    totalNumberOfRetainedWords={
-                      appState.totalNumberOfRetainedWords
-                    }
-                    totalNumberOfMistypedWords={
-                      appState.totalNumberOfMistypedWords
-                    }
-                    totalNumberOfHintedWords={appState.totalNumberOfHintedWords}
-                    totalWordCount={
-                      appProps.stateLesson.presentedMaterial.length
-                    }
-                    upcomingPhrases={appProps.upcomingMaterial}
-                    focusTriggerInt={appState.focusTriggerInt}
-                  />
-                </ErrorBoundary>
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route>
-            <div>
-              <DocumentTitle title={"Typey Type | Page not found"}>
-                <AsyncPageNotFound />
-              </DocumentTitle>
-            </div>
-          </Route>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="lookup"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Lookup"}>
+                  <ErrorBoundary>
+                    <AsyncLookup
+                      globalLookupDictionary={appState.globalLookupDictionary}
+                      globalLookupDictionaryLoaded={
+                        appState.globalLookupDictionaryLoaded
+                      }
+                      personalDictionaries={appState.personalDictionaries}
+                    />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="dictionaries/*"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Dictionaries"}>
+                  <ErrorBoundary>
+                    <AsyncDictionaries
+                      globalLookupDictionary={appState.globalLookupDictionary}
+                      globalLookupDictionaryLoaded={
+                        appState.globalLookupDictionaryLoaded
+                      }
+                      personalDictionaries={appState.personalDictionaries}
+                    />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path="lessons/*"
+            element={
+              <div>
+                <Header />
+                <DocumentTitle title={"Typey Type | Lessons"}>
+                  <ErrorBoundary>
+                    <Lessons
+                      customLesson={appState.customLesson}
+                      customLessonMaterial={appState.customLessonMaterial}
+                      customLessonMaterialValidationState={
+                        appState.customLessonMaterialValidationState
+                      }
+                      customLessonMaterialValidationMessages={
+                        appState.customLessonMaterialValidationMessages
+                      }
+                      globalLookupDictionary={appState.globalLookupDictionary}
+                      globalLookupDictionaryLoaded={
+                        appState.globalLookupDictionaryLoaded
+                      }
+                      personalDictionaries={appState.personalDictionaries}
+                      lessonNotFound={appState.lessonNotFound}
+                      lessonSubTitle={appState.lesson.subtitle}
+                      lessonTitle={appState.lesson.title}
+                      lessonLength={
+                        appProps.stateLesson.presentedMaterial.length
+                      }
+                      lesson={appState.lesson}
+                      actualText={appState.actualText}
+                      completedPhrases={appProps.completedMaterial}
+                      currentLessonStrokes={appState.currentLessonStrokes}
+                      currentPhraseID={appState.currentPhraseID}
+                      currentPhrase={
+                        appProps.presentedMaterialCurrentItem.phrase
+                      }
+                      currentStroke={
+                        appProps.presentedMaterialCurrentItem.stroke
+                      }
+                      disableUserSettings={appState.disableUserSettings}
+                      metWords={appState.metWords}
+                      previousCompletedPhraseAsTyped={
+                        appState.previousCompletedPhraseAsTyped
+                      }
+                      repetitionsRemaining={appState.repetitionsRemaining}
+                      startTime={appState.startTime}
+                      settings={appState.lesson.settings}
+                      showStrokesInLesson={appState.showStrokesInLesson}
+                      targetStrokeCount={appState.targetStrokeCount}
+                      timer={appState.timer}
+                      totalNumberOfMatchedWords={
+                        appState.totalNumberOfMatchedWords
+                      }
+                      totalNumberOfNewWordsMet={
+                        appState.totalNumberOfNewWordsMet
+                      }
+                      totalNumberOfLowExposuresSeen={
+                        appState.totalNumberOfLowExposuresSeen
+                      }
+                      totalNumberOfRetainedWords={
+                        appState.totalNumberOfRetainedWords
+                      }
+                      totalNumberOfMistypedWords={
+                        appState.totalNumberOfMistypedWords
+                      }
+                      totalNumberOfHintedWords={
+                        appState.totalNumberOfHintedWords
+                      }
+                      totalWordCount={
+                        appProps.stateLesson.presentedMaterial.length
+                      }
+                      upcomingPhrases={appProps.upcomingMaterial}
+                      focusTriggerInt={appState.focusTriggerInt}
+                    />
+                  </ErrorBoundary>
+                </DocumentTitle>
+              </div>
+            }
+          />
+          <Route
+            path={":notfound"}
+            element={
+              <div>
+                <DocumentTitle title={"Typey Type | Page not found"}>
+                  <AsyncPageNotFound />
+                </DocumentTitle>
+              </div>
+            }
+          />
         </Routes>
       </div>
       <Footer />

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { Route, Switch, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 import DocumentTitle from "react-document-title";
 import Loadable from "react-loadable";
 import PageLoading from "./components/PageLoading";
@@ -164,7 +164,7 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
     <AnnouncerController>
       <Announcer />
       <div>
-        <Switch>
+        <Routes>
           <Route exact={true} path="/">
             <div>
               <Header />
@@ -372,7 +372,7 @@ const AppRoutes: React.FC<Props> = ({ appProps, appState }) => {
               </DocumentTitle>
             </div>
           </Route>
-        </Switch>
+        </Routes>
       </div>
       <Footer />
     </AnnouncerController>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "./components/ErrorBoundary";
 import App from "./App";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import "./index.scss";
 import { withAtomsCompat } from "states/atomUtils";
 import { userSettingsState } from "./states/userSettingsState";
@@ -42,11 +42,11 @@ ReactDOM.render(
   <DocumentTitle title="Typey Type for Stenographers">
     <Router basename="/typey-type">
       <ErrorBoundary>
-        <Switch>
+        <Routes>
           <Route>
             <AppWithAtomsCompat />
           </Route>
-        </Switch>
+        </Routes>
       </ErrorBoundary>
     </Router>
   </DocumentTitle>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,9 +43,7 @@ ReactDOM.render(
     <Router basename="/typey-type">
       <ErrorBoundary>
         <Routes>
-          <Route>
-            <AppWithAtomsCompat />
-          </Route>
+          <Route path={"*"} element={<AppWithAtomsCompat />} />
         </Routes>
       </ErrorBoundary>
     </Router>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,13 @@ const AppWithAtomsCompat = withAtomsCompat(AppWrapper, [
 
 ReactDOM.render(
   <DocumentTitle title="Typey Type for Stenographers">
-    <Router basename="/typey-type">
+    <Router
+      basename="/typey-type"
+      future={{
+        v7_relativeSplatPath: false,
+        v7_startTransition: false,
+      }}
+    >
       <ErrorBoundary>
         <Routes>
           <Route path={"*"} element={<AppWithAtomsCompat />} />

--- a/src/pages/contribute/Contribute.stories.tsx
+++ b/src/pages/contribute/Contribute.stories.tsx
@@ -1,14 +1,13 @@
-import React from "react";
 import Contribute from "./Contribute";
 
-export default {
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Contribute> = {
   title: "Pages/Contribute",
   component: Contribute,
 };
+export default meta;
 
-// @ts-expect-error TS(7006) FIXME: Parameter 'args' implicitly has an 'any' type.
-const Template = (args) => {
-  return <Contribute {...args} />;
-};
+type Story = StoryObj<typeof Contribute>;
 
-export const ContributeStory = Template.bind({});
+export const ContributeStory: Story = {};

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -37,7 +37,6 @@ const Dictionaries = ({
   globalLookupDictionaryLoaded,
   globalLookupDictionary,
   personalDictionaries,
-  ...dictionaryProps
 }: Props) => {
   const userSettings = useAtomValue(userSettingsState);
   const { updatePersonalDictionaries, appFetchAndSetupGlobalDict } =
@@ -74,7 +73,6 @@ const Dictionaries = ({
               globalLookupDictionary={globalLookupDictionary}
               toggleExperiment={toggleExperiment}
               updatePersonalDictionaries={updatePersonalDictionaries}
-              {...dictionaryProps}
             />
           }
         />
@@ -88,7 +86,6 @@ const Dictionaries = ({
                 globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
                 personalDictionaries={personalDictionaries}
                 fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
-                {...dictionaryProps}
               />
             </Suspense>
           }

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { Route, Routes, useRouteMatch } from "react-router-dom";
+import { Route, Routes, useMatch } from "react-router-dom";
 import Loadable from "react-loadable";
 import DictionariesIndex from "./DictionariesIndex";
 import PageLoading from "../../components/PageLoading";
@@ -43,12 +43,12 @@ const Dictionaries = ({
   const { updatePersonalDictionaries, appFetchAndSetupGlobalDict } =
     useAppMethods();
   const toggleExperiment = useToggleExperiment();
-  const match = useRouteMatch({
+  const match = useMatch({
     path: "/dictionaries",
-    strict: true,
-    sensitive: true,
+    end: true,
+    caseSensitive: true,
   });
-  const url = match?.url ?? "";
+  const url = match?.pathname ?? "";
 
   return (
     <div>

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { Route, Switch, useRouteMatch } from "react-router-dom";
+import { Route, Routes, useRouteMatch } from "react-router-dom";
 import Loadable from "react-loadable";
 import DictionariesIndex from "./DictionariesIndex";
 import PageLoading from "../../components/PageLoading";
@@ -52,7 +52,7 @@ const Dictionaries = ({
 
   return (
     <div>
-      <Switch>
+      <Routes>
         <Route
           path={[
             `${url}/lessons/:category/:subcategory/:dictionaryPath`,
@@ -92,7 +92,7 @@ const Dictionaries = ({
         <Route path={"*"}>
           <DictionaryNotFound />
         </Route>
-      </Switch>
+      </Routes>
     </div>
   );
 };

--- a/src/pages/dictionaries/Dictionaries.tsx
+++ b/src/pages/dictionaries/Dictionaries.tsx
@@ -1,18 +1,18 @@
 import React, { Suspense } from "react";
-import { Route, Routes, useMatch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import Loadable from "react-loadable";
 import DictionariesIndex from "./DictionariesIndex";
 import PageLoading from "../../components/PageLoading";
-
-import type {
-  ImportedPersonalDictionaries,
-  LookupDictWithNamespacedDictsAndConfig,
-} from "../../types";
 import { useAppMethods } from "../../states/legacy/AppMethodsContext";
 import { useAtomValue } from "jotai";
 import { userSettingsState } from "../../states/userSettingsState";
 import { useToggleExperiment } from "../lessons/components/UserSettings/updateGlobalUserSetting";
 import DictionaryNotFound from "pages/dictionaries/DictionaryNotFound";
+
+import type {
+  ImportedPersonalDictionaries,
+  LookupDictWithNamespacedDictsAndConfig,
+} from "../../types";
 
 const AsyncDictionary = Loadable({
   loader: () => import("./Dictionary"),
@@ -43,55 +43,57 @@ const Dictionaries = ({
   const { updatePersonalDictionaries, appFetchAndSetupGlobalDict } =
     useAppMethods();
   const toggleExperiment = useToggleExperiment();
-  const match = useMatch({
-    path: "/dictionaries",
-    end: true,
-    caseSensitive: true,
-  });
-  const url = match?.pathname ?? "";
 
   return (
     <div>
       <Routes>
-        <Route
-          path={[
-            `${url}/lessons/:category/:subcategory/:dictionaryPath`,
-            `${url}/lessons/fundamentals/:dictionaryPath`,
-            `${url}/lessons/drills/:dictionaryPath`,
-            `${url}/typey-type/:dictionaryPath`,
-            `${url}/individual/:dictionaryPath`,
-            `${url}/didoesdigital/:dictionaryPath`,
-            `${url}/plover/:dictionaryPath`,
-          ]}
-        >
-          <Suspense fallback={<PageLoading pastDelay={true} />}>
-            <AsyncDictionary />
-          </Suspense>
-        </Route>
-        <Route exact={true} path={`${url}/management`}>
-          <AsyncDictionaryManagement
-            fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
-            globalLookupDictionary={globalLookupDictionary}
-            toggleExperiment={toggleExperiment}
-            updatePersonalDictionaries={updatePersonalDictionaries}
-            {...dictionaryProps}
+        {[
+          "lessons/:category/:subcategory/:dictionaryPath",
+          "lessons/fundamentals/:dictionaryPath",
+          "lessons/drills/:dictionaryPath",
+          "typey-type/:dictionaryPath",
+          "individual/:dictionaryPath",
+          "didoesdigital/:dictionaryPath",
+          "plover/:dictionaryPath",
+        ].map((path) => (
+          <Route
+            key={"Dictionaries"}
+            path={path}
+            element={
+              <Suspense fallback={<PageLoading pastDelay={true} />}>
+                <AsyncDictionary />
+              </Suspense>
+            }
           />
-        </Route>
-        <Route exact={true} path={url}>
-          <Suspense fallback={<PageLoading pastDelay={true} />}>
-            <DictionariesIndex
-              userSettings={userSettings}
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              personalDictionaries={personalDictionaries}
+        ))}
+        <Route
+          path={"management"}
+          element={
+            <AsyncDictionaryManagement
               fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
+              globalLookupDictionary={globalLookupDictionary}
+              toggleExperiment={toggleExperiment}
+              updatePersonalDictionaries={updatePersonalDictionaries}
               {...dictionaryProps}
             />
-          </Suspense>
-        </Route>
-        <Route path={"*"}>
-          <DictionaryNotFound />
-        </Route>
+          }
+        />
+        <Route
+          path={"/"}
+          element={
+            <Suspense fallback={<PageLoading pastDelay={true} />}>
+              <DictionariesIndex
+                userSettings={userSettings}
+                globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                personalDictionaries={personalDictionaries}
+                fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
+                {...dictionaryProps}
+              />
+            </Suspense>
+          }
+        />
+        <Route path={"*"} element={<DictionaryNotFound />} />
       </Routes>
     </div>
   );

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -76,61 +76,77 @@ const Games = ({
 
   return (
     <Routes>
-      <Route exact={true} path={`/games/KAOES`}>
-        <DocumentTitle title={"Typey Type | KAOES game"}>
-          <ErrorBoundary>
-            <AsyncKAOES inputForKAOES={globalUserSettings.inputForKAOES} />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/KHAERT`}>
-        <DocumentTitle title={"Typey Type | KHAERT"}>
-          <ErrorBoundary>
-            <AsyncKHAERT globalLookupDictionary={globalLookupDictionary} />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/SHUFL`}>
-        <DocumentTitle title={"Typey Type | SHUFL game"}>
-          <ErrorBoundary>
-            <AsyncSHUFL
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              startingMetWordsToday={startingMetWordsToday}
-            />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/TPEUBGSZ`}>
-        <DocumentTitle title={"Typey Type | TPEUBGSZ game"}>
-          <ErrorBoundary>
-            <AsyncTPEUBGSZ startingMetWordsToday={startingMetWordsToday} />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/TPEURPBGS`}>
-        <DocumentTitle title={"Typey Type | TPEURPBGS game"}>
-          <ErrorBoundary>
-            <AsyncTPEURPBGS />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/KPOES`}>
-        <DocumentTitle title={"Typey Type | KPOES game"}>
-          <ErrorBoundary>
-            <AsyncKPOES
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              metWords={metWords}
-              personalDictionaries={personalDictionaries}
-              userSettings={userSettings}
-            />
-          </ErrorBoundary>
-        </DocumentTitle>
-      </Route>
-      <Route exact={true} path={`/games/`}>
-        <AsyncGamesIndex />
-      </Route>
+      <Route
+        path={"KAOES"}
+        element={
+          <DocumentTitle title={"Typey Type | KAOES game"}>
+            <ErrorBoundary>
+              <AsyncKAOES inputForKAOES={globalUserSettings.inputForKAOES} />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route
+        path={"KHAERT"}
+        element={
+          <DocumentTitle title={"Typey Type | KHAERT"}>
+            <ErrorBoundary>
+              <AsyncKHAERT globalLookupDictionary={globalLookupDictionary} />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route
+        path={"SHUFL"}
+        element={
+          <DocumentTitle title={"Typey Type | SHUFL game"}>
+            <ErrorBoundary>
+              <AsyncSHUFL
+                globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                startingMetWordsToday={startingMetWordsToday}
+              />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route
+        path={"TPEUBGSZ"}
+        element={
+          <DocumentTitle title={"Typey Type | TPEUBGSZ game"}>
+            <ErrorBoundary>
+              <AsyncTPEUBGSZ startingMetWordsToday={startingMetWordsToday} />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route
+        path={"TPEURPBGS"}
+        element={
+          <DocumentTitle title={"Typey Type | TPEURPBGS game"}>
+            <ErrorBoundary>
+              <AsyncTPEURPBGS />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route
+        path={"KPOES"}
+        element={
+          <DocumentTitle title={"Typey Type | KPOES game"}>
+            <ErrorBoundary>
+              <AsyncKPOES
+                globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                metWords={metWords}
+                personalDictionaries={personalDictionaries}
+                userSettings={userSettings}
+              />
+            </ErrorBoundary>
+          </DocumentTitle>
+        }
+      />
+      <Route path={`/`} element={<AsyncGamesIndex />} />
     </Routes>
   );
 };

--- a/src/pages/games/Games.tsx
+++ b/src/pages/games/Games.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import Loadable from "react-loadable";
@@ -75,7 +75,7 @@ const Games = ({
   const userSettings = useAtomValue(userSettingsState);
 
   return (
-    <Switch>
+    <Routes>
       <Route exact={true} path={`/games/KAOES`}>
         <DocumentTitle title={"Typey Type | KAOES game"}>
           <ErrorBoundary>
@@ -131,7 +131,7 @@ const Games = ({
       <Route exact={true} path={`/games/`}>
         <AsyncGamesIndex />
       </Route>
-    </Switch>
+    </Routes>
   );
 };
 

--- a/src/pages/lessons/CustomLesson.tsx
+++ b/src/pages/lessons/CustomLesson.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import queryString from "query-string";
 import DocumentTitle from "react-document-title";
 import LessonSubheader from "./components/LessonSubheader";
@@ -58,7 +58,7 @@ const Lesson = ({
   focusTriggerInt,
 }: Omit<LessonProps, "personalDictionaries">) => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     changeShowStrokesInLesson,
@@ -112,7 +112,7 @@ const Lesson = ({
       const urlSearchParams = new URLSearchParams(location.search);
       const needsSetupLesson = [...urlSearchParams].length > 0;
       if (needsSetupLesson) {
-        history.replace({ search: "", hash: history.location.hash });
+        navigate({ search: "", hash: location.hash }, { replace: true });
       }
     }
     // TODO: revisit this after reducing parent component re-renders and converting class component to function component

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Link, Route, Switch, useHistory, useLocation } from "react-router-dom";
+import { Link, Route, Routes, useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "../../components/ErrorBoundary";
@@ -273,7 +273,7 @@ const Lesson = ({
       );
     } else {
       return (
-        <Switch>
+        <Routes>
           <Route path={`/lessons/:category/:subcategory?/:lessonPath/overview`}>
             <div>
               <ErrorBoundary>
@@ -360,7 +360,7 @@ const Lesson = ({
           <Route path={"*"}>
             <LessonNotFound />
           </Route>
-        </Switch>
+        </Routes>
       );
     }
   } else {

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useRef } from "react";
-import { Link, Route, Routes, useHistory, useLocation } from "react-router-dom";
+import {
+  Link,
+  Route,
+  Routes,
+  useNavigate,
+  useLocation,
+} from "react-router-dom";
 import queryString from "query-string";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "../../components/ErrorBoundary";
@@ -69,7 +75,7 @@ const Lesson = ({
   focusTriggerInt,
 }: LessonProps) => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     appFetchAndSetupGlobalDict,
@@ -136,7 +142,7 @@ const Lesson = ({
       const urlSearchParams = new URLSearchParams(location.search);
       const needsSetupLesson = [...urlSearchParams].length > 0;
       if (needsSetupLesson) {
-        history.replace({ search: "", hash: history.location.hash });
+        navigate({ search: "", hash: location.hash }, { replace: true });
       }
     }
     // TODO: revisit this after reducing parent component re-renders and converting class component to function component

--- a/src/pages/lessons/Lesson.tsx
+++ b/src/pages/lessons/Lesson.tsx
@@ -55,6 +55,7 @@ const Lesson = ({
   lessonLength,
   lessonSubTitle: lessonSubTitleProp,
   lessonTitle,
+  lessonNotFound,
   metWords,
   personalDictionaries,
   previousCompletedPhraseAsTyped,
@@ -228,6 +229,10 @@ const Lesson = ({
     </Link>
   ) : undefined;
 
+  if (lessonNotFound) {
+    return <LessonNotFound />;
+  }
+
   if (lesson) {
     if (
       isFinished(lesson, currentPhraseID) &&
@@ -280,92 +285,97 @@ const Lesson = ({
     } else {
       return (
         <Routes>
-          <Route path={`/lessons/:category/:subcategory?/:lessonPath/overview`}>
-            <div>
-              <ErrorBoundary>
-                <DocumentTitle title={"Typey Type | Lesson overview"}>
-                  <LessonOverview
-                    lessonIndex={lessonIndex}
-                    lessonMetadata={metadata}
-                    lessonPath={location.pathname.replace("overview", "")}
-                    lessonTxtPath={location.pathname.replace(
-                      "overview",
+          <Route
+            path={"overview"}
+            element={
+              <div>
+                <ErrorBoundary>
+                  <DocumentTitle title={"Typey Type | Lesson overview"}>
+                    <LessonOverview
+                      lessonIndex={lessonIndex}
+                      lessonMetadata={metadata}
+                      lessonPath={location.pathname.replace("overview", "")}
+                      lessonTxtPath={location.pathname.replace(
+                        "overview",
+                        "lesson.txt"
+                      )}
+                      lessonTitle={lesson.title}
+                    />
+                  </DocumentTitle>
+                </ErrorBoundary>
+              </div>
+            }
+          />
+          <Route
+            path={"flashcards"}
+            element={
+              <div>
+                <DocumentTitle title={"Typey Type | Flashcards"}>
+                  <Flashcards
+                    fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
+                    globalLookupDictionary={globalLookupDictionary}
+                    globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                    personalDictionaries={personalDictionaries}
+                    updateGlobalLookupDictionary={updateGlobalLookupDictionary}
+                    updatePersonalDictionaries={updatePersonalDictionaries}
+                    lessonpath={
+                      process.env.PUBLIC_URL +
+                      location.pathname.replace(/flashcards/, "") +
                       "lesson.txt"
-                    )}
-                    lessonTitle={lesson.title}
+                    }
+                    locationpathname={location.pathname}
                   />
                 </DocumentTitle>
-              </ErrorBoundary>
-            </div>
-          </Route>
+              </div>
+            }
+          />
           <Route
-            path={`/lessons/:category/:subcategory?/:lessonPath/flashcards`}
-          >
-            <div>
-              <DocumentTitle title={"Typey Type | Flashcards"}>
-                <Flashcards
-                  fetchAndSetupGlobalDict={appFetchAndSetupGlobalDict}
-                  globalLookupDictionary={globalLookupDictionary}
-                  globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-                  personalDictionaries={personalDictionaries}
-                  updateGlobalLookupDictionary={updateGlobalLookupDictionary}
-                  updatePersonalDictionaries={updatePersonalDictionaries}
-                  lessonpath={
-                    process.env.PUBLIC_URL +
-                    location.pathname.replace(/flashcards/, "") +
-                    "lesson.txt"
-                  }
-                  locationpathname={location.pathname}
-                />
-              </DocumentTitle>
-            </div>
-          </Route>
-          <Route exact={true} path={`${location.pathname}`}>
-            <MainLessonView
-              createNewCustomLesson={createNewCustomLesson}
-              lessonSubTitle={lessonSubTitle}
-              overviewLink={overviewLink}
-              actualText={actualText}
-              changeShowStrokesInLesson={changeShowStrokesInLesson}
-              chooseStudy={chooseStudy}
-              completedPhrases={completedPhrases}
-              currentLessonStrokes={currentLessonStrokes}
-              currentPhrase={currentPhrase}
-              currentPhraseID={currentPhraseID}
-              currentStroke={currentStroke}
-              disableUserSettings={disableUserSettings}
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-              stopLesson={stopLesson}
-              toggleHideOtherSettings={toggleHideOtherSettings}
-              lesson={lesson}
-              lessonLength={lessonLength}
-              lessonTitle={lessonTitle}
-              previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
-              repetitionsRemaining={repetitionsRemaining}
-              restartLesson={setRevisionModeAndRestartLesson}
-              revisionMode={revisionMode}
-              sayCurrentPhraseAgain={sayCurrentPhraseAgain}
-              settings={settings}
-              showStrokesInLesson={showStrokesInLesson}
-              targetStrokeCount={targetStrokeCount}
-              timer={timer}
-              totalNumberOfHintedWords={totalNumberOfHintedWords}
-              totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
-              totalNumberOfMatchedWords={totalNumberOfMatchedWords}
-              totalNumberOfMistypedWords={totalNumberOfMistypedWords}
-              totalNumberOfNewWordsMet={totalNumberOfNewWordsMet}
-              totalNumberOfRetainedWords={totalNumberOfRetainedWords}
-              totalWordCount={totalWordCount}
-              upcomingPhrases={upcomingPhrases}
-              updatePreset={updatePreset}
-              updateMarkup={updateRecentLessonsAndUpdateMarkup}
-              focusTriggerInt={focusTriggerInt}
-            />
-          </Route>
-          <Route path={"*"}>
-            <LessonNotFound />
-          </Route>
+            path={"/"}
+            element={
+              <MainLessonView
+                createNewCustomLesson={createNewCustomLesson}
+                lessonSubTitle={lessonSubTitle}
+                overviewLink={overviewLink}
+                actualText={actualText}
+                changeShowStrokesInLesson={changeShowStrokesInLesson}
+                chooseStudy={chooseStudy}
+                completedPhrases={completedPhrases}
+                currentLessonStrokes={currentLessonStrokes}
+                currentPhrase={currentPhrase}
+                currentPhraseID={currentPhraseID}
+                currentStroke={currentStroke}
+                disableUserSettings={disableUserSettings}
+                globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
+                stopLesson={stopLesson}
+                toggleHideOtherSettings={toggleHideOtherSettings}
+                lesson={lesson}
+                lessonLength={lessonLength}
+                lessonTitle={lessonTitle}
+                previousCompletedPhraseAsTyped={previousCompletedPhraseAsTyped}
+                repetitionsRemaining={repetitionsRemaining}
+                restartLesson={setRevisionModeAndRestartLesson}
+                revisionMode={revisionMode}
+                sayCurrentPhraseAgain={sayCurrentPhraseAgain}
+                settings={settings}
+                showStrokesInLesson={showStrokesInLesson}
+                targetStrokeCount={targetStrokeCount}
+                timer={timer}
+                totalNumberOfHintedWords={totalNumberOfHintedWords}
+                totalNumberOfLowExposuresSeen={totalNumberOfLowExposuresSeen}
+                totalNumberOfMatchedWords={totalNumberOfMatchedWords}
+                totalNumberOfMistypedWords={totalNumberOfMistypedWords}
+                totalNumberOfNewWordsMet={totalNumberOfNewWordsMet}
+                totalNumberOfRetainedWords={totalNumberOfRetainedWords}
+                totalWordCount={totalWordCount}
+                upcomingPhrases={upcomingPhrases}
+                updatePreset={updatePreset}
+                updateMarkup={updateRecentLessonsAndUpdateMarkup}
+                focusTriggerInt={focusTriggerInt}
+              />
+            }
+          />
+          <Route path={"*"} element={<LessonNotFound />} />
         </Routes>
       );
     }

--- a/src/pages/lessons/LessonNotFound.tsx
+++ b/src/pages/lessons/LessonNotFound.tsx
@@ -38,23 +38,17 @@ const LessonNotFound = ({ restartLesson }: LessonNotFoundProps) => {
     mainHeading.current?.focus();
   }, [location]);
 
-  let possibleBetterPath = "";
-  let attemptedPathLessonTxt = "";
-  let possibleBetterLessonTitle = "";
-  if (location && location.pathname) {
-    attemptedPathLessonTxt = location.pathname + "/lesson.txt";
-
-    if (lessonIndex && lessonIndex.length > 0) {
-      let length = lessonIndex.length;
-      for (let i = 0; i < length; i++) {
-        let tmpBetterPath = "/lessons" + lessonIndex[i].path;
-        if (attemptedPathLessonTxt === tmpBetterPath) {
-          possibleBetterPath = tmpBetterPath.replace("lesson.txt", "");
-          possibleBetterLessonTitle = lessonIndex[i].title;
-        }
-      }
+  // Note: rewriting trailing slashes could be handled on the server instead:
+  const correctedLessonWithTrailingSlash = lessonIndex?.find(
+    (lessonIndexEntry) => {
+      return (
+        // e.g. "/fundamentals/roman-numerals/lesson.txt" => "/fundamentals/roman-numerals"
+        lessonIndexEntry.path.replace("/lesson.txt", "") ===
+        // e.g. "/lessons/fundamentals/roman-numerals" => "/fundamentals/roman-numerals"
+        location?.pathname.replace("/lessons", "")
+      );
     }
-  }
+  );
 
   return (
     <DocumentTitle title={"Typey Type | Missing Lesson"}>
@@ -89,13 +83,18 @@ const LessonNotFound = ({ restartLesson }: LessonNotFoundProps) => {
                   Top 100 words lesson
                 </Link>
               </li>
-              {possibleBetterPath.length > 0 && (
+              {correctedLessonWithTrailingSlash ? (
                 <li>
-                  <Link to={possibleBetterPath}>
-                    {possibleBetterLessonTitle} lesson
+                  <Link
+                    to={`/lessons${correctedLessonWithTrailingSlash.path.replace(
+                      "lesson.txt",
+                      ""
+                    )}`}
+                  >
+                    {correctedLessonWithTrailingSlash.title} lesson
                   </Link>
                 </li>
-              )}
+              ) : null}
             </ul>
             <p>
               Or{" "}

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentPropsWithoutRef, Suspense } from "react";
-import { Route, Switch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import DocumentTitle from "react-document-title";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import Lesson from "./Lesson";
@@ -104,7 +104,7 @@ const Lessons = ({
 
   return (
     <Suspense fallback={<PageLoading pastDelay={true} />}>
-      <Switch>
+      <Routes>
         <Route
           path={[
             `/lessons/:category/:subcategory/:lessonPath/flashcards`,
@@ -172,7 +172,7 @@ const Lessons = ({
         <Route path={"*"}>
           <LessonNotFound />
         </Route>
-      </Switch>
+      </Routes>
     </Suspense>
   );
 };

--- a/src/pages/lessons/Lessons.tsx
+++ b/src/pages/lessons/Lessons.tsx
@@ -13,9 +13,7 @@ import LessonNotFound from "pages/lessons/LessonNotFound";
 
 export type LessonsRoutingProps = ComponentPropsWithoutRef<typeof Lesson> &
   ComponentPropsWithoutRef<typeof CustomLessonSetup> &
-  ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator> & {
-    lessonNotFound: boolean;
-  };
+  ComponentPropsWithoutRef<typeof AsyncCustomLessonGenerator>;
 
 const AsyncCustomLessonGenerator = Loadable({
   loader: () => import("./custom/CustomLessonGenerator"),
@@ -96,82 +94,68 @@ const Lessons = ({
     focusTriggerInt,
   };
 
-  // This would happen if we try to load a specific lesson's data and the
-  // route is sensible but we fail to fetch valid lesson text:
-  if (lessonNotFound) {
-    return <LessonNotFound />;
-  }
-
   return (
     <Suspense fallback={<PageLoading pastDelay={true} />}>
       <Routes>
+        {[
+          ":category/:subcategory/:lessonPath/*",
+          "fundamentals/:lessonPath/*",
+          "drills/:lessonPath/*",
+        ].map((path) => (
+          <Route key={path} path={path} element={<Lesson {...lessonProps} />} />
+        ))}
+        {["progress/", "progress/seen/", "progress/memorised/"].map((path) => (
+          <Route
+            key="ProgressLessons"
+            path={path}
+            element={<ProgressLesson {...lessonProps} />}
+          />
+        ))}
         <Route
-          path={[
-            `/lessons/:category/:subcategory/:lessonPath/flashcards`,
-            `/lessons/fundamentals/:lessonPath/flashcards`,
-            `/lessons/drills/:lessonPath/flashcards`,
-            `/lessons/:category/:subcategory/:lessonPath`,
-            `/lessons/fundamentals/:lessonPath`,
-            `/lessons/drills/:lessonPath`,
-          ]}
-        >
-          <Lesson {...lessonProps} />
-        </Route>
-        <Route
-          exact={true}
-          path={[
-            `/lessons/progress/`,
-            `/lessons/progress/seen/`,
-            `/lessons/progress/memorised/`,
-          ]}
-        >
-          <ProgressLesson {...lessonProps} />
-        </Route>
-        <Route exact={true} path={`/lessons/custom/setup`}>
-          <DocumentTitle title="Typey Type | Create a custom lesson">
-            <CustomLessonSetup
-              customLessonMaterial={customLessonMaterial}
-              customLessonMaterialValidationMessages={
-                customLessonMaterialValidationMessages
-              }
-              customLessonMaterialValidationState={
-                customLessonMaterialValidationState
-              }
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
-            />
-          </DocumentTitle>
-        </Route>
-        <Route exact={true} path={`/lessons/custom/generator`}>
-          <DocumentTitle title="Typey Type | Lesson generator">
-            <ErrorBoundary>
-              <AsyncCustomLessonGenerator
-                customLesson={customLesson}
+          path={"custom/setup"}
+          element={
+            <DocumentTitle title="Typey Type | Create a custom lesson">
+              <CustomLessonSetup
+                customLessonMaterial={customLessonMaterial}
+                customLessonMaterialValidationMessages={
+                  customLessonMaterialValidationMessages
+                }
                 customLessonMaterialValidationState={
                   customLessonMaterialValidationState
                 }
                 globalLookupDictionary={globalLookupDictionary}
+                globalLookupDictionaryLoaded={globalLookupDictionaryLoaded}
               />
-            </ErrorBoundary>
-          </DocumentTitle>
-        </Route>
-        <Route exact={true} path={`/lessons/custom`}>
-          <CustomLesson {...lessonProps} />
-        </Route>
-        <Route exact={true} path={`/lessons/flashcards`}>
-          <Lesson {...lessonProps} />
-        </Route>
-        <Route exact={true} path={`/lessons/:notFound`}>
-          <LessonNotFound />
-        </Route>
-        <Route exact={true} path={"/lessons"}>
-          <Suspense fallback={<PageLoading pastDelay={true} />}>
-            <LessonsIndex customLesson={customLesson} />
-          </Suspense>
-        </Route>
-        <Route path={"*"}>
-          <LessonNotFound />
-        </Route>
+            </DocumentTitle>
+          }
+        />
+        <Route
+          path={"custom/generator"}
+          element={
+            <DocumentTitle title="Typey Type | Lesson generator">
+              <ErrorBoundary>
+                <AsyncCustomLessonGenerator
+                  customLesson={customLesson}
+                  customLessonMaterialValidationState={
+                    customLessonMaterialValidationState
+                  }
+                  globalLookupDictionary={globalLookupDictionary}
+                />
+              </ErrorBoundary>
+            </DocumentTitle>
+          }
+        />
+        <Route path={"custom"} element={<CustomLesson {...lessonProps} />} />
+        <Route path={"flashcards"} element={<Lesson {...lessonProps} />} />
+        <Route
+          path={"/"}
+          element={
+            <Suspense fallback={<PageLoading pastDelay={true} />}>
+              <LessonsIndex customLesson={customLesson} />
+            </Suspense>
+          }
+        />
+        <Route path={"*"} element={<LessonNotFound />} />
       </Routes>
     </Suspense>
   );

--- a/src/pages/lessons/LessonsIndex.tsx
+++ b/src/pages/lessons/LessonsIndex.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Link, useMatch } from "react-router-dom";
+import { Link } from "react-router-dom";
 import OutboundLink from "../../components/OutboundLink";
 import LessonList from "./components/LessonList/LessonList";
 import Subheader from "../../components/Subheader";
@@ -18,13 +18,6 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
     mainHeading.current?.focus();
   }, []);
 
-  const match = useMatch({
-    path: "/lessons",
-    end: true,
-    caseSensitive: true,
-  });
-  const url = match?.pathname ?? "";
-
   return (
     <main id="main">
       <Subheader>
@@ -38,7 +31,7 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
         <div className="flex flex-wrap mxn2">
           {customLesson.title !== "Steno" ? (
             <Link
-              to={`${url}/custom?study=discover&newWords=1&seenWords=1&retainedWords=1&startFromWord=1`.replace(
+              to={`../custom?study=discover&newWords=1&seenWords=1&retainedWords=1&startFromWord=1`.replace(
                 /\/{2,}/g,
                 "/"
               )}
@@ -49,7 +42,7 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
             </Link>
           ) : null}
           <Link
-            to={`${url}/custom/setup`.replace(/\/{2,}/g, "/")}
+            to={`../custom/setup`.replace(/\/{2,}/g, "/")}
             className="link-button button button--secondary table-cell mr2 ml1"
             style={{ lineHeight: 2 }}
             id="ga--lesson-index--create-a-custom-lesson"
@@ -60,7 +53,7 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
       </Subheader>
       <div className="p3 mx-auto mw-1024">
         <h3>Typey&nbsp;Type lessons</h3>
-        <LessonList url={url} />
+        <LessonList />
         <div className="mw-584">
           <h3 className="mt3 pt6">Community lessons</h3>
           <p className="text-balance">

--- a/src/pages/lessons/LessonsIndex.tsx
+++ b/src/pages/lessons/LessonsIndex.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Link, useRouteMatch } from "react-router-dom";
+import { Link, useMatch } from "react-router-dom";
 import OutboundLink from "../../components/OutboundLink";
 import LessonList from "./components/LessonList";
 import Subheader from "../../components/Subheader";
@@ -18,12 +18,12 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
     mainHeading.current?.focus();
   }, []);
 
-  const match = useRouteMatch({
+  const match = useMatch({
     path: "/lessons",
-    strict: true,
-    sensitive: true,
+    end: true,
+    caseSensitive: true,
   });
-  const url = match?.url ?? "";
+  const url = match?.pathname ?? "";
 
   return (
     <main id="main">

--- a/src/pages/lessons/LessonsIndex.tsx
+++ b/src/pages/lessons/LessonsIndex.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { Link, useMatch } from "react-router-dom";
 import OutboundLink from "../../components/OutboundLink";
-import LessonList from "./components/LessonList";
+import LessonList from "./components/LessonList/LessonList";
 import Subheader from "../../components/Subheader";
 import { useAppMethods } from "../../states/legacy/AppMethodsContext";
 import type { CustomLesson } from "types";

--- a/src/pages/lessons/LessonsIndex.tsx
+++ b/src/pages/lessons/LessonsIndex.tsx
@@ -42,7 +42,7 @@ const LessonsIndex = ({ customLesson }: LessonsIndexProps) => {
             </Link>
           ) : null}
           <Link
-            to={`../custom/setup`.replace(/\/{2,}/g, "/")}
+            to={`custom/setup`.replace(/\/{2,}/g, "/")}
             className="link-button button button--secondary table-cell mr2 ml1"
             style={{ lineHeight: 2 }}
             id="ga--lesson-index--create-a-custom-lesson"

--- a/src/pages/lessons/MainLessonView.stories.tsx
+++ b/src/pages/lessons/MainLessonView.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, Route, Switch } from "react-router-dom";
+import { Link, Route, Routes } from "react-router-dom";
 import { useHydrateAtoms } from "jotai/utils";
 import { userSettingsState } from "../../states/userSettingsState";
 import MainLessonView from "./MainLessonView";
@@ -72,7 +72,7 @@ const Template = (args: any) => {
   useHydrateAtoms([[userSettingsState, userSettings]]);
   return (
     <AppMethodsContext.Provider value={appMethods}>
-      <Switch>
+      <Routes>
         <Route>
           <div>
             <MainLessonView
@@ -133,7 +133,7 @@ const Template = (args: any) => {
             />
           </div>
         </Route>
-      </Switch>
+      </Routes>
     </AppMethodsContext.Provider>
   );
 };

--- a/src/pages/lessons/MainLessonView.stories.tsx
+++ b/src/pages/lessons/MainLessonView.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, Route, Routes } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useHydrateAtoms } from "jotai/utils";
 import { userSettingsState } from "../../states/userSettingsState";
 import MainLessonView from "./MainLessonView";
@@ -72,68 +72,62 @@ const Template = (args: any) => {
   useHydrateAtoms([[userSettingsState, userSettings]]);
   return (
     <AppMethodsContext.Provider value={appMethods}>
-      <Routes>
-        <Route>
-          <div>
-            <MainLessonView
-              createNewCustomLesson={createNewCustomLesson}
-              globalLookupDictionary={globalLookupDictionary}
-              globalLookupDictionaryLoaded={true}
-              lesson={lesson}
-              lessonLength={1}
-              lessonSubTitle={""}
-              lessonTitle={"Test lesson"}
-              actualText={""}
-              currentLessonStrokes={[]}
-              currentPhraseID={0}
-              disableUserSettings={false}
-              previousCompletedPhraseAsTyped={""}
-              repetitionsRemaining={1}
-              revisionMode={false}
-              settings={{ ignoredChars: "" }}
-              showStrokesInLesson={false}
-              targetStrokeCount={1}
-              timer={1}
-              totalNumberOfMatchedWords={0}
-              totalNumberOfNewWordsMet={0}
-              totalNumberOfLowExposuresSeen={0}
-              totalNumberOfRetainedWords={0}
-              totalNumberOfMistypedWords={0}
-              totalNumberOfHintedWords={0}
-              restartLesson={() => undefined}
-              stopLesson={() => undefined}
-              changeShowStrokesAsList={() => undefined}
-              changeShowStrokesInLesson={() => undefined}
-              changeShowStrokesOnMisstroke={() => undefined}
-              changeSortOrderUserSetting={() => undefined}
-              changeStenoLayout={() => undefined}
-              changeShowScoresWhileTyping={() => undefined}
-              changeShowStrokesAs={() => undefined}
-              changeUserSetting={() => undefined}
-              changeVoiceUserSetting={() => undefined}
-              chooseStudy={() => undefined}
-              completedPhrases={[]}
-              propsLesson={lesson}
-              currentPhrase={presentedMaterialCurrentItem.phrase}
-              currentStroke={presentedMaterialCurrentItem.stroke}
-              handleBeatsPerMinute={() => undefined}
-              handleDiagramSize={() => undefined}
-              handleLimitWordsChange={() => undefined}
-              handleStartFromWordChange={() => undefined}
-              handleRepetitionsChange={() => undefined}
-              handleUpcomingWordsLayout={() => undefined}
-              toggleHideOtherSettings={() => undefined}
-              sayCurrentPhraseAgain={() => undefined}
-              totalWordCount={1}
-              upcomingPhrases={["and the"]}
-              updatePreset={() => undefined}
-              updateMarkup={() => undefined}
-              overviewLink={undefined}
-              {...args}
-            />
-          </div>
-        </Route>
-      </Routes>
+      <MainLessonView
+        createNewCustomLesson={createNewCustomLesson}
+        globalLookupDictionary={globalLookupDictionary}
+        globalLookupDictionaryLoaded={true}
+        lesson={lesson}
+        lessonLength={1}
+        lessonSubTitle={""}
+        lessonTitle={"Test lesson"}
+        actualText={""}
+        currentLessonStrokes={[]}
+        currentPhraseID={0}
+        disableUserSettings={false}
+        previousCompletedPhraseAsTyped={""}
+        repetitionsRemaining={1}
+        revisionMode={false}
+        settings={{ ignoredChars: "" }}
+        showStrokesInLesson={false}
+        targetStrokeCount={1}
+        timer={1}
+        totalNumberOfMatchedWords={0}
+        totalNumberOfNewWordsMet={0}
+        totalNumberOfLowExposuresSeen={0}
+        totalNumberOfRetainedWords={0}
+        totalNumberOfMistypedWords={0}
+        totalNumberOfHintedWords={0}
+        restartLesson={() => undefined}
+        stopLesson={() => undefined}
+        changeShowStrokesAsList={() => undefined}
+        changeShowStrokesInLesson={() => undefined}
+        changeShowStrokesOnMisstroke={() => undefined}
+        changeSortOrderUserSetting={() => undefined}
+        changeStenoLayout={() => undefined}
+        changeShowScoresWhileTyping={() => undefined}
+        changeShowStrokesAs={() => undefined}
+        changeUserSetting={() => undefined}
+        changeVoiceUserSetting={() => undefined}
+        chooseStudy={() => undefined}
+        completedPhrases={[]}
+        propsLesson={lesson}
+        currentPhrase={presentedMaterialCurrentItem.phrase}
+        currentStroke={presentedMaterialCurrentItem.stroke}
+        handleBeatsPerMinute={() => undefined}
+        handleDiagramSize={() => undefined}
+        handleLimitWordsChange={() => undefined}
+        handleStartFromWordChange={() => undefined}
+        handleRepetitionsChange={() => undefined}
+        handleUpcomingWordsLayout={() => undefined}
+        toggleHideOtherSettings={() => undefined}
+        sayCurrentPhraseAgain={() => undefined}
+        totalWordCount={1}
+        upcomingPhrases={["and the"]}
+        updatePreset={() => undefined}
+        updateMarkup={() => undefined}
+        overviewLink={undefined}
+        {...args}
+      />
     </AppMethodsContext.Provider>
   );
 };

--- a/src/pages/lessons/ProgressLesson.tsx
+++ b/src/pages/lessons/ProgressLesson.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import queryString from "query-string";
 import DocumentTitle from "react-document-title";
 import LessonSubheader from "./components/LessonSubheader";
@@ -60,7 +60,7 @@ const Lesson = ({
   focusTriggerInt,
 }: Omit<LessonProps, "personalDictionaries">) => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     customiseLesson,
@@ -155,7 +155,7 @@ const Lesson = ({
       const urlSearchParams = new URLSearchParams(location.search);
       const needsSetupLesson = [...urlSearchParams].length > 0;
       if (needsSetupLesson) {
-        history.replace({ search: "", hash: history.location.hash });
+        navigate({ search: "", hash: location.hash }, { replace: true });
       }
     }
     // TODO: revisit this after reducing parent component re-renders and converting class component to function component

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -122,7 +122,7 @@ export default function LessonList({ url }: LessonListProps) {
 
   const filteredLessonIndex = filterLessons(searchFilter, lessonIndex);
 
-  const updateSearchParams = useMemo(
+  const memoisedUpdateSearchParams = useMemo(
     () =>
       debounce((q: string) => {
         const search = q === "" ? undefined : `?q=${q}`;
@@ -131,9 +131,10 @@ export default function LessonList({ url }: LessonListProps) {
     [navigate]
   );
 
+  // When search filter input value changes, update search params in URL with debounce:
   useEffect(() => {
-    updateSearchParams(searchFilter);
-  }, [searchFilter, updateSearchParams]);
+    memoisedUpdateSearchParams(searchFilter);
+  }, [searchFilter, memoisedUpdateSearchParams]);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -114,13 +114,14 @@ function filterLessons(searchTerm: string, lessonIndex: LessonIndexEntry[]) {
 
 export default function LessonList({ url }: LessonListProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const lessonIndex = useLessonIndex();
   const [searchFilter, setSearchFilter] = useState(
     () => new URLSearchParams(location.search).get("q") ?? ""
   );
+
   const filteredLessonIndex = filterLessons(searchFilter, lessonIndex);
 
-  const navigate = useNavigate();
   const updateSearchParams = useMemo(
     () =>
       debounce((q: string) => {

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useLocation } from "react-router-dom";
 import { groups } from "d3-array";
 import { useLessonIndex } from "../../../states/lessonIndexState";
 import debounce from "../../../utils/debounce";
+import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
 import type { LessonIndexEntry } from "../../../types";
 
 type LessonListProps = {
@@ -75,42 +76,6 @@ const scrollToHeading = (hash: string) => {
     }, 300);
   }
 };
-
-function filterLessons(searchTerm: string, lessonIndex: LessonIndexEntry[]) {
-  const cleanedSearchTerm = searchTerm
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^ A-Za-z0-9’',*:-]/g, ""); // all characters that don't appear in lesson titles
-
-  if (cleanedSearchTerm.length === 0) return lessonIndex;
-
-  let filteredLessons = lessonIndex.filter((lesson) => {
-    const cleanedLessonTitle = lesson.title.toLowerCase();
-    const searchSnippets = cleanedSearchTerm.split(" ");
-    const titleMatches = searchSnippets.reduce(
-      (trueSoFar, searchSnippet) =>
-        trueSoFar && cleanedLessonTitle.includes(searchSnippet),
-      true
-    );
-    return titleMatches;
-  });
-
-  if (filteredLessons.length === 0) {
-    filteredLessons = lessonIndex.filter((lesson) => {
-      const searchSnippets = cleanedSearchTerm.split(" ");
-      const categoryMatches = searchSnippets.reduce(
-        (trueSoFar, searchSnippet) =>
-          trueSoFar &&
-          (lesson.category.toLowerCase().includes(searchSnippet) ||
-            lesson.subcategory.toLowerCase().includes(searchSnippet)),
-        true
-      );
-      return categoryMatches;
-    });
-  }
-
-  return filteredLessons;
-}
 
 export default function LessonList({ url }: LessonListProps) {
   const location = useLocation();

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import GoogleAnalytics from "react-ga4";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { groups } from "d3-array";
 import { useLessonIndex } from "../../../states/lessonIndexState";
 import debounce from "../../../utils/debounce";
@@ -120,14 +120,14 @@ export default function LessonList({ url }: LessonListProps) {
   );
   const filteredLessonIndex = filterLessons(searchFilter, lessonIndex);
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const updateSearchParams = useMemo(
     () =>
       debounce((q: string) => {
         const search = q === "" ? undefined : `?q=${q}`;
-        history.replace({ search, hash: history.location.hash });
+        navigate({ search, hash: location.hash }, { replace: true });
       }, 100),
-    [history]
+    [location.hash, navigate]
   );
 
   useEffect(() => {
@@ -138,10 +138,13 @@ export default function LessonList({ url }: LessonListProps) {
 
   useEffect(() => {
     if (window.location.hash.length > 0) {
-      history.replace({
-        search: history.location.search,
-        hash: window.decodeURIComponent(window.location.hash),
-      });
+      navigate(
+        {
+          search: location.search,
+          hash: window.decodeURIComponent(window.location.hash),
+        },
+        { replace: true }
+      );
     }
 
     const scrollToAnchor = () => {
@@ -158,7 +161,7 @@ export default function LessonList({ url }: LessonListProps) {
     scrollToAnchor();
 
     window.onhashchange = scrollToAnchor;
-  }, [lessonIndex, history]);
+  }, [lessonIndex, location.search, navigate]);
 
   const changeSearchFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = event.target.value;

--- a/src/pages/lessons/components/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList.tsx
@@ -125,9 +125,9 @@ export default function LessonList({ url }: LessonListProps) {
     () =>
       debounce((q: string) => {
         const search = q === "" ? undefined : `?q=${q}`;
-        navigate({ search, hash: location.hash }, { replace: true });
+        navigate({ search }, { replace: true });
       }, 100),
-    [location.hash, navigate]
+    [navigate]
   );
 
   useEffect(() => {

--- a/src/pages/lessons/components/LessonList/GroupedLessons.tsx
+++ b/src/pages/lessons/components/LessonList/GroupedLessons.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { wrangleId } from "pages/lessons/components/LessonList/LessonList";
+import { InnerLessonList } from "pages/lessons/components/LessonList/InnerLessonList";
+import type { Category, LessonIndexEntry } from "types";
+
+type GroupedLessonProps = {
+  groupedLessons: [Category, [string, LessonIndexEntry[]][]][];
+};
+
+const GroupedLessons = ({ groupedLessons }: GroupedLessonProps) => {
+  return (
+    <>
+      {groupedLessons.map(([category, subcategories]) => {
+        return (
+          <div key={category}>
+            <a
+              href={`#${wrangleId(category)}`}
+              id={wrangleId(category)}
+              className="heading-link--content"
+            >
+              <h4 className="h3">{category}</h4>
+            </a>
+            {subcategories.map(([subcategory, lessons]) => {
+              if (subcategory) {
+                return (
+                  <div key={subcategory}>
+                    <a
+                      href={`#${wrangleId(subcategory)}`}
+                      id={wrangleId(subcategory)}
+                      className="heading-link--content"
+                    >
+                      <h5 className="h4">{subcategory}</h5>
+                    </a>
+                    <InnerLessonList lessonIndex={lessons} />
+                  </div>
+                );
+              } else {
+                return (
+                  <div key={subcategory}>
+                    <InnerLessonList lessonIndex={lessons} />
+                  </div>
+                );
+              }
+            })}
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default GroupedLessons;

--- a/src/pages/lessons/components/LessonList/GroupedLessons.tsx
+++ b/src/pages/lessons/components/LessonList/GroupedLessons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { wrangleId } from "pages/lessons/components/LessonList/LessonList";
+import { wrangleId } from "./wrangleId";
 import { InnerLessonList } from "pages/lessons/components/LessonList/InnerLessonList";
 import type { Category, LessonIndexEntry } from "types";
 

--- a/src/pages/lessons/components/LessonList/InnerLessonList.tsx
+++ b/src/pages/lessons/components/LessonList/InnerLessonList.tsx
@@ -2,23 +2,18 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import type { LessonIndexEntry } from "types";
-import type { LessonListProps } from "pages/lessons/components/LessonList/LessonList";
+
+type InnerLessonListProps = {
+  lessonIndex: LessonIndexEntry[];
+};
 
 const WordCount = ({ lesson }: { lesson: LessonIndexEntry }) => (
   <>{lesson.wordCount > 0 && ` · ${lesson.wordCount} words`}</>
 );
 
-const LessonLink = ({
-  lesson,
-  url,
-}: {
-  lesson: LessonIndexEntry;
-  url: string;
-}) => (
+const LessonLink = ({ lesson }: { lesson: LessonIndexEntry }) => (
   <Link
-    to={`${url}${lesson.path}`
-      .replace(/lesson\.txt$/, "")
-      .replace(/\/{2,}/g, "/")}
+    to={`../${lesson.path}`.replace(/lesson\.txt$/, "").replace(/\/{2,}/g, "/")}
     id={
       "ga--lesson-index-" +
       lesson.path.replace(/\/lesson\.txt/g, "").replace(/[/.]/g, "-")
@@ -29,14 +24,11 @@ const LessonLink = ({
   </Link>
 );
 
-export const InnerLessonList = ({
-  lessonIndex,
-  url,
-}: LessonListProps & { lessonIndex: LessonIndexEntry[] }) => (
+export const InnerLessonList = ({ lessonIndex }: InnerLessonListProps) => (
   <ul className="unstyled-list">
     {lessonIndex.map((lesson) => (
       <li className="unstyled-list-item mb1" key={lesson.path}>
-        <LessonLink lesson={lesson} url={url} />
+        <LessonLink lesson={lesson} />
         <WordCount lesson={lesson} />
       </li>
     ))}

--- a/src/pages/lessons/components/LessonList/InnerLessonList.tsx
+++ b/src/pages/lessons/components/LessonList/InnerLessonList.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import type { LessonIndexEntry } from "types";
+import type { LessonListProps } from "pages/lessons/components/LessonList/LessonList";
+
+const WordCount = ({ lesson }: { lesson: LessonIndexEntry }) => (
+  <>{lesson.wordCount > 0 && ` · ${lesson.wordCount} words`}</>
+);
+
+const LessonLink = ({
+  lesson,
+  url,
+}: {
+  lesson: LessonIndexEntry;
+  url: string;
+}) => (
+  <Link
+    to={`${url}${lesson.path}`
+      .replace(/lesson\.txt$/, "")
+      .replace(/\/{2,}/g, "/")}
+    id={
+      "ga--lesson-index-" +
+      lesson.path.replace(/\/lesson\.txt/g, "").replace(/[/.]/g, "-")
+    }
+  >
+    {lesson.title}
+    {lesson.subtitle?.length > 0 && `: ${lesson.subtitle}`}
+  </Link>
+);
+
+export const InnerLessonList = ({
+  lessonIndex,
+  url,
+}: LessonListProps & { lessonIndex: LessonIndexEntry[] }) => (
+  <ul className="unstyled-list">
+    {lessonIndex.map((lesson) => (
+      <li className="unstyled-list-item mb1" key={lesson.path}>
+        <LessonLink lesson={lesson} url={url} />
+        <WordCount lesson={lesson} />
+      </li>
+    ))}
+  </ul>
+);

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -13,6 +13,7 @@ const mungeHash = (hash: string) => {
 };
 
 const scrollToHeading = (hash: string) => {
+  // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité
   const el = document.querySelector<HTMLAnchorElement>(
     window.decodeURIComponent(hash)
   );

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -65,9 +65,9 @@ export default function LessonList() {
     const scrollToAnchor = () => {
       // https://stackoverflow.com/questions/33955650/what-is-settimeout-doing-when-set-to-0-milliseconds/33955673
       window.setTimeout(() => {
-        const hash = window.location.hash;
         if (hash && hash.length > 0) {
           scrollToHeading(mungeHash(hash));
+        const hash = location.hash;
         } else {
           searchInputRef?.current?.focus();
         }

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -57,6 +57,7 @@ export default function LessonList() {
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  // On page load, if there's a hash, smooth scroll to valid matching headings, otherwise focus search input:
   useEffect(() => {
     const scrollToAnchor = () => {
       // https://stackoverflow.com/questions/33955650/what-is-settimeout-doing-when-set-to-0-milliseconds/33955673

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -65,9 +65,9 @@ export default function LessonList() {
     const scrollToAnchor = () => {
       // https://stackoverflow.com/questions/33955650/what-is-settimeout-doing-when-set-to-0-milliseconds/33955673
       window.setTimeout(() => {
-        if (hash && hash.length > 0) {
-          scrollToHeading(mungeHash(hash));
         const hash = location.hash;
+        if (hash && hash.length > 1) {
+          scrollToHeading(hash);
         } else {
           searchInputRef?.current?.focus();
         }

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -6,6 +6,7 @@ import { useLessonIndex } from "../../../../states/lessonIndexState";
 import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
 import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
+import TableOfContentsItem from "pages/lessons/components/LessonList/TableOfContentsItem";
 
 export const wrangleId = (id: string) => {
   return id.toLowerCase().replace(/[ ,’()]/g, "-");
@@ -160,18 +161,11 @@ export default function LessonList() {
           <p className="mb0">Jump to:</p>
           <ul>
             {groupedLessons.map(([category, subcategories]) => (
-              <li key={category}>
-                <a href={`#${wrangleId(category)}`}>{category}</a>
-                {subcategories[0][0] && (
-                  <ul>
-                    {subcategories.map(([subcategory, _]) => (
-                      <li key={subcategory}>
-                        <a href={`#${wrangleId(subcategory)}`}>{subcategory}</a>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
+              <TableOfContentsItem
+                key={category}
+                category={category}
+                subcategories={subcategories}
+              />
             ))}
           </ul>
         </>

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -47,10 +47,11 @@ export default function LessonList() {
   const memoisedUpdateSearchParams = useMemo(
     () =>
       debounce((q: string) => {
-        const search = q === "" ? undefined : `?q=${q}`;
-        navigate({ search }, { replace: true });
+        const search = q === "" ? "" : `?q=${q}`;
+        const hash = location.hash.length > 1 ? `${location.hash}` : "";
+        navigate(`${search}${hash}`, { replace: true });
       }, 100),
-    [navigate]
+    [location.hash, navigate]
   );
 
   // When search filter input value changes, update search params in URL with debounce:

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -124,7 +124,7 @@ export default function LessonList() {
       {searchFilter.trim().toLowerCase().includes("custom") && (
         <p className="py05">
           <Link
-            to={`/lessons/custom/setup`.replace(/\/{2,}/g, "/")}
+            to={"custom/setup".replace(/\/{2,}/g, "/")}
             id="ga--lesson-index--search--create-a-custom-lesson"
           >
             Create a custom lesson

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -13,7 +13,9 @@ const mungeHash = (hash: string) => {
 };
 
 const scrollToHeading = (hash: string) => {
-  const el = document.querySelector<HTMLAnchorElement>(mungeHash(hash));
+  const el = document.querySelector<HTMLAnchorElement>(
+    window.decodeURIComponent(hash)
+  );
   let top = 0;
   if (el && el.getBoundingClientRect().top) {
     top = el.getBoundingClientRect().top;

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -12,7 +12,7 @@ const mungeHash = (hash: string) => {
   return decodeURIComponent(hash);
 };
 
-const scrollToHeading = (hash: string) => {
+const scrollToHeading = (hash: Location["hash"]) => {
   // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité
   const el = document.querySelector<HTMLAnchorElement>(
     window.decodeURIComponent(hash)

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -5,9 +5,9 @@ import { groups } from "d3-array";
 import { useLessonIndex } from "../../../../states/lessonIndexState";
 import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
-import { InnerLessonList } from "pages/lessons/components/LessonList/InnerLessonList";
+import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
 
-const wrangleId = (id: string) => {
+export const wrangleId = (id: string) => {
   return id.toLowerCase().replace(/[ ,’()]/g, "-");
 };
 
@@ -176,41 +176,7 @@ export default function LessonList() {
           </ul>
         </>
       )}
-      {groupedLessons.map(([category, subcategories]) => {
-        return (
-          <div key={category}>
-            <a
-              href={`#${wrangleId(category)}`}
-              id={wrangleId(category)}
-              className="heading-link--content"
-            >
-              <h4 className="h3">{category}</h4>
-            </a>
-            {subcategories.map(([subcategory, lessons]) => {
-              if (subcategory) {
-                return (
-                  <div key={subcategory}>
-                    <a
-                      href={`#${wrangleId(subcategory)}`}
-                      id={wrangleId(subcategory)}
-                      className="heading-link--content"
-                    >
-                      <h5 className="h4">{subcategory}</h5>
-                    </a>
-                    <InnerLessonList lessonIndex={lessons} />
-                  </div>
-                );
-              } else {
-                return (
-                  <div key={subcategory}>
-                    <InnerLessonList lessonIndex={lessons} />
-                  </div>
-                );
-              }
-            })}
-          </div>
-        );
-      })}
+      <GroupedLessons groupedLessons={groupedLessons} />
     </div>
   );
 }

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -7,10 +7,6 @@ import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
 import { InnerLessonList } from "pages/lessons/components/LessonList/InnerLessonList";
 
-export type LessonListProps = {
-  url: string;
-};
-
 const wrangleId = (id: string) => {
   return id.toLowerCase().replace(/[ ,’()]/g, "-");
 };
@@ -38,7 +34,7 @@ const scrollToHeading = (hash: string) => {
   }
 };
 
-export default function LessonList({ url }: LessonListProps) {
+export default function LessonList() {
   const location = useLocation();
   const navigate = useNavigate();
   const lessonIndex = useLessonIndex();
@@ -201,13 +197,13 @@ export default function LessonList({ url }: LessonListProps) {
                     >
                       <h5 className="h4">{subcategory}</h5>
                     </a>
-                    <InnerLessonList lessonIndex={lessons} url={url} />
+                    <InnerLessonList lessonIndex={lessons} />
                   </div>
                 );
               } else {
                 return (
                   <div key={subcategory}>
-                    <InnerLessonList lessonIndex={lessons} url={url} />
+                    <InnerLessonList lessonIndex={lessons} />
                   </div>
                 );
               }

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -5,50 +5,11 @@ import { groups } from "d3-array";
 import { useLessonIndex } from "../../../../states/lessonIndexState";
 import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
-import type { LessonIndexEntry } from "../../../../types";
+import { InnerLessonList } from "pages/lessons/components/LessonList/InnerLessonList";
 
-type LessonListProps = {
+export type LessonListProps = {
   url: string;
 };
-
-const WordCount = ({ lesson }: { lesson: LessonIndexEntry }) => (
-  <>{lesson.wordCount > 0 && ` · ${lesson.wordCount} words`}</>
-);
-
-const LessonLink = ({
-  lesson,
-  url,
-}: {
-  lesson: LessonIndexEntry;
-  url: string;
-}) => (
-  <Link
-    to={`${url}${lesson.path}`
-      .replace(/lesson\.txt$/, "")
-      .replace(/\/{2,}/g, "/")}
-    id={
-      "ga--lesson-index-" +
-      lesson.path.replace(/\/lesson\.txt/g, "").replace(/[/.]/g, "-")
-    }
-  >
-    {lesson.title}
-    {lesson.subtitle?.length > 0 && `: ${lesson.subtitle}`}
-  </Link>
-);
-
-const InnerLessonList = ({
-  lessonIndex,
-  url,
-}: LessonListProps & { lessonIndex: LessonIndexEntry[] }) => (
-  <ul className="unstyled-list">
-    {lessonIndex.map((lesson) => (
-      <li className="unstyled-list-item mb1" key={lesson.path}>
-        <LessonLink lesson={lesson} url={url} />
-        <WordCount lesson={lesson} />
-      </li>
-    ))}
-  </ul>
-);
 
 const wrangleId = (id: string) => {
   return id.toLowerCase().replace(/[ ,’()]/g, "-");

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -62,16 +62,6 @@ export default function LessonList() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (window.location.hash.length > 0) {
-      navigate(
-        {
-          search: location.search,
-          hash: window.decodeURIComponent(window.location.hash),
-        },
-        { replace: true }
-      );
-    }
-
     const scrollToAnchor = () => {
       // https://stackoverflow.com/questions/33955650/what-is-settimeout-doing-when-set-to-0-milliseconds/33955673
       window.setTimeout(() => {
@@ -86,7 +76,7 @@ export default function LessonList() {
     scrollToAnchor();
 
     window.onhashchange = scrollToAnchor;
-  }, [lessonIndex, location.search, navigate]);
+  }, [location.hash, navigate]);
 
   const changeSearchFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = event.target.value;

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -8,10 +8,6 @@ import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySe
 import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
 import TableOfContentsItem from "pages/lessons/components/LessonList/TableOfContentsItem";
 
-export const wrangleId = (id: string) => {
-  return id.toLowerCase().replace(/[ ,’()]/g, "-");
-};
-
 const mungeHash = (hash: string) => {
   return decodeURIComponent(hash);
 };

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import GoogleAnalytics from "react-ga4";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { groups } from "d3-array";
-import { useLessonIndex } from "../../../states/lessonIndexState";
-import debounce from "../../../utils/debounce";
+import { useLessonIndex } from "../../../../states/lessonIndexState";
+import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
-import type { LessonIndexEntry } from "../../../types";
+import type { LessonIndexEntry } from "../../../../types";
 
 type LessonListProps = {
   url: string;

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -8,10 +8,6 @@ import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySe
 import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
 import TableOfContents from "pages/lessons/components/LessonList/TableOfContents";
 
-const mungeHash = (hash: string) => {
-  return decodeURIComponent(hash);
-};
-
 const scrollToHeading = (hash: Location["hash"]) => {
   // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité
   const el = document.querySelector<HTMLAnchorElement>(

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -6,7 +6,7 @@ import { useLessonIndex } from "../../../../states/lessonIndexState";
 import debounce from "../../../../utils/debounce";
 import filterLessons from "pages/lessons/components/LessonList/filterLessonsBySearchTerm";
 import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
-import TableOfContentsItem from "pages/lessons/components/LessonList/TableOfContentsItem";
+import TableOfContents from "pages/lessons/components/LessonList/TableOfContents";
 
 const mungeHash = (hash: string) => {
   return decodeURIComponent(hash);
@@ -131,6 +131,7 @@ export default function LessonList() {
           value={searchFilter}
         ></input>
       </div>
+
       {searchFilter.trim().toLowerCase().includes("custom") && (
         <p className="py05">
           <Link
@@ -141,9 +142,11 @@ export default function LessonList() {
           </Link>
         </p>
       )}
+
       {filteredLessonIndex.length === 0 && (
         <p>No results. Try changing your search.</p>
       )}
+
       <p aria-live="polite" aria-atomic="true">
         {searchFilter.length > 0 && filteredLessonIndex.length > 0 && (
           <>
@@ -152,20 +155,12 @@ export default function LessonList() {
           </>
         )}
       </p>
-      {searchFilter.length === 0 && (
-        <>
-          <p className="mb0">Jump to:</p>
-          <ul>
-            {groupedLessons.map(([category, subcategories]) => (
-              <TableOfContentsItem
-                key={category}
-                category={category}
-                subcategories={subcategories}
-              />
-            ))}
-          </ul>
-        </>
-      )}
+
+      <TableOfContents
+        groupedLessons={groupedLessons}
+        searchFilter={searchFilter}
+      />
+
       <GroupedLessons groupedLessons={groupedLessons} />
     </div>
   );

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -71,8 +71,6 @@ export default function LessonList() {
       }, 0);
     };
     scrollToAnchor();
-
-    window.onhashchange = scrollToAnchor;
   }, [location.hash, navigate]);
 
   const changeSearchFilter = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/lessons/components/LessonList/TableOfContents.tsx
+++ b/src/pages/lessons/components/LessonList/TableOfContents.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import TableOfContentsItem from "pages/lessons/components/LessonList/TableOfContentsItem";
+import type { Category, LessonIndexEntry } from "types";
+
+type Props = {
+  groupedLessons: [Category, [string, LessonIndexEntry[]][]][];
+  searchFilter: string;
+};
+
+const TableOfContents = ({ groupedLessons, searchFilter }: Props) => {
+  return searchFilter.length === 0 ? (
+    <>
+      <p className="mb0">Jump to:</p>
+      <ul>
+        {groupedLessons.map(([category, subcategories]) => (
+          <TableOfContentsItem
+            key={category}
+            category={category}
+            subcategories={subcategories}
+          />
+        ))}
+      </ul>
+    </>
+  ) : null;
+};
+
+export default TableOfContents;

--- a/src/pages/lessons/components/LessonList/TableOfContentsItem.tsx
+++ b/src/pages/lessons/components/LessonList/TableOfContentsItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { wrangleId } from "pages/lessons/components/LessonList/LessonList";
+import { wrangleId } from "./wrangleId";
 import type { Category, LessonIndexEntry } from "types";
 
 type TableOfContentsItemProps = {

--- a/src/pages/lessons/components/LessonList/TableOfContentsItem.tsx
+++ b/src/pages/lessons/components/LessonList/TableOfContentsItem.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { wrangleId } from "pages/lessons/components/LessonList/LessonList";
+import type { Category, LessonIndexEntry } from "types";
+
+type TableOfContentsItemProps = {
+  category: Category;
+  subcategories: [string, LessonIndexEntry[]][];
+};
+
+const TableOfContentsItem = ({
+  category,
+  subcategories,
+}: TableOfContentsItemProps) => (
+  <li>
+    <a href={`#${wrangleId(category)}`}>{category}</a>
+    {subcategories[0][0] && (
+      <ul>
+        {subcategories.map(([subcategory, _]) => (
+          <li key={subcategory}>
+            <a href={`#${wrangleId(subcategory)}`}>{subcategory}</a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </li>
+);
+
+export default TableOfContentsItem;

--- a/src/pages/lessons/components/LessonList/filterLessonsBySearchTerm.ts
+++ b/src/pages/lessons/components/LessonList/filterLessonsBySearchTerm.ts
@@ -1,0 +1,40 @@
+import type { LessonIndexEntry } from "types";
+
+export default function filterLessons(
+  searchTerm: string,
+  lessonIndex: LessonIndexEntry[]
+) {
+  const cleanedSearchTerm = searchTerm
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^ A-Za-z0-9’',*:-]/g, ""); // all characters that don't appear in lesson titles
+
+  if (cleanedSearchTerm.length === 0) return lessonIndex;
+
+  let filteredLessons = lessonIndex.filter((lesson) => {
+    const cleanedLessonTitle = lesson.title.toLowerCase();
+    const searchSnippets = cleanedSearchTerm.split(" ");
+    const titleMatches = searchSnippets.reduce(
+      (trueSoFar, searchSnippet) =>
+        trueSoFar && cleanedLessonTitle.includes(searchSnippet),
+      true
+    );
+    return titleMatches;
+  });
+
+  if (filteredLessons.length === 0) {
+    filteredLessons = lessonIndex.filter((lesson) => {
+      const searchSnippets = cleanedSearchTerm.split(" ");
+      const categoryMatches = searchSnippets.reduce(
+        (trueSoFar, searchSnippet) =>
+          trueSoFar &&
+          (lesson.category.toLowerCase().includes(searchSnippet) ||
+            lesson.subcategory.toLowerCase().includes(searchSnippet)),
+        true
+      );
+      return categoryMatches;
+    });
+  }
+
+  return filteredLessons;
+}

--- a/src/pages/lessons/components/LessonList/filterLessonsBySearchTerm.ts
+++ b/src/pages/lessons/components/LessonList/filterLessonsBySearchTerm.ts
@@ -3,7 +3,7 @@ import type { LessonIndexEntry } from "types";
 export default function filterLessons(
   searchTerm: string,
   lessonIndex: LessonIndexEntry[]
-) {
+): LessonIndexEntry[] {
   const cleanedSearchTerm = searchTerm
     .trim()
     .toLowerCase()

--- a/src/pages/lessons/components/LessonList/wrangleId.tsx
+++ b/src/pages/lessons/components/LessonList/wrangleId.tsx
@@ -1,0 +1,3 @@
+export const wrangleId = (id: string) => {
+  return id.toLowerCase().replace(/[ ,’()]/g, "-");
+};

--- a/src/pages/lessons/custom/CustomLessonGenerator.stories.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.stories.tsx
@@ -68,7 +68,7 @@ export const CustomLessonGeneratorHelp = Template.bind({});
 CustomLessonGeneratorHelp.storyName = "Show generator help";
 // @ts-expect-error TS(2339) FIXME: Property 'play' does not exist on type '(args: any... Remove this comment to see the full error message
 CustomLessonGeneratorHelp.play = async ({ canvasElement }) => {
-  const canvas = await within(canvasElement);
+  const canvas = within(canvasElement);
 
   const submitButton = canvas.getByRole("button", { name: "Show help" });
   await userEvent.click(submitButton);

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -12,7 +12,7 @@ import {
   defaultState as defaultRulesWithData,
   rulesWithDataReducer,
 } from "./generator/rulesWithDataReducer";
-import { Link, useMatch } from "react-router-dom";
+import { Link } from "react-router-dom";
 import RuleOptions from "./generator/components/RuleOptions";
 import RegexRuleSetting from "./generator/components/RegexRuleSetting";
 import availableRulePrettyNames from "./generator/utilities/availableRulePrettyNames";
@@ -168,13 +168,6 @@ const CustomLessonGenerator = ({
     });
   };
 
-  const match = useMatch({
-    path: "/lessons",
-    end: true,
-    caseSensitive: true,
-  });
-  const url = match?.pathname ?? "";
-
   return (
     <main id="main">
       <Subheader>
@@ -191,7 +184,7 @@ const CustomLessonGenerator = ({
         </div>
         <div className="flex flex-wrap mxn2">
           <Link
-            to={`${url}/custom/setup`.replace(/\/{2,}/g, "/")}
+            to={"../custom/setup".replace(/\/{2,}/g, "/")}
             className="link-button link-button-ghost table-cell mr1"
             style={{ lineHeight: 2 }}
             id="ga--lesson-index--create-a-custom-lesson"

--- a/src/pages/lessons/custom/CustomLessonGenerator.tsx
+++ b/src/pages/lessons/custom/CustomLessonGenerator.tsx
@@ -12,7 +12,7 @@ import {
   defaultState as defaultRulesWithData,
   rulesWithDataReducer,
 } from "./generator/rulesWithDataReducer";
-import { Link, useRouteMatch } from "react-router-dom";
+import { Link, useMatch } from "react-router-dom";
 import RuleOptions from "./generator/components/RuleOptions";
 import RegexRuleSetting from "./generator/components/RegexRuleSetting";
 import availableRulePrettyNames from "./generator/utilities/availableRulePrettyNames";
@@ -168,12 +168,12 @@ const CustomLessonGenerator = ({
     });
   };
 
-  const match = useRouteMatch({
+  const match = useMatch({
     path: "/lessons",
-    strict: true,
-    sensitive: true,
+    end: true,
+    caseSensitive: true,
   });
-  const url = match?.url ?? "";
+  const url = match?.pathname ?? "";
 
   return (
     <main id="main">

--- a/src/pages/lessons/custom/CustomLessonSetup.stories.tsx
+++ b/src/pages/lessons/custom/CustomLessonSetup.stories.tsx
@@ -3,10 +3,22 @@ import CustomLessonSetup from "./CustomLessonSetup";
 import AppMethodsContext from "../../../states/legacy/AppMethodsContext";
 import appMethods from "../../../stories/fixtures/appMethods";
 
-export default {
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof CustomLessonSetup> = {
   title: "Pages/CustomLessonSetup",
   component: CustomLessonSetup,
+  decorators: [
+    (Story) => (
+      <AppMethodsContext.Provider value={appMethods}>
+        <Story />
+      </AppMethodsContext.Provider>
+    ),
+  ],
 };
+export default meta;
+
+type Story = StoryObj<typeof CustomLessonSetup>;
 
 const globalLookupDictionary = new Map([
   ["huh", [["H*U", "typey:typey-type.json"]]],
@@ -22,21 +34,12 @@ const globalLookupDictionary = new Map([
   ],
 ]);
 
-// @ts-expect-error TS(7006) FIXME: Parameter 'args' implicitly has an 'any' type.
-const Template = (args) => {
-  return (
-    <AppMethodsContext.Provider value={appMethods}>
-      <CustomLessonSetup
-        customLessonMaterial={""}
-        customLessonMaterialValidationMessages={[]}
-        customLessonMaterialValidationState={"success"}
-        globalLookupDictionary={globalLookupDictionary}
-        globalLookupDictionaryLoaded={true}
-        personalDictionaries={{ dictionariesNamesAndContents: null }}
-        {...args}
-      />
-    </AppMethodsContext.Provider>
-  );
+export const CustomLessonSetupStory: Story = {
+  args: {
+    customLessonMaterial: "",
+    customLessonMaterialValidationMessages: [],
+    customLessonMaterialValidationState: "success",
+    globalLookupDictionary: globalLookupDictionary,
+    globalLookupDictionaryLoaded: true,
+  },
 };
-
-export const CustomLessonSetupStory = Template.bind({});

--- a/src/pages/lessons/custom/CustomLessonSetup.tsx
+++ b/src/pages/lessons/custom/CustomLessonSetup.tsx
@@ -67,7 +67,7 @@ const CustomLessonSetup = ({
             to={`/lessons/custom/generator`.replace(/\/{2,}/g, "/")}
             className="link-button link-button-ghost table-cell mr1"
             style={{ lineHeight: 2 }}
-            id="ga--lesson-index--create-a-custom-lesson"
+            id="ga--lesson-index--generate-a-custom-lesson--subheader"
           >
             Generate a lesson
           </Link>
@@ -107,7 +107,7 @@ const CustomLessonSetup = ({
               to={`/lessons/custom/generator`.replace(/\/{2,}/g, "/")}
               className="link-button dib mt3"
               style={{ lineHeight: 2 }}
-              id="ga--lesson-index--create-a-custom-lesson"
+              id="ga--lesson-index--generate-a-custom-lesson"
             >
               Generate a lesson
             </Link>

--- a/src/pages/lessons/custom/components/CustomWordListLesson.stories.tsx
+++ b/src/pages/lessons/custom/components/CustomWordListLesson.stories.tsx
@@ -5,6 +5,11 @@ import { expect, within, userEvent } from "@storybook/test";
 import CustomWordListLesson from "./CustomWordListLesson";
 
 import type { Meta, StoryObj } from "@storybook/react";
+import type {
+  DictionaryConfig,
+  LookupDictWithNamespacedDicts,
+  LookupDictWithNamespacedDictsAndConfig,
+} from "types";
 
 const meta: Meta<typeof CustomWordListLesson> = {
   title: "Lessons/Custom/CustomWordListLesson",
@@ -33,13 +38,22 @@ export const CustomWordListLessonEmptyState: Story = {
   },
 };
 
+const dict: LookupDictWithNamespacedDicts = new Map([
+  ["hello", [["H-L", "typey:typey-type.json"]]],
+  ["world", [["WORLD", "typey:typey-type.json"]]],
+]);
+let config: DictionaryConfig = {
+  configuration: [],
+};
+dict.configuration = config.configuration;
+
+let globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig =
+  dict as LookupDictWithNamespacedDictsAndConfig;
+
 export const CustomWordListLessonFilled: Story = {
   name: "Dictionary filled",
   args: {
-    globalLookupDictionary: new Map([
-      ["hello", [["H-L", "typey:typey-type.json"]]],
-      ["world", [["WORLD", "typey:typey-type.json"]]],
-    ]),
+    globalLookupDictionary,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/pages/lessons/custom/components/CustomWordListLesson.stories.tsx
+++ b/src/pages/lessons/custom/components/CustomWordListLesson.stories.tsx
@@ -1,64 +1,67 @@
 import React from "react";
 
-import { within, userEvent } from "@storybook/test";
-import { expect } from "@storybook/test";
+import { expect, within, userEvent } from "@storybook/test";
 
 import CustomWordListLesson from "./CustomWordListLesson";
 
-export default {
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof CustomWordListLesson> = {
   title: "Lessons/Custom/CustomWordListLesson",
   component: CustomWordListLesson,
-};
-
-// @ts-expect-error TS(7006) FIXME: Parameter 'args' implicitly has an 'any' type.
-const Template = (args) => (
-  <div className="p3">
-    <CustomWordListLesson
-      globalLookupDictionary={
-        new Map([
-          ["hello", [["H-L", "typey:typey-type.json"]]],
-          ["world", [["WORLD", "typey:typey-type.json"]]],
-        ])
-      }
-      {...args}
-    />
-  </div>
-);
-
-export const CustomWordListLessonEmptyState = Template.bind({});
-// @ts-expect-error TS(2339) FIXME: Property 'storyName' does not exist on type '(args... Remove this comment to see the full error message
-CustomWordListLessonEmptyState.storyName = "Empty state";
-// @ts-expect-error TS(2339) FIXME: Property 'play' does not exist on type '(args: any... Remove this comment to see the full error message
-CustomWordListLessonEmptyState.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await expect(
-    canvas.getByTestId("custom-lesson-formatted-pre"),
-  ).not.toHaveClass("quote");
-};
-
-export const CustomWordListLessonFilled = Template.bind({});
-// @ts-expect-error TS(2339) FIXME: Property 'storyName' does not exist on type '(args... Remove this comment to see the full error message
-CustomWordListLessonFilled.storyName = "Dictionary filled";
-// @ts-expect-error TS(2339) FIXME: Property 'play' does not exist on type '(args: any... Remove this comment to see the full error message
-CustomWordListLessonFilled.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  await userEvent.type(
-    within(canvasElement).getByLabelText(
-      "Paste a word list without strokes here to create a custom lesson (using Plover theory by default):",
+  decorators: [
+    (Story) => (
+      <div className="p3">
+        <Story />
+      </div>
     ),
-    `hello
-world`,
-  );
+  ],
+};
 
-  await expect(canvas.getByTestId("custom-lesson-formatted-pre")).toHaveClass(
-    "quote",
-  );
-  await expect(
-    canvas.getByTestId("custom-lesson-formatted-code"),
-  ).toHaveTextContent(/WORLD/);
-  await expect(
-    canvas.getByTestId("custom-lesson-formatted-code"),
-  ).toHaveTextContent(/H-L/);
+export default meta;
+
+type Story = StoryObj<typeof CustomWordListLesson>;
+
+export const CustomWordListLessonEmptyState: Story = {
+  name: "Empty state",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByTestId("custom-lesson-formatted-pre")
+    ).not.toHaveClass("quote");
+  },
+};
+
+export const CustomWordListLessonFilled: Story = {
+  name: "Dictionary filled",
+  args: {
+    globalLookupDictionary: new Map([
+      ["hello", [["H-L", "typey:typey-type.json"]]],
+      ["world", [["WORLD", "typey:typey-type.json"]]],
+    ]),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const wordListInput = canvas.getByLabelText(
+      "Paste a word list without strokes here to create a custom lesson (using Plover theory by default):"
+    );
+
+    await userEvent.type(
+      wordListInput,
+      `hello
+world`
+    );
+
+    await expect(canvas.getByTestId("custom-lesson-formatted-pre")).toHaveClass(
+      "quote"
+    );
+    await expect(
+      canvas.getByTestId("custom-lesson-formatted-code")
+    ).toHaveTextContent(/WORLD/);
+    await expect(
+      canvas.getByTestId("custom-lesson-formatted-code")
+    ).toHaveTextContent(/H-L/);
+  },
 };

--- a/src/pages/lessons/custom/components/CustomWordListLesson.tsx
+++ b/src/pages/lessons/custom/components/CustomWordListLesson.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useMemo, useState } from "react";
 import PseudoContentButton from "../../../../components/PseudoContentButton";
 import CustomLessonFormattedCode from "./CustomLessonFormattedCode";
-import { parseWordList } from 'utils/parseWordList';
+import { parseWordList } from "utils/parseWordList";
 import { generateListOfWordsAndStrokes } from "../../../../utils/transformingDictionaries/transformingDictionaries";
+import type { LookupDictWithNamespacedDictsAndConfig } from "types";
 
 type PhraseAndStroke = { phrase: string; stroke: string };
 
 type Props = {
-  globalLookupDictionary: any;
+  globalLookupDictionary: LookupDictWithNamespacedDictsAndConfig;
 };
 
 const CustomWordListLesson = ({ globalLookupDictionary }: Props) => {

--- a/src/pages/lessons/flashcards/Flashcards.stories.tsx
+++ b/src/pages/lessons/flashcards/Flashcards.stories.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { Route, Routes } from "react-router-dom";
-
 import Flashcards from "./Flashcards";
 import { useHydrateAtoms } from "jotai/utils";
 import { flashcardsProgressState } from "../../../states/flashcardsProgressState";
@@ -28,35 +26,29 @@ const Template = (args) => {
   useHydrateAtoms([[flashcardsProgressState, flashcardsProgress]]);
   return (
     <div className="p3">
-      <Routes>
-        <Route path={`/`}>
-          <div>
-            <AppMethodsContext.Provider
-              // @ts-expect-error TS(2740) FIXME: Type '{ appFetchAndSetupGlobalDict: () => Promise<... Remove this comment to see the full error message
-              value={{
-                appFetchAndSetupGlobalDict: () => Promise.resolve(true),
-              }}
-            >
-              <Flashcards
-                fetchAndSetupGlobalDict={() => Promise.resolve(true)}
-                globalLookupDictionary={globalLookupDictionary}
-                globalLookupDictionaryLoaded={true}
-                personalDictionaries={{}}
-                updateGlobalLookupDictionary={() => undefined}
-                updatePersonalDictionaries={() => undefined}
-                userSettings={{}}
-                changeFullscreen={() => undefined}
-                lessonpath={
-                  process.env.PUBLIC_URL +
-                  lessonPath.replace(/flashcards/, "") +
-                  "lesson.txt"
-                }
-                locationpathname={lessonPath}
-              />
-            </AppMethodsContext.Provider>
-          </div>
-        </Route>
-      </Routes>
+      <AppMethodsContext.Provider
+        // @ts-expect-error TS(2740) FIXME: Type '{ appFetchAndSetupGlobalDict: () => Promise<... Remove this comment to see the full error message
+        value={{
+          appFetchAndSetupGlobalDict: () => Promise.resolve(true),
+        }}
+      >
+        <Flashcards
+          fetchAndSetupGlobalDict={() => Promise.resolve(true)}
+          globalLookupDictionary={globalLookupDictionary}
+          globalLookupDictionaryLoaded={true}
+          personalDictionaries={{}}
+          updateGlobalLookupDictionary={() => undefined}
+          updatePersonalDictionaries={() => undefined}
+          userSettings={{}}
+          changeFullscreen={() => undefined}
+          lessonpath={
+            process.env.PUBLIC_URL +
+            lessonPath.replace(/flashcards/, "") +
+            "lesson.txt"
+          }
+          locationpathname={lessonPath}
+        />
+      </AppMethodsContext.Provider>
     </div>
   );
 };

--- a/src/pages/lessons/flashcards/Flashcards.stories.tsx
+++ b/src/pages/lessons/flashcards/Flashcards.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import Flashcards from "./Flashcards";
 import { useHydrateAtoms } from "jotai/utils";
@@ -28,7 +28,7 @@ const Template = (args) => {
   useHydrateAtoms([[flashcardsProgressState, flashcardsProgress]]);
   return (
     <div className="p3">
-      <Switch>
+      <Routes>
         <Route path={`/`}>
           <div>
             <AppMethodsContext.Provider
@@ -56,7 +56,7 @@ const Template = (args) => {
             </AppMethodsContext.Provider>
           </div>
         </Route>
-      </Switch>
+      </Routes>
     </div>
   );
 };

--- a/src/pages/lessons/types.ts
+++ b/src/pages/lessons/types.ts
@@ -68,6 +68,7 @@ export type LessonProps = Pick<
   | "timer"
   | "focusTriggerInt"
 > & {
+  lessonNotFound: boolean;
   metWords: MetWords; // For Finished props
   personalDictionaries?: ImportedPersonalDictionaries; // For Flashcards props
   startTime: number | null;

--- a/src/pages/lookup/Lookup.tsx
+++ b/src/pages/lookup/Lookup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import StrokesForWords from "../../components/StrokesForWords";
 import PseudoContentButton from "../../components/PseudoContentButton";
 import Subheader from "../../components/Subheader";
@@ -23,7 +23,7 @@ const Lookup = ({
   personalDictionaries,
 }: Props) => {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const [lookupTerm, setLookupTerm] = useState(
     () => new URLSearchParams(location.search).get("q") ?? ""
@@ -33,9 +33,9 @@ const Lookup = ({
     () =>
       debounce((q: string) => {
         const search = q === "" ? undefined : `?q=${q}`;
-        history.replace({ search, hash: history.location.hash });
+        navigate({ search, hash: location.hash }, { replace: true });
       }, 100),
-    [history]
+    [location.hash, navigate]
   );
 
   const userSettings = useAtomValue(userSettingsState);

--- a/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
+++ b/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 import ProgressSummaryAndLinks from "./ProgressSummaryAndLinks";
 import metWordsNovice from "../../../fixtures/metWordsNovice.json";
@@ -266,7 +266,7 @@ describe("progress summary and links", () => {
   it("has 0 seen and 0 memorised", () => {
     render(
       <Router basename="/">
-        <Switch>
+        <Routes>
           <Route>
             <div data-testid="test-wrapper">
               <ProgressSummaryAndLinks
@@ -278,7 +278,7 @@ describe("progress summary and links", () => {
               />
             </div>
           </Route>
-        </Switch>
+        </Routes>
       </Router>
     );
 

--- a/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
+++ b/src/pages/progress/components/ProgressSummaryAndLinks.test.tsx
@@ -48,15 +48,20 @@ describe("progress summary and links", () => {
   it("renders", () => {
     render(
       <Router basename="/">
-        <Route>
-          <ProgressSummaryAndLinks
-            metWords={metWordsNovice}
-            restartConfetti={() => undefined}
-            userSettings={userSettings}
-            yourMemorisedWordCount={1}
-            yourSeenWordCount={1}
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <ProgressSummaryAndLinks
+                metWords={metWordsNovice}
+                restartConfetti={() => undefined}
+                userSettings={userSettings}
+                yourMemorisedWordCount={1}
+                yourSeenWordCount={1}
+              />
+            }
           />
-        </Route>
+        </Routes>
       </Router>
     );
     const textElement = screen.getByText(/successfully typed/i);
@@ -66,15 +71,20 @@ describe("progress summary and links", () => {
   it("celebrates finishing Typey Type", () => {
     render(
       <Router basename="/">
-        <Route>
-          <ProgressSummaryAndLinks
-            metWords={metWords10000WordsSeen10000Memorised}
-            restartConfetti={() => undefined}
-            userSettings={userSettings}
-            yourMemorisedWordCount={10000}
-            yourSeenWordCount={10000}
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <ProgressSummaryAndLinks
+                metWords={metWords10000WordsSeen10000Memorised}
+                restartConfetti={() => undefined}
+                userSettings={userSettings}
+                yourMemorisedWordCount={10000}
+                yourSeenWordCount={10000}
+              />
+            }
           />
-        </Route>
+        </Routes>
       </Router>
     );
     const textElement = screen.getByText(/You rock!/i);
@@ -84,17 +94,22 @@ describe("progress summary and links", () => {
   it("has 1 seen and 0 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{ "one": 1 }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={0}
-              yourSeenWordCount={1}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{ "one": 1 }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={0}
+                  yourSeenWordCount={1}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -109,17 +124,22 @@ describe("progress summary and links", () => {
   it("has 1 seen and 1 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{ "one": 1, "two": 30 }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={1}
-              yourSeenWordCount={1}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{ "one": 1, "two": 30 }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={1}
+                  yourSeenWordCount={1}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -134,17 +154,22 @@ describe("progress summary and links", () => {
   it("has 0 seen and 1 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{ "memorised": 30 }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={30}
-              yourSeenWordCount={0}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{ "memorised": 30 }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={30}
+                  yourSeenWordCount={0}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -159,28 +184,33 @@ describe("progress summary and links", () => {
   it("has 10 seen and 0 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{
-                "seen1": 1,
-                "seen2": 1,
-                "seen3": 1,
-                "seen4": 1,
-                "seen5": 1,
-                "seen6": 1,
-                "seen7": 1,
-                "seen8": 1,
-                "seen9": 1,
-                "seen10": 1,
-              }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={0}
-              yourSeenWordCount={10}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{
+                    "seen1": 1,
+                    "seen2": 1,
+                    "seen3": 1,
+                    "seen4": 1,
+                    "seen5": 1,
+                    "seen6": 1,
+                    "seen7": 1,
+                    "seen8": 1,
+                    "seen9": 1,
+                    "seen10": 1,
+                  }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={0}
+                  yourSeenWordCount={10}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -195,29 +225,34 @@ describe("progress summary and links", () => {
   it("has 10 seen and 1 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{
-                "seen1": 1,
-                "seen2": 1,
-                "seen3": 1,
-                "seen4": 1,
-                "seen5": 1,
-                "seen6": 1,
-                "seen7": 1,
-                "seen8": 1,
-                "seen9": 1,
-                "seen10": 1,
-                "memorised": 30,
-              }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={1}
-              yourSeenWordCount={10}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{
+                    "seen1": 1,
+                    "seen2": 1,
+                    "seen3": 1,
+                    "seen4": 1,
+                    "seen5": 1,
+                    "seen6": 1,
+                    "seen7": 1,
+                    "seen8": 1,
+                    "seen9": 1,
+                    "seen10": 1,
+                    "memorised": 30,
+                  }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={1}
+                  yourSeenWordCount={10}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -230,30 +265,35 @@ describe("progress summary and links", () => {
   it("has 10 seen and 2 memorised", () => {
     render(
       <Router basename="/">
-        <Route>
-          <div data-testid="test-wrapper">
-            <ProgressSummaryAndLinks
-              metWords={{
-                "seen1": 1,
-                "seen2": 1,
-                "seen3": 1,
-                "seen4": 1,
-                "seen5": 1,
-                "seen6": 1,
-                "seen7": 1,
-                "seen8": 1,
-                "seen9": 1,
-                "seen10": 1,
-                "memorised1": 30,
-                "memorised2": 30,
-              }}
-              restartConfetti={() => undefined}
-              userSettings={userSettings}
-              yourMemorisedWordCount={2}
-              yourSeenWordCount={10}
-            />
-          </div>
-        </Route>
+        <Routes>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{
+                    "seen1": 1,
+                    "seen2": 1,
+                    "seen3": 1,
+                    "seen4": 1,
+                    "seen5": 1,
+                    "seen6": 1,
+                    "seen7": 1,
+                    "seen8": 1,
+                    "seen9": 1,
+                    "seen10": 1,
+                    "memorised1": 30,
+                    "memorised2": 30,
+                  }}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={2}
+                  yourSeenWordCount={10}
+                />
+              </div>
+            }
+          />
+        </Routes>
       </Router>
     );
 
@@ -267,17 +307,20 @@ describe("progress summary and links", () => {
     render(
       <Router basename="/">
         <Routes>
-          <Route>
-            <div data-testid="test-wrapper">
-              <ProgressSummaryAndLinks
-                metWords={{}}
-                restartConfetti={() => undefined}
-                userSettings={userSettings}
-                yourMemorisedWordCount={0}
-                yourSeenWordCount={0}
-              />
-            </div>
-          </Route>
+          <Route
+            path={"/"}
+            element={
+              <div data-testid="test-wrapper">
+                <ProgressSummaryAndLinks
+                  metWords={{}}
+                  restartConfetti={() => undefined}
+                  userSettings={userSettings}
+                  yourMemorisedWordCount={0}
+                  yourSeenWordCount={0}
+                />
+              </div>
+            }
+          />
         </Routes>
       </Router>
     );

--- a/src/pages/progress/components/RecommendationBox.tsx
+++ b/src/pages/progress/components/RecommendationBox.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import GoogleAnalytics from "react-ga4";
 import OutboundLink from "../../../components/OutboundLink";
 import RecommendationDescription from "./RecommendationDescription";
-import { Link, Redirect } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useAnnouncerApi } from "../../../components/Announcer/useAnnouncer";
 
 import type {
@@ -206,7 +206,7 @@ const RecommendationBox = ({
       updateRecommendationHistory(recommendationHistory);
     } else {
       setToRecommendedNextLesson(true);
-      // does not navigate using link but instead allows Router Redirect
+      // does not navigate using link but instead allows Router Navigate
       e.preventDefault();
     }
   }
@@ -436,7 +436,7 @@ const RecommendationBox = ({
   }
 
   if (toRecommendedNextLesson === true) {
-    return <Redirect push to={recommendedNextLesson.link} />;
+    return <Navigate to={recommendedNextLesson.link} />;
   }
 
   return <React.Fragment>{recommendedNextLessonBox}</React.Fragment>;

--- a/src/pages/support/Support.tsx
+++ b/src/pages/support/Support.tsx
@@ -63,8 +63,6 @@ const Support = () => {
     };
     scrollToAnchor();
 
-    window.onhashchange = scrollToAnchor;
-
     if (mainHeading.current && !location.hash) {
       mainHeading.current?.focus();
     }

--- a/src/pages/support/Support.tsx
+++ b/src/pages/support/Support.tsx
@@ -6,7 +6,7 @@ import DescriptionTerm from "../../components/DescriptionTerm";
 import DescriptionDetails from "../../components/DescriptionDetails";
 import Subheader from "../../components/Subheader";
 
-function hashToQuery(hash: string) {
+function hashToQuery(hash: Location["hash"]) {
   if (hash.includes(":~:text")) {
     const trimmedHashText = hash.replace(":~:text=", "");
     if (trimmedHashText.includes(encodeURIComponent("How long"))) {

--- a/src/pages/support/Support.tsx
+++ b/src/pages/support/Support.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import OutboundLink from "../../components/OutboundLink";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import DescriptionList from "../../components/DescriptionList";
 import DescriptionTerm from "../../components/DescriptionTerm";
 import DescriptionDetails from "../../components/DescriptionDetails";
@@ -31,11 +31,11 @@ const dictionaryEntryForMacReviseAccessKey =
 
 const Support = () => {
   const mainHeading = useRef<HTMLHeadingElement>(null);
+  const location = useLocation();
 
   useEffect(() => {
-    window.location.hash = window.decodeURIComponent(window.location.hash);
+    const hash = window.decodeURIComponent(location.hash);
     const scrollToAnchor = () => {
-      const hash = window.location.hash;
       if (hash && hash.length > 0) {
         try {
           const el = document.querySelector<HTMLAnchorElement>(
@@ -65,10 +65,10 @@ const Support = () => {
 
     window.onhashchange = scrollToAnchor;
 
-    if (mainHeading.current && !window.location.hash) {
+    if (mainHeading.current && !location.hash) {
       mainHeading.current?.focus();
     }
-  }, []);
+  }, [location.hash]);
 
   return (
     <main id="main">

--- a/src/pages/support/Support.tsx
+++ b/src/pages/support/Support.tsx
@@ -6,17 +6,6 @@ import DescriptionTerm from "../../components/DescriptionTerm";
 import DescriptionDetails from "../../components/DescriptionDetails";
 import Subheader from "../../components/Subheader";
 
-function hashToQuery(hash: Location["hash"]) {
-  if (hash.includes(":~:text")) {
-    const trimmedHashText = hash.replace(":~:text=", "");
-    if (trimmedHashText.includes(encodeURIComponent("How long"))) {
-      return "#time-to-learn";
-    }
-  }
-
-  return hash;
-}
-
 const dictionaryEntryForTabSpace = '"STA*PB": "{#Tab}{#space}",';
 const dictionaryEntryForWinNextLessonAccessKey =
   '"HR*FPB": "{#alt(shift(o))}",';
@@ -38,9 +27,7 @@ const Support = () => {
     const scrollToAnchor = () => {
       if (hash && hash.length > 0) {
         try {
-          const el = document.querySelector<HTMLAnchorElement>(
-            hashToQuery(hash)
-          );
+          const el = document.querySelector<HTMLAnchorElement>(hash);
           let top = 0;
           if (el && el.getBoundingClientRect().top) {
             top = el.getBoundingClientRect().top;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,13 +5674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:^4.7.11":
-  version: 4.7.11
-  resolution: "@types/history@npm:4.7.11"
-  checksum: 10c0/3facf37c2493d1f92b2e93a22cac7ea70b06351c2ab9aaceaa3c56aa6099fb63516f6c4ec1616deb5c56b4093c026a043ea2d3373e6c0644d55710364d02c934
-  languageName: node
-  linkType: hard
-
 "@types/howler@npm:^2.2.7":
   version: 2.2.7
   resolution: "@types/howler@npm:2.2.7"
@@ -5904,27 +5897,6 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10c0/49268a0d999eb6683e272e0fd0f58c6932455ae0eca37efea3294fc04885b40f7094edd3dd3edcd662bb533b521225056c7eb6708e246eaed1f8ec3d81dfe44b
-  languageName: node
-  linkType: hard
-
-"@types/react-router-dom@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "@types/react-router-dom@npm:5.3.3"
-  dependencies:
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    "@types/react-router": "npm:*"
-  checksum: 10c0/a9231a16afb9ed5142678147eafec9d48582809295754fb60946e29fcd3757a4c7a3180fa94b45763e4c7f6e3f02379e2fcb8dd986db479dcab40eff5fc62a91
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:*":
-  version: 5.1.18
-  resolution: "@types/react-router@npm:5.1.18"
-  dependencies:
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-  checksum: 10c0/cc0c900b6c06597a963cc1bf4b541d51edd59f820741ee754b8539340b2247c391b9ea0c113938a7038680e3b58e9c290f0318657cfd1abe9d5b238b4829f0c2
   languageName: node
   linkType: hard
 
@@ -18241,7 +18213,6 @@ __metadata:
     "@types/react-loadable": "npm:^5.5.6"
     "@types/react-modal": "npm:^3.13.1"
     "@types/react-numeric-input": "npm:^2.2.4"
-    "@types/react-router-dom": "npm:^5.3.3"
     "@types/react-transition-group": "npm:^4.4.5"
     chromatic: "npm:^12.2.0"
     clipboard: "npm:^1.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,13 +3158,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.13":
-  version: 7.27.6
-  resolution: "@babel/runtime@npm:7.27.6"
-  checksum: 10c0/89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:^7.12.5":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
@@ -4451,6 +4444,13 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: 10c0/11bc7e2223eda628ee90164b2dbdc8e3c7a83c4d43871c3ed217e3cae6f70df76e7e2270da9377c77ca7ef14e3886654e8497cce3792011f34dd07730fc59706
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:1.23.0":
+  version: 1.23.0
+  resolution: "@remix-run/router@npm:1.23.0"
+  checksum: 10c0/eaef5cb46a1e413f7d1019a75990808307e08e53a39d4cf69c339432ddc03143d725decef3d6b9b5071b898da07f72a4a57c4e73f787005fcf10162973d8d7d7
   languageName: node
   linkType: hard
 
@@ -11055,29 +11055,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.1.2"
-    loose-envify: "npm:^1.2.0"
-    resolve-pathname: "npm:^3.0.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-    value-equal: "npm:^1.0.1"
-  checksum: 10c0/35377694e4f10f2cf056a9cb1a8ee083e04e4b4717a63baeee4afd565658a62c7e73700bf9e82aa53dbe1ec94e0a25a83c080d63bad8ee6b274a98d2fbc5ed4c
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: "npm:^16.7.0"
-  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
-  languageName: node
-  linkType: hard
-
 "hoopy@npm:^0.1.4":
   version: 0.1.4
   resolution: "hoopy@npm:0.1.4"
@@ -11875,13 +11852,6 @@ __metadata:
   dependencies:
     is-docker: "npm:^2.0.0"
   checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
   languageName: node
   linkType: hard
 
@@ -13051,7 +13021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -14234,15 +14204,6 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 10c0/50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: "npm:0.0.1"
-  checksum: 10c0/7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
   languageName: node
   linkType: hard
 
@@ -15772,7 +15733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -15842,39 +15803,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:5.3.4":
-  version: 5.3.4
-  resolution: "react-router-dom@npm:5.3.4"
+"react-router-dom@npm:^6.30.1":
+  version: 6.30.1
+  resolution: "react-router-dom@npm:6.30.1"
   dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    loose-envify: "npm:^1.3.1"
-    prop-types: "npm:^15.6.2"
-    react-router: "npm:5.3.4"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
+    "@remix-run/router": "npm:1.23.0"
+    react-router: "npm:6.30.1"
   peerDependencies:
-    react: ">=15"
-  checksum: 10c0/f04f727e2ed2e9d1d3830af02cc61690ff67b1524c0d18690582bfba0f4d14142ccc88fb6da6befad644fddf086f5ae4c2eb7048c67da8a0b0929c19426421b0
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: 10c0/e9e1297236b0faa864424ad7d51c392fc6e118595d4dad4cd542fd217c479a81601a81c6266d5801f04f9e154de02d3b094fc22ccb544e755c2eb448fab4ec6b
   languageName: node
   linkType: hard
 
-"react-router@npm:5.3.4":
-  version: 5.3.4
-  resolution: "react-router@npm:5.3.4"
+"react-router@npm:6.30.1":
+  version: 6.30.1
+  resolution: "react-router@npm:6.30.1"
   dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    hoist-non-react-statics: "npm:^3.1.0"
-    loose-envify: "npm:^1.3.1"
-    path-to-regexp: "npm:^1.7.0"
-    prop-types: "npm:^15.6.2"
-    react-is: "npm:^16.6.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
+    "@remix-run/router": "npm:1.23.0"
   peerDependencies:
-    react: ">=15"
-  checksum: 10c0/e15c00dfef199249b4c6e6d98e5e76cc352ce66f3270f13df37cc069ddf7c05e43281e8c308fc407e4435d72924373baef1d2890e0f6b0b1eb423cf47315a053
+    react: ">=16.8"
+  checksum: 10c0/0414326f2d8e0c107fb4603cf4066dacba6a1f6f025c6e273f003e177b2f18888aca3de06d9b5522908f0e41de93be1754c37e82aa97b3a269c4742c08e82539
   languageName: node
   linkType: hard
 
@@ -16305,13 +16254,6 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 10c0/c6ec49b670dc35b9a303c47fa83ba9348a71e92d64a4c4bb85e1b659a29b407aa1ac1cb14a9b5b502982132ca77482bd80534bca147439d66880d35a137fe723
   languageName: node
   linkType: hard
 
@@ -17890,13 +17832,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.0.6
-  resolution: "tiny-invariant@npm:1.0.6"
-  checksum: 10c0/37ca64a84b71ff34545466dfb511d206f329a262d3dd1e3ac93db485c23e06c685670437e24c07cb06bba4cf1f75e44ae6cd8f2f30502556b33a71ef2762aeb5
-  languageName: node
-  linkType: hard
-
 "tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
@@ -17908,13 +17843,6 @@ __metadata:
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
   languageName: node
   linkType: hard
 
@@ -18238,7 +18166,7 @@ __metadata:
     react-loadable: "npm:^5.5.0"
     react-modal: "npm:^3.14.4"
     react-numeric-input: "npm:^2.2.3"
-    react-router-dom: "npm:5.3.4"
+    react-router-dom: "npm:^6.30.1"
     react-scripts: "npm:5.0.1"
     react-tooltip: "npm:^5.28.0"
     react-transition-group: "npm:^2.4.0"
@@ -18556,13 +18484,6 @@ __metadata:
     convert-source-map: "npm:^1.6.0"
     source-map: "npm:^0.7.3"
   checksum: 10c0/c3c99c4aa1ffffb098cc85c0c13c21871e6cbb9a83537d4e0650aa61589c347b2add787ceac68b8ea7fa1b7f446e9059d8e374cd7e7ab13b170a6caf8ad29c30
-  languageName: node
-  linkType: hard
-
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: 10c0/79068098355483ef29f4d3753999ad880875b87625d7e9055cad9346ea4b7662aad3a66f87976801b0dd7a6f828ba973d28b1669ebcd37eaf88cc5f687c1a691
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/didoesdigital/typey-type/issues/226

This PR upgrades to `react-router-dom`: `6.30.1`. It also:

- Restructures components such as extracting a bunch of child components and functions out of `LessonList.tsx`
- Changes subtle implementation details of behaviour around scrolling to/focus-ing headings, `?q=` filtering lessons, `#` jump to links, re-rendering, and replacing pages in the browser's history stack
- Changes Storybook `preview.tsx` to use a `MemoryRouter` and removes router from some specific stories
- Improves some Storybook story syntax (because there are lots of console errors strewn throughout them from recent SB change https://github.com/didoesdigital/typey-type/pull/227)
- Updates some IDs on custom lesson page for analytics

Note: several of the intermediary commits on this branch are NOT in a stable state.