### PR TITLE
Security: Unvalidated URL passed directly to anchor href (possible `javascript:` URL injection)

### DIFF
--- a/src/components/OutboundLink.tsx
+++ b/src/components/OutboundLink.tsx
@@ -40,6 +40,20 @@ const OutboundLink = ({
     }
   };
 
+  const safeTo = React.useMemo(() => {
+    try {
+      const parsedUrl = new URL(to, "https://example.com");
+
+      if (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") {
+        return to;
+      }
+
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }, [to]);
+
   const newTabProps = newTabAndIUnderstandTheAccessibilityImplications
     ? {
         target: "_blank",
@@ -49,7 +63,7 @@ const OutboundLink = ({
 
   return (
     <a
-      href={to}
+      href={safeTo}
       aria-label={ariaLabel}
       className={className}
       onClick={clickHandler}


### PR DESCRIPTION
## Summary

Security: Unvalidated URL passed directly to anchor href (possible `javascript:` URL injection)

## Problem

**Severity**: `Medium` | **File**: `src/components/OutboundLink.tsx:L49`

The `OutboundLink` component renders `to` مباشرة into `<a href={to}>` without scheme/host validation. If any caller passes user-controlled input (for example chat/content-driven links), an attacker could inject `javascript:` or other unsafe schemes, leading to script execution or phishing-style navigation when clicked.

## Solution

Validate and normalize outbound URLs before rendering. Allow only trusted schemes (e.g., `https:`) and optionally trusted hosts. Reject/strip `javascript:`, `data:`, and malformed URLs. Example: `const u = new URL(to, window.location.origin); if (u.protocol !== 'https:') return null;`.

## Changes

- `src/components/OutboundLink.tsx` (modified)