### PR TITLE
Remove `react-animate-height`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "pure-react-carousel": "https://github.com/didoesdigital/pure-react-carousel.git#add-slider-callback",
     "query-string": "^7.1.3",
     "react": "^18.3.1",
-    "react-animate-height": "^2.0.5",
     "react-chatbot-kit": "^2.2.2",
     "react-dom": "^18.3.1",
     "react-ga4": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "d3-shape": "^3.0.1",
     "d3-time": "^3.0.0",
     "d3-time-format": "^4.1.0",
-    "framer-motion": "^12.38.0",
     "howler": "^2.2.3",
     "jotai": "^2.19.0",
     "motion": "^12.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
-      react-animate-height:
-        specifier: ^2.0.5
-        version: 2.0.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-chatbot-kit:
         specifier: ^2.2.2
         version: 2.2.2
@@ -3231,13 +3228,6 @@ packages:
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
-
-  react-animate-height@2.0.23:
-    resolution: {integrity: sha512-DucSC/1QuxWEFzR9IsHMzrf2nrcZ6qAmLIFoENa2kLK7h72XybcMA9o073z7aHccFzdMEW0/fhAdnQG7a4rDow==}
-    engines: {node: '>= 6.0.0'}
-    peerDependencies:
-      react: '>=15.6.2'
-      react-dom: '>=15.6.2'
 
   react-chatbot-kit@2.2.2:
     resolution: {integrity: sha512-8p/i0KkzkhoyG2XsL6Pb6f72k9j7GYNAc5SOa4f9OZwbCD3Q34uEruNPc06qa1wZHKfT6aFna19PA2plFuO2NA==}
@@ -7082,13 +7072,6 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-
-  react-animate-height@2.0.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      classnames: 2.5.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   react-chatbot-kit@2.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,6 @@ importers:
       d3-time-format:
         specifier: ^4.1.0
         version: 4.1.0
-      framer-motion:
-        specifier: ^12.38.0
-        version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       howler:
         specifier: ^2.2.3
         version: 2.2.3

--- a/src/components/TypedText.tsx
+++ b/src/components/TypedText.tsx
@@ -4,8 +4,7 @@ import {
   type ChangeEventHandler,
   type KeyboardEvent,
 } from "react";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 import GoogleAnalytics from "react-ga4";
 import { useAtomValue } from "jotai";
 import { userSettingsState } from "../states/userSettingsState";

--- a/src/pages/games/KAOES/Game.tsx
+++ b/src/pages/games/KAOES/Game.tsx
@@ -9,8 +9,7 @@ import {
 } from "react";
 import GoogleAnalytics from "react-ga4";
 import ReactModal from "react-modal";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 import * as Confetti from "../../../utils/confetti";
 import { actions } from "../utilities/gameActions";
 import { initConfig, gameReducer, defaultRoundToWin } from "./gameReducer";

--- a/src/pages/games/KAOES/Puzzle.tsx
+++ b/src/pages/games/KAOES/Puzzle.tsx
@@ -1,5 +1,4 @@
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 
 type Props = {
   puzzleText: string;

--- a/src/pages/games/TPEURPBGS/GamePlay.tsx
+++ b/src/pages/games/TPEURPBGS/GamePlay.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from "react";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 import Input from "../components/Input";
 import {
   useTPEURPBGSApi,

--- a/src/pages/games/TPEURPBGS/GameProgress.tsx
+++ b/src/pages/games/TPEURPBGS/GameProgress.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 import { useTPEURPBGSData } from "./TPEURPBGSContext/useTPEURPBGS";
 
 const Section: FC = () => {

--- a/src/pages/games/components/GameProgress.tsx
+++ b/src/pages/games/components/GameProgress.tsx
@@ -15,7 +15,7 @@ export const Round: FC<RoundProps> = ({ round, roundToWin }) => {
         className={"dib"}
         animate={{
           transform: shouldReduceMotion
-            ? "scale(1)"
+            ? ["scale(1)", "scale(1)", "scale(1)"]
             : ["scale(1)", "scale(2)", "scale(1)"],
         }}
         transition={{

--- a/src/pages/games/components/GameProgress.tsx
+++ b/src/pages/games/components/GameProgress.tsx
@@ -1,6 +1,5 @@
 import { FC, type ReactNode } from "react";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 
 type RoundProps = {
   round: number;

--- a/src/pages/games/components/Input.tsx
+++ b/src/pages/games/components/Input.tsx
@@ -1,6 +1,5 @@
 import { type ChangeEventHandler, useEffect, useRef } from "react";
-import { motion } from "motion/react";
-import { useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 
 type InputProps = {
   onChangeInput: (inputText: string) => void;

--- a/src/pages/lessons/MainLessonView.tsx
+++ b/src/pages/lessons/MainLessonView.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import ClosingCross from "../../components/Icons/icon-images/ClosingCross.svg";
 import Icon from "../../components/Icons/Icon";
 import { Link, useLocation } from "react-router-dom";
-import AnimateHeight from "react-animate-height";
+import { motion } from "motion/react";
 import DocumentTitle from "components/DocumentTitle";
 import LessonCanvasFooter, {
   type LessonCanvasFooterProps,
@@ -45,7 +45,7 @@ export type MainLessonViewProps = {
   overviewLink: JSX.Element | undefined;
   actualText: string;
   changeShowStrokesInLesson: (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => boolean;
   chooseStudy: LessonCanvasFooterProps["chooseStudy"];
   completedPhrases: MaterialText[];
@@ -185,17 +185,20 @@ const MainLessonView = ({
                 >
                   Show scores
                 </button>
-                <AnimateHeight
-                  duration={300}
-                  height={userSettings.showScoresWhileTyping ? "auto" : 0}
-                  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
-                  ease={"cubic-bezier(0.645, 0.045, 0.355, 1)"}
+                <motion.div
+                  animate={{
+                    height: userSettings.showScoresWhileTyping ? "auto" : 0,
+                  }}
+                  transition={{
+                    duration: 0.3,
+                    ease: [[0.645, 0.045, 0.355, 1]],
+                  }}
                 >
                   {/* This setting is available with accessible controls via the UserSettings */}
                   {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                   <div
                     className={
-                      "mb3 " +
+                      "pb3 " +
                       (userSettings.showScoresWhileTyping
                         ? "scores--shown"
                         : "scores--hidden")
@@ -214,7 +217,7 @@ const MainLessonView = ({
                       totalNumberOfHintedWords={totalNumberOfHintedWords}
                     />
                   </div>
-                </AnimateHeight>
+                </motion.div>
                 <div className="lesson-canvas panel overflow-hidden flex relative bg-white dark:bg-coolgrey-1000 mx-auto mw-1440 p2 mb3 flex">
                   {revisionMode && (
                     <div>


### PR DESCRIPTION
This PR:

- Removes `react-animate-height`
- Removes explicit dep for `framer-motion`, which is a sub-dependency of `motion`, and updates all the imports to `motion`
- Fixes transition behaviour when user prefers reduced motion