### PR TITLE
Add "Infinite" rounds checkbox for KAOES game

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -2457,6 +2457,9 @@ img.homepage-demo-gif {
 .bloop-appear.bloop-appear-active {
   transform: scale(2);
   transition: transform 0.5s cubic-bezier(.61,0,.48,1);
+  @media (prefers-reduced-motion: reduce) {
+    transform: scale(1);
+  }
 }
 .bloop-enter-done {
   transform: scale(1);

--- a/src/pages/games/KAOES/Game.tsx
+++ b/src/pages/games/KAOES/Game.tsx
@@ -101,13 +101,10 @@ export default function Game({
   const [state, dispatch] = useReducer(
     gameReducer,
     undefined, // init state
-    initConfig
+    initConfig,
   );
+
   useEffect(() => {
-    dispatch({
-      type: actions.setPuzzleText,
-      payload: { puzzleText: choosePuzzleKey("") },
-    });
     ReactModal.setAppElement("#js-app");
   }, []);
 

--- a/src/pages/games/KAOES/Game.tsx
+++ b/src/pages/games/KAOES/Game.tsx
@@ -95,7 +95,6 @@ export default function Game({
   const [typedText, setTypedText] = useState("");
   const [modalVisibility, setModalVisibility] = useState(false);
 
-  const [puzzleText, setPuzzleText] = useState("");
   const [stenoStroke, setStenoStroke] = useState(new Stroke());
   const [previousStenoStroke, setPreviousStenoStroke] = useState(new Stroke());
   const [rightWrongColor, setRightWrongColor] = useState(neutralDarkColor);
@@ -105,7 +104,10 @@ export default function Game({
     initConfig
   );
   useEffect(() => {
-    setPuzzleText(choosePuzzleKey(""));
+    dispatch({
+      type: actions.setPuzzleText,
+      payload: { puzzleText: choosePuzzleKey("") },
+    });
     ReactModal.setAppElement("#js-app");
   }, []);
 
@@ -141,10 +143,13 @@ export default function Game({
     }
     const tmpBoard = new Stroke();
     const clickedKey = tmpBoard.set(key).toString();
-    if (puzzleText === clickedKey) {
+    if (state.puzzleText === clickedKey) {
       setPreviousCompletedPhraseAsTyped("");
       restartConfetti();
-      setPuzzleText(choosePuzzleKey(clickedKey));
+      dispatch({
+        type: actions.setPuzzleText,
+        payload: { puzzleText: choosePuzzleKey(clickedKey) },
+      });
       setStenoStroke(new Stroke());
       setRightWrongColor(rightColor);
       dispatch({ type: actions.roundCompleted });
@@ -180,11 +185,14 @@ export default function Game({
           stenoTypedTextToKeysMapping[comparableTypedKeyString] ?? 0
         : rawStenoKeyNumber;
 
-    if (puzzleText === comparableTypedKeyString) {
+    if (state.puzzleText === comparableTypedKeyString) {
       setTypedText("");
       setPreviousCompletedPhraseAsTyped(typedStenoKey);
       restartConfetti();
-      setPuzzleText(choosePuzzleKey(comparableTypedKeyString));
+      dispatch({
+        type: actions.setPuzzleText,
+        payload: { puzzleText: choosePuzzleKey(comparableTypedKeyString) },
+      });
       setStenoStroke(new Stroke());
       setRightWrongColor(rightColor);
       dispatch({ type: actions.roundCompleted });
@@ -262,7 +270,7 @@ export default function Game({
                 />
               </div>
             </div>
-            <Puzzle puzzleText={prettyKey(puzzleText)} />
+            <Puzzle puzzleText={prettyKey(state.puzzleText)} />
             <div className="flex flex-wrap flex-grow justify-center pt1 pb3">
               <div className="inline-flex relative mx-auto mw100">
                 <TransitionGroup
@@ -283,7 +291,7 @@ export default function Game({
                         {...mapBriefsFunction(
                           state.firstGuess ? "" : previousStenoStroke.toString()
                         )}
-                        brief={`duplicate-${puzzleText}`}
+                        brief={`duplicate-${state.puzzleText}`}
                         classes="w-100 steno-diagram-svg"
                         diagramWidth={diagramWidth}
                         handleOnClick={undefined}
@@ -302,7 +310,7 @@ export default function Game({
                   id="stenoDiagram"
                   {...mapBriefsFunction(stenoStroke.toString())}
                   handleOnClick={onClickHandler}
-                  brief={puzzleText}
+                  brief={state.puzzleText}
                   diagramWidth={diagramWidth}
                   hideLetters={true}
                   onStrokeColor={neutralDarkColor}

--- a/src/pages/games/KAOES/Game.tsx
+++ b/src/pages/games/KAOES/Game.tsx
@@ -5,11 +5,11 @@ import ReactModal from "react-modal";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import * as Confetti from "../../../utils/confetti";
 import { actions } from "../utilities/gameActions";
-import { initConfig, gameReducer, roundToWin } from "./gameReducer";
+import { initConfig, gameReducer, defaultRoundToWin } from "./gameReducer";
 import Completed from "../components/Completed";
 import Intro from "../components/Intro";
 import Input from "../components/Input";
-import GameProgress from "../components/GameProgress";
+import { ProgressWrapper, Round } from "../components/GameProgress";
 import StenoLayoutDiagram from "../../../StenoLayout/AmericanStenoDiagram";
 import Stroke from "utils/stroke";
 import strokeBits from "utils/strokeBits";
@@ -223,6 +223,18 @@ export default function Game({
     });
   };
 
+  const setContinuousKAOES = () => {
+    // If you can write a key every second then 1000 rounds is about 17 min.
+    // At that point a beginner student may wish to move onto actual stenography.
+    const infiniteRounds = 1000;
+    dispatch({
+      type: "roundToWinUpdated",
+      payload: {
+        roundToWin: state.roundToWin > 8 ? defaultRoundToWin : infiniteRounds,
+      },
+    });
+  };
+
   return (
     <div className="flex flex-wrap justify-between">
       <div className="mx-auto mw-1024 min-width-320 w-100">
@@ -251,6 +263,7 @@ export default function Game({
             <div className="flex flex-wrap pb1">
               <Intro
                 introText={introText}
+                maxWidthClass="mw-800"
                 robot={
                   <MischievousRobot
                     id="mischievous-robot-KAOES"
@@ -260,11 +273,23 @@ export default function Game({
                 }
               />
               <div id={"good-guess"} className="flex flex-grow">
-                <GameProgress
-                  // NOTE: this is a hack to show "∞" when current round is higher than expected
-                  round={state.roundIndex + 1 > 9 ? -1 : state.roundIndex + 1}
-                  roundToWin={roundToWin}
-                />
+                <ProgressWrapper>
+                  <Round
+                    round={state.roundIndex + 1}
+                    roundToWin={state.roundToWin}
+                  />
+
+                  <label htmlFor="continuousKAOES" className="">
+                    <input
+                      type="checkbox"
+                      name="continuousKAOES"
+                      id="continuousKAOES"
+                      onChange={setContinuousKAOES}
+                      checked={state.roundToWin > 8}
+                    />{" "}
+                    Infinite
+                  </label>
+                </ProgressWrapper>
               </div>
             </div>
             <Puzzle puzzleText={prettyKey(state.puzzleText)} />

--- a/src/pages/games/KAOES/gameReducer.ts
+++ b/src/pages/games/KAOES/gameReducer.ts
@@ -9,6 +9,7 @@ type KAOESState = {
   firstGuess: boolean;
   gameComplete: boolean;
   roundIndex: number;
+  puzzleText: string;
 };
 
 type KAOESActionGameRestarted = { type: typeof actions.gameRestarted };
@@ -17,21 +18,35 @@ type KAOESActionMakeGuess = { type: typeof actions.makeGuess };
 
 type KAOESActionRoundCompleted = { type: typeof actions.roundCompleted };
 
+type SetPuzzleText = {
+  type: typeof actions.setPuzzleText;
+  payload: { puzzleText: string };
+};
+
 type KAOESAction =
   | KAOESActionGameRestarted
   | KAOESActionMakeGuess
-  | KAOESActionRoundCompleted;
+  | KAOESActionRoundCompleted
+  | SetPuzzleText;
 
 const defaultState: KAOESState = {
   firstGuess: true,
   gameComplete: false,
   roundIndex: 0,
+  puzzleText: "",
 };
 
 export const initConfig = (state: undefined | KAOESState): KAOESState => ({
   ...defaultState,
   ...state,
 });
+
+const getPuzzleTextState = (state: KAOESState, action: SetPuzzleText) => {
+  return {
+    ...state,
+    puzzleText: action.payload.puzzleText,
+  };
+};
 
 export const gameReducer = (state: KAOESState, action: KAOESAction) => {
   let experimentalRoundToWin = roundToWin;
@@ -50,12 +65,13 @@ export const gameReducer = (state: KAOESState, action: KAOESAction) => {
     console.error(e);
   }
 
-  switch (action?.type) {
+  switch (action.type) {
     case actions.makeGuess:
       return {
         ...state,
         firstGuess: false,
       };
+
     case actions.roundCompleted:
       return state.roundIndex + 1 === experimentalRoundToWin
         ? {
@@ -67,6 +83,7 @@ export const gameReducer = (state: KAOESState, action: KAOESAction) => {
             ...state,
             roundIndex: state.roundIndex + 1,
           };
+
     case actions.gameRestarted:
       return {
         ...state,
@@ -74,6 +91,9 @@ export const gameReducer = (state: KAOESState, action: KAOESAction) => {
         gameComplete: false,
         roundIndex: 0,
       };
+
+    case actions.setPuzzleText:
+      return getPuzzleTextState(state, action);
 
     default:
       return state;

--- a/src/pages/games/KAOES/gameReducer.ts
+++ b/src/pages/games/KAOES/gameReducer.ts
@@ -2,7 +2,7 @@ import isNormalInteger from "../../../utils/isNormalInteger";
 import { actions } from "../utilities/gameActions";
 import { choosePuzzleKey } from "./utilities";
 
-export const roundToWin = 8;
+export const defaultRoundToWin = 8;
 
 const roundToWinStorageKey = "typey-KAOES-rounds";
 
@@ -11,6 +11,7 @@ type KAOESState = {
   gameComplete: boolean;
   roundIndex: number;
   puzzleText: string;
+  roundToWin: number;
 };
 
 type KAOESActionGameRestarted = { type: typeof actions.gameRestarted };
@@ -18,6 +19,13 @@ type KAOESActionGameRestarted = { type: typeof actions.gameRestarted };
 type KAOESActionMakeGuess = { type: typeof actions.makeGuess };
 
 type KAOESActionRoundCompleted = { type: typeof actions.roundCompleted };
+
+type KAOESActionRoundToWinUpdated = {
+  type: typeof actions.roundToWinUpdated;
+  payload: {
+    roundToWin: number;
+  };
+};
 
 type SetPuzzleText = {
   type: typeof actions.setPuzzleText;
@@ -28,12 +36,34 @@ type KAOESAction =
   | KAOESActionGameRestarted
   | KAOESActionMakeGuess
   | KAOESActionRoundCompleted
+  | KAOESActionRoundToWinUpdated
   | SetPuzzleText;
+
+const getInitialRoundToWin = () => {
+  let initialRoundToWin = defaultRoundToWin;
+
+  try {
+    const storageRounds =
+      window.localStorage.getItem(roundToWinStorageKey) ?? "0";
+    if (
+      isNormalInteger(storageRounds) &&
+      +storageRounds > 1 &&
+      +storageRounds < 10000
+    ) {
+      initialRoundToWin = +storageRounds;
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  return initialRoundToWin;
+};
 
 const defaultState: KAOESState = {
   firstGuess: true,
   gameComplete: false,
   roundIndex: 0,
+  roundToWin: getInitialRoundToWin(),
   puzzleText: choosePuzzleKey(""),
 };
 
@@ -49,23 +79,25 @@ const getPuzzleTextState = (state: KAOESState, action: SetPuzzleText) => {
   };
 };
 
-export const gameReducer = (state: KAOESState, action: KAOESAction) => {
-  let experimentalRoundToWin = roundToWin;
+const getRoundToWinUpdatedState = (
+  state: KAOESState,
+  action: KAOESActionRoundToWinUpdated,
+) => {
+  const newRoundToWin = action.payload.roundToWin;
 
   try {
-    const storageRounds =
-      window.localStorage.getItem(roundToWinStorageKey) ?? "0";
-    if (
-      isNormalInteger(storageRounds) &&
-      +storageRounds > 1 &&
-      +storageRounds < 10000
-    ) {
-      experimentalRoundToWin = +storageRounds;
-    }
-  } catch (e) {
-    console.error(e);
+    window.localStorage.setItem(roundToWinStorageKey, `${newRoundToWin}`);
+  } catch (err) {
+    console.error(err);
   }
 
+  return {
+    ...state,
+    roundToWin: newRoundToWin,
+  };
+};
+
+export const gameReducer = (state: KAOESState, action: KAOESAction) => {
   switch (action.type) {
     case actions.makeGuess:
       return {
@@ -74,7 +106,7 @@ export const gameReducer = (state: KAOESState, action: KAOESAction) => {
       };
 
     case actions.roundCompleted:
-      return state.roundIndex + 1 === experimentalRoundToWin
+      return state.roundIndex + 1 === state.roundToWin
         ? {
             ...state,
             gameComplete: true,
@@ -92,6 +124,9 @@ export const gameReducer = (state: KAOESState, action: KAOESAction) => {
         gameComplete: false,
         roundIndex: 0,
       };
+
+    case actions.roundToWinUpdated:
+      return getRoundToWinUpdatedState(state, action);
 
     case actions.setPuzzleText:
       return getPuzzleTextState(state, action);

--- a/src/pages/games/KAOES/gameReducer.ts
+++ b/src/pages/games/KAOES/gameReducer.ts
@@ -1,5 +1,6 @@
 import isNormalInteger from "../../../utils/isNormalInteger";
 import { actions } from "../utilities/gameActions";
+import { choosePuzzleKey } from "./utilities";
 
 export const roundToWin = 8;
 
@@ -33,7 +34,7 @@ const defaultState: KAOESState = {
   firstGuess: true,
   gameComplete: false,
   roundIndex: 0,
-  puzzleText: "",
+  puzzleText: choosePuzzleKey(""),
 };
 
 export const initConfig = (state: undefined | KAOESState): KAOESState => ({

--- a/src/pages/games/KPOES/Game.tsx
+++ b/src/pages/games/KPOES/Game.tsx
@@ -46,6 +46,7 @@ export default function Game({
               {gameName} game
             </h3>
             <Intro
+              maxWidthClass="mw100"
               introText={introText}
               robot={
                 <ComposingRobot

--- a/src/pages/games/components/GameProgress.tsx
+++ b/src/pages/games/components/GameProgress.tsx
@@ -6,15 +6,15 @@ type RoundProps = {
   roundToWin: number;
 };
 
-const Round: FC<RoundProps> = ({ round, roundToWin }) => (
+export const Round: FC<RoundProps> = ({ round, roundToWin }) => (
   <>
     Round:{" "}
     <TransitionGroup className={"dib"} component={"span"} key={round}>
       <CSSTransition timeout={500} classNames="bloop" appear={true}>
-        <strong className="dib">{round < 1 ? "∞" : round}</strong>
+        <strong className="dib">{round}</strong>
       </CSSTransition>
-    </TransitionGroup>{" "}
-    of {roundToWin}
+    </TransitionGroup>
+    {roundToWin > 9 ? "" : ` of ${roundToWin}`}
     <br />
   </>
 );
@@ -39,13 +39,19 @@ type Props = {
   levelToWin?: number;
 };
 
+export const ProgressWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="flex flex-grow">
+      <p className="text-center w-100">{children}</p>
+    </div>
+  );
+};
+
 const GameProgress: FC<Props> = ({ level, levelToWin, round, roundToWin }) => (
-  <div className="flex flex-grow">
-    <p className="text-center w-100">
-      <Round round={round} roundToWin={roundToWin} />
-      <Level level={level} levelToWin={levelToWin} />
-    </p>
-  </div>
+  <ProgressWrapper>
+    <Round round={round} roundToWin={roundToWin} />
+    <Level level={level} levelToWin={levelToWin} />
+  </ProgressWrapper>
 );
 
 export default GameProgress;

--- a/src/pages/games/components/Intro.tsx
+++ b/src/pages/games/components/Intro.tsx
@@ -2,12 +2,17 @@ import * as React from "react";
 
 type Props = {
   introText: string;
+  maxWidthClass?: string;
   robot: React.ReactNode;
 };
 
-export default function Intro({ introText, robot }: Props) {
+export default function Intro({
+  introText,
+  maxWidthClass = "mw-824",
+  robot,
+}: Props) {
   return (
-    <div className="mw-824 mr3 flex-grow">
+    <div className={`${maxWidthClass} mr3 flex-grow`}>
       <div className="flex">
         <div className="w-100 mw-48 mr3 game-robot">{robot}</div>
         <p>{introText}</p>

--- a/src/pages/games/utilities/gameActions.ts
+++ b/src/pages/games/utilities/gameActions.ts
@@ -1,5 +1,6 @@
 export const actions = {
   gameRestarted: "gameRestarted",
   roundCompleted: "roundCompleted",
-  makeGuess: "makeGuess"
-};
+  makeGuess: "makeGuess",
+  setPuzzleText: "setPuzzleText",
+} as const;

--- a/src/pages/games/utilities/gameActions.ts
+++ b/src/pages/games/utilities/gameActions.ts
@@ -1,6 +1,7 @@
 export const actions = {
   gameRestarted: "gameRestarted",
   roundCompleted: "roundCompleted",
+  roundToWinUpdated: "roundToWinUpdated",
   makeGuess: "makeGuess",
   setPuzzleText: "setPuzzleText",
 } as const;


### PR DESCRIPTION
Closes https://github.com/didoesdigital/typey-type/issues/192

This PR adds "Infinite" checkbox:

<img width="1200" height="986" alt="KAOES game with new Infinite checkbox under rounds" src="https://github.com/user-attachments/assets/9b44c5fe-a7e0-4de0-b844-e1666db7a61c" />

Technically, it sets the number of rounds to win the game to 1000 (>17 minutes worth of practice). It hides the "of 8" rounds label when more than 1 digit (10+). The "Infinite" checkbox toggles rounds to win to 100 or back to 8.

A code-savvy student may still change `typey-KAOES-rounds` in local storage to any number they want between 2 and 10,000.

This PR also:

- stops `bloop` animation from scaling text/numbers up if user prefers reduced motion
- refactors KAOES game state a smidge