### PR TITLE
Prevent 1Password autofill, prevent invalid selectors, and add prompt for new/seen words

### DIFF
--- a/src/components/TypedText.tsx
+++ b/src/components/TypedText.tsx
@@ -141,6 +141,10 @@ const TypedText = (props: Props) => {
           </samp>
           <span>
             <textarea
+              data-1p-ignore
+              data-bwignore
+              data-lpignore="true"
+              data-form-type="other"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"

--- a/src/pages/lessons/components/FinishedZeroAndEmptyState.tsx
+++ b/src/pages/lessons/components/FinishedZeroAndEmptyState.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 import FinishedNextLessonButton from "./FinishedNextLessonButton";
 import { useAtomValue } from "jotai";
-import { startFromWordSettingState } from "../../../states/userSettingsState";
+import {
+  newWordsState,
+  seenWordsState,
+  startFromWordSettingState,
+} from "../../../states/userSettingsState";
 
-import { useStartFromWordOne } from "./UserSettings/updateUserSetting";
+import {
+  useSetNewWords,
+  useSetSeenWords,
+  useStartFromWordOne,
+} from "./UserSettings/updateUserSetting";
 
 type FinishedZeroAndEmptyStateProps = {
   suggestedNextUrl: string;
@@ -12,8 +20,40 @@ type FinishedZeroAndEmptyStateProps = {
 const FinishedZeroAndEmptyState = ({
   suggestedNextUrl,
 }: FinishedZeroAndEmptyStateProps) => {
+  const newWords = useAtomValue(newWordsState);
+  const seenWords = useAtomValue(seenWordsState);
   const startFromWordSetting = useAtomValue(startFromWordSettingState);
   const startFromWordOne = useStartFromWordOne();
+  const setNewWords = useSetNewWords();
+  const setSeenWords = useSetSeenWords();
+
+  const StartFromWordOneButton = () => (
+    <div className="text-center">
+      <button className="button mt3 dib" onClick={startFromWordOne}>
+        Start from word 1
+      </button>
+    </div>
+  );
+
+  const addNewWords = () => {
+    setNewWords(true);
+  };
+
+  const addSeenWords = () => {
+    setSeenWords(true);
+  };
+
+  const DiscoverOrReviseButton = () =>
+    !newWords ? (
+      <button className="button button--secondary" onClick={addNewWords}>
+        Add new words
+      </button>
+    ) : !seenWords ? (
+      <button className="button button--secondary" onClick={addSeenWords}>
+        Add seen words
+      </button>
+    ) : null;
+
   return (
     <div className="dc">
       <div className="text-center mt10 mx-auto">
@@ -21,13 +61,10 @@ const FinishedZeroAndEmptyState = ({
           There are no words to write.
         </span>
         {startFromWordSetting > 1 ? (
-          <div className="text-center">
-            <button className="button mt3 dib" onClick={startFromWordOne}>
-              Start from word 1
-            </button>
-          </div>
+          <StartFromWordOneButton />
         ) : (
-          <div className="text-center mt3">
+          <div className="text-center mt3 flex flex-wrap justify-center items-center gap-4">
+            <DiscoverOrReviseButton />
             <FinishedNextLessonButton suggestedNextUrl={suggestedNextUrl} />
           </div>
         )}

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -9,28 +9,33 @@ import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
 import TableOfContents from "pages/lessons/components/LessonList/TableOfContents";
 
 const scrollToHeading = (hash: Location["hash"]) => {
-  // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité:
-  const decodedHash = window.decodeURIComponent(hash);
-  // Given `# had# had had# had`, replace all symbols, spaces, and so on, including multiple `#`, but keep `-` and add a new `#`:
-  const cleanedDecodedHash = `#${decodedHash.replaceAll(
-    /[^\p{Letter}\p{Number}-]/gu,
-    ""
-  )}`;
-  const el = document.querySelector<HTMLAnchorElement>(cleanedDecodedHash);
-  let top = 0;
-  if (el && el.getBoundingClientRect().top) {
-    top = el.getBoundingClientRect().top;
-  }
-  const scrollOptions: ScrollToOptions = {
-    left: 0,
-    top: window.scrollY + top,
-    behavior: "smooth",
-  };
-  if (el) {
-    window.scrollTo(scrollOptions);
-    window.setTimeout(function () {
-      el.focus();
-    }, 300);
+  try {
+    // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité:
+    const decodedHash = window.decodeURIComponent(hash);
+    // Given `# had# had had# had`, replace all symbols, spaces, and so on, including multiple `#`, but keep `-` and add a new `#`:
+    const cleanedDecodedHash = `#${decodedHash.replaceAll(
+      /[^\p{Letter}\p{Number}-]/gu,
+      ""
+    )}`;
+    const el = document.querySelector<HTMLAnchorElement>(cleanedDecodedHash);
+    let top = 0;
+    if (el && el.getBoundingClientRect().top) {
+      top = el.getBoundingClientRect().top;
+    }
+    const scrollOptions: ScrollToOptions = {
+      left: 0,
+      top: window.scrollY + top,
+      behavior: "smooth",
+    };
+    if (el) {
+      window.scrollTo(scrollOptions);
+      window.setTimeout(function () {
+        el.focus();
+      }, 300);
+    }
+  } catch (e) {
+    // Catch "Failed to execute 'querySelector' on 'Document'":
+    console.error(e);
   }
 };
 

--- a/src/pages/lessons/components/LessonList/LessonList.tsx
+++ b/src/pages/lessons/components/LessonList/LessonList.tsx
@@ -9,10 +9,14 @@ import GroupedLessons from "pages/lessons/components/LessonList/GroupedLessons";
 import TableOfContents from "pages/lessons/components/LessonList/TableOfContents";
 
 const scrollToHeading = (hash: Location["hash"]) => {
-  // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité
-  const el = document.querySelector<HTMLAnchorElement>(
-    window.decodeURIComponent(hash)
-  );
+  // Given #gerard-nolst-trenit%C3%A9, decode it to #gerard-nolst-trenité:
+  const decodedHash = window.decodeURIComponent(hash);
+  // Given `# had# had had# had`, replace all symbols, spaces, and so on, including multiple `#`, but keep `-` and add a new `#`:
+  const cleanedDecodedHash = `#${decodedHash.replaceAll(
+    /[^\p{Letter}\p{Number}-]/gu,
+    ""
+  )}`;
+  const el = document.querySelector<HTMLAnchorElement>(cleanedDecodedHash);
   let top = 0;
   if (el && el.getBoundingClientRect().top) {
     top = el.getBoundingClientRect().top;

--- a/src/pages/lessons/components/UserSettings/updateUserSetting.ts
+++ b/src/pages/lessons/components/UserSettings/updateUserSetting.ts
@@ -6,7 +6,9 @@ import {
   diagramSizeState,
   hideOtherSettingsState,
   limitNumberOfWordsState,
+  newWordsState,
   repetitionsState,
+  seenWordsState,
   showScoresWhileTypingState,
   showStrokesAsDiagramsState,
   showStrokesAsListState,
@@ -530,6 +532,34 @@ export function useStartFromWordOne() {
       category: "UserSettings",
       action: "Start from word 1",
       label: "true",
+    });
+  };
+}
+
+export function useSetNewWords(): (newState: boolean) => void {
+  const setNewWordsState = useSetAtom(newWordsState);
+
+  return (newState) => {
+    setNewWordsState(newState);
+
+    GoogleAnalytics.event({
+      category: "UserSettings",
+      action: "Set new words",
+      label: newState ? "true" : "false",
+    });
+  };
+}
+
+export function useSetSeenWords(): (newState: boolean) => void {
+  const setSeenWordsState = useSetAtom(seenWordsState);
+
+  return (newState) => {
+    setSeenWordsState(newState);
+
+    GoogleAnalytics.event({
+      category: "UserSettings",
+      action: "Set seen words",
+      label: newState ? "true" : "false",
     });
   };
 }

--- a/src/states/userSettingsState.ts
+++ b/src/states/userSettingsState.ts
@@ -55,3 +55,5 @@ export const diagramSizeState = subFieldAtom('diagramSize');
 export const limitNumberOfWordsState = subFieldAtom('limitNumberOfWords');
 export const repetitionsState = subFieldAtom('repetitions');
 export const hideOtherSettingsState = subFieldAtom('hideOtherSettings');
+export const newWordsState = subFieldAtom('newWords');
+export const seenWordsState = subFieldAtom('seenWords');


### PR DESCRIPTION
This PR:

- prevents 1Password autofill appearing on main Typed Text field on specific words like "Street"
- guards against bad URL hashes on lesson index when trying to scroll to them e.g. `# had# had had# had`
- adds a new prompt to "Add new words" or "Add seen words" on "There are no words to write" screen if new/seen words are turned off. This is motivated by new students relying on Progress/Lesson pages as "filters" and ignoring the study types and user settings.

<img width="602" height="344" alt="Typey Type with current word Street shows the 1Password icon in the text field" src="https://github.com/user-attachments/assets/3e82844b-0107-4702-a083-25731c911dc0" />

<img width="1452" height="832" alt="With no new, seen, memorised words turned on, Typey Type says There are no words to write and offers buttons to Add new words or Next lesson" src="https://github.com/user-attachments/assets/53de6e1b-8c6b-427a-b2ad-68769e9dca94" />

<img width="1452" height="828" alt="With only new words turned on, Typey Type says There are no words to write and offers buttons to Add seen words or Next lesson" src="https://github.com/user-attachments/assets/941a4e8c-7636-4dbe-8cb4-a64527f86737" />
