### PR TITLE
Fix accented input matching and false misstrokes with Plover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -708,7 +708,8 @@ class App extends Component<Props, AppState> {
   updateBufferTimer = null;
 
   updateMarkup(event: ChangeEvent<HTMLTextAreaElement>) {
-    const actualText = event.target.value;
+    // NFC so buffer/state matches matchSplitText prefixes (e.g. after combining strokes).
+    const actualText = event.target.value.normalize("NFC");
 
     // Immediately update the text in the input field
     this.setState({ actualText });
@@ -794,10 +795,8 @@ class App extends Component<Props, AppState> {
 
     const currentPhraseAttempts = state.currentPhraseAttempts.map(copy => ({...copy}));
 
-    if (buffer) {
-      // Assuming a single buffer contains inputs from one stroke, peaks are always at the end of buffer. (i.e. steno can either keep typing or backspace first and then keep typing) Since currentPhraseAttempts is only used to calculate attempts and its logic is to use peaks or the last strokes, it's safe to push elements that lacks `numberOfMatchedWordsSoFar` and `hintWasShown` into `currentPhraseAttempts`.
-      currentPhraseAttempts.push(...buffer.slice(0, -1));
-    }
+    // One debounced batch == one steno stroke; omit buffer intermediates so strokeAccuracy
+    // does not count multi-event OS input (e.g. combining marks) as extra attempts.
     currentPhraseAttempts.push({
       text: actualText,
       time: time,

--- a/src/utils/matchSplitText.test.ts
+++ b/src/utils/matchSplitText.test.ts
@@ -4,6 +4,41 @@ import {
 } from "./matchSplitText";
 
 describe("matchSplitText", () => {
+  describe("Unicode normalization (NFC)", () => {
+    const settings = { ignoredChars: "" };
+    const userSettings: PartialUserSettingsAndCaseAndSpacePlacement = {
+      caseSensitive: true,
+      simpleTypography: true,
+      retainedWords: false,
+      limitNumberOfWords: 0,
+      startFromWord: 1,
+      newWords: true,
+      repetitions: 1,
+      showStrokes: false,
+      showStrokesAsDiagrams: false,
+      hideStrokesOnLastRepetition: false,
+      spacePlacement: "spaceOff",
+      sortOrder: "sortOff",
+      seenWords: true,
+    };
+
+    it("matches NFC lesson text when actual text is NFD (base + combining mark)", () => {
+      const expectedText = "Jos\u00e9";
+      const actualText = "Jos\u0065\u0301";
+      expect(
+        matchSplitText(expectedText, actualText, settings, userSettings)
+      ).toEqual(["José", "", "José", ""]);
+    });
+
+    it("matches NFD lesson text when actual text is NFC", () => {
+      const expectedText = "Jos\u0065\u0301";
+      const actualText = "Jos\u00e9";
+      expect(
+        matchSplitText(expectedText, actualText, settings, userSettings)
+      ).toEqual(["José", "", "José", ""]);
+    });
+  });
+
   describe("case insensitive, ignore spacing", () => {
     const settings = { ignoredChars: "" };
     const userSettings: PartialUserSettingsAndCaseAndSpacePlacement = {

--- a/src/utils/matchSplitText.ts
+++ b/src/utils/matchSplitText.ts
@@ -44,6 +44,9 @@ function matchSplitText(
   } else if (userSettings?.spacePlacement === "spaceAfterOutput") {
     expected = expected + " ";
   }
+  // NFC aligns precomposed vs decomposed accents (common with some OS/steno input paths).
+  expected = expected.normalize("NFC");
+  actualText = actualText.normalize("NFC");
   const expectedChars = expected.split("");
   const actualTextChars = actualText.split("");
   let charactersMatch: (char1: string, char2: string) => boolean;


### PR DESCRIPTION
## Problem

- Lesson text and typed text could disagree when accents differed by Unicode normalization (e.g. precomposed `é` vs `e` + combining acute), so matching looked wrong compared to paste.
- After normalizing, multiple `input` events in one debounced batch could still produce **false misstrokes**: `strokeAccuracy` treats same-length adjacent snapshots as extra attempts.

## Changes

- **`matchSplitText`:** Normalize `expected` and `actualText` to NFC before comparing; tests for José NFC/NFD.
- **`App.tsx`:** Normalize textarea value to NFC so buffer/state aligns with `matchSplitText` prefixes; stop pushing `buffer.slice(0, -1)` into phrase attempts so one batch stays one steno stroke for stroke counting.

## Testing

- `pnpm exec vitest run src/utils/matchSplitText.test.ts src/utils/strokeAccuracy.test.ts`
- Manual: Plover output for accented words (e.g. José) in a lesson.

Fixes #275